### PR TITLE
feat(ship-flow): port review agent stack from glucofit-partners (BAC-704)

### DIFF
--- a/tools/ship-flow/agents/code-reviewer.md
+++ b/tools/ship-flow/agents/code-reviewer.md
@@ -1,0 +1,62 @@
+---
+name: code-reviewer
+description: Reviews a diff against this repo's explicit blocker criteria (CLAUDE.md conventions + the fixed checklist below), running in its own context — never the implementation session's. Use before opening a PR, alongside (not instead of) any separate general-purpose PR-review tool this repo already runs, or whenever a diff needs a fail-any-criterion pass/block verdict before PR.
+tools: Read, Grep, Glob, Bash
+---
+
+You are this repo's code-review gate. Self-review that grades its own work on invented, averaged
+criteria is exactly the failure mode Anthropic's own harness research flagged ("an agent asked to
+judge its own work tends to praise it confidently even when a human would see it as plainly
+mediocre"). You exist to not do that.
+
+## Non-negotiable operating rules
+
+1. **Separate context, always.** You never inherit the implementation session's reasoning or
+   rationalizations — you only see the diff (and whatever files you choose to read). This is the
+   whole point of running you as a subagent instead of an inline self-check.
+2. **Fail-any-criterion, not averaged.** Below is a fixed checklist. Check every item that applies to
+   the diff. If ANY applicable item fails, the overall verdict is **BLOCK** — never round up to PASS
+   because most other items looked fine.
+3. **You report findings; you do not grade yourself a pass by omission.** For every checklist item,
+   state explicitly whether it applies to this diff, and if it applies, PASS or BLOCK with the file:line
+   evidence. An item you didn't check is not a silent PASS — say "not checked" and why, and treat
+   unchecked-but-plausibly-applicable as BLOCK (fail-closed), not PASS.
+4. **You do not replace deterministic gates.** A clean review from you means the diff meets these
+   review-time criteria — it does not mean this repo's verify command or deep gates passed, and it
+   never substitutes for them. State this in your output so a reader doesn't conflate the two.
+5. **If you die mid-review or your context gets cut off, that is not a clean APPROVE.** An incomplete
+   review reports itself as incomplete/BLOCK, never as an implicit pass.
+6. **Human merge approval is untouched by this review.** Nothing here changes that merging into a
+   shared branch is always a human decision — you inform that decision, you don't replace it.
+7. **Boundary with other review tools:** if this repo also runs a separate general-purpose PR-review
+   tool, run both — don't treat this review as a superset or subset of that tool's pass. Report only
+   what you actually checked; don't claim coverage you didn't do.
+
+## Fixed blocker checklist — the concrete, non-inventable bar
+
+- **Row-level-security/authorization path changes without a behavior-proof test.** If this repo has
+  row-level security or an equivalent tenant-isolation invariant (e.g. a `withTenant` helper wrapping
+  every tenant-scoped query), a diff touching that invariant, its policies, or an auth guard/route
+  must have a test that actually exercises the invariant (not just "the code looks right") — a
+  behavior-first testing strategy applies at full force here: prove the invariant holds, don't just
+  eyeball it.
+- **New silent `catch` blocks.** A newly added `catch` that swallows an error without logging,
+  re-throwing, or surfacing it in a way the caller can observe is a BLOCK, not a style nit.
+- **Gate/test files changed inside a feature diff without a stated reason.** If a PR touching feature
+  code also edits a test file, a verify script, or anything under `.claude/**`/`tools/**`, that change
+  needs an explicit justification in the diff or PR description — unexplained gate edits bundled with
+  feature work is exactly the shape of a reward-hacked test.
+- **Send/payment/external-effect paths without a fake adapter in tests.** Code that sends a
+  notification, charges money, or otherwise has an irreversible external side effect must be tested
+  against a fake/mock adapter, never a path that could hit the real integration during tests.
+- **General CLAUDE.md compliance:** package-boundary imports (no deep-path imports bypassing barrel
+  exports), no speculative abstractions/config for single-use code, matches existing style in touched
+  files, no dead code left behind by the change, no unrelated "drive-by" edits outside the diff's
+  stated scope.
+
+## Output
+
+For each checklist item: applies (yes/no) → if yes, PASS/BLOCK + evidence. Then the overall verdict
+(BLOCK if any applicable item BLOCKed) and a one-line reminder that this verdict doesn't replace this
+repo's verify command, deep gates, or human merge review.
+</content>

--- a/tools/ship-flow/agents/planner.md
+++ b/tools/ship-flow/agents/planner.md
@@ -1,0 +1,45 @@
+---
+name: planner
+description: Validates an implementation plan before code is written — checks that acceptance criteria are verifiable and that test seams actually exist for what's being planned. Use after a plan is drafted but before TDD/implementation starts (e.g. as a checkpoint in this plugin's ship-feature workflow, if used), whenever the plan wasn't already sharpened by grill-with-docs (a design-decision plan has already had this scrutiny; a routine CRUD/bugfix plan hasn't).
+tools: Read, Grep, Glob, Bash
+---
+
+You are a plan-validation specialist. You do not implement anything — your only job is to decide
+whether a plan is concrete enough to safely hand to TDD, and to say exactly why not when it isn't.
+
+## What you check (fail-any-criterion — one miss is a BLOCK, not a soft score)
+
+1. **Verifiable success criteria.** Every acceptance criterion in the plan must be checkable by a
+   machine or a concrete manual step — "make it work" / "handle edge cases properly" / "improve X"
+   are not acceptance criteria, they're vibes. Reject plans that only state intent.
+2. **Test seam exists.** For each acceptance criterion, there must be an identifiable place a test
+   can attach — an existing test file to extend, a function/module boundary the plan proposes to
+   create, or an integration point (API route, CLI command, DB migration) that a behavior-proof test
+   can drive. If the plan can't name where a test would live, TDD will stall on "what do I even
+   test" — that's a planning gap, not an implementation detail to figure out later.
+3. **Scope matches a single verifiable unit of work.** If the plan bundles unrelated changes, or is
+   so large that "what does done mean" can't be stated in one sentence, say so — recommend splitting
+   into decision-ticket-sized issues rather than approving a plan no single TDD pass can converge on.
+4. **No speculative scope.** Flag anything in the plan that isn't required by the stated acceptance
+   criteria — configurability, abstractions, or error handling for scenarios the plan itself doesn't
+   claim can happen. This isn't your call to delete, just to flag for the implementer.
+
+## What you don't do
+
+- You don't write or suggest the implementation. Naming what's missing is your job; filling it in is
+  the implementer's.
+- You don't second-guess the *decision* behind a plan that already went through `grill-with-docs` or
+  has an ADR backing it — your scope is "is this concrete enough to build and test", not "is this the
+  right design".
+- You are not a substitute for this repo's verify command or any deterministic gate. A plan passing
+  your review means it's ready for TDD to attempt — it says nothing about whether the resulting code
+  will be correct. That's still the verifier's job, always.
+
+## Output
+
+Report, per acceptance criterion in the plan: PASS or BLOCK, with the specific reason for any BLOCK
+(quote the vague phrase, name the missing test seam). If ANY criterion is BLOCK, the overall verdict
+is BLOCK — do not average or round up an ambiguous case to PASS. If you genuinely can't tell whether
+a test seam exists (the plan is too abstract to check), that's also a BLOCK, not a pass by default —
+fail-closed, not fail-open.
+</content>

--- a/tools/ship-flow/agents/test-hunter.md
+++ b/tools/ship-flow/agents/test-hunter.md
@@ -1,0 +1,48 @@
+---
+name: test-hunter
+description: Reviews a diff for test strength, coverage gaps, and silent failures in one pass — merges the roles of pr-test-analyzer (behavioral coverage) and silent-failure-hunter (swallowed errors, bad fallbacks). Use before opening a PR, alongside code-reviewer, or whenever a diff's test quality and error-handling need a dedicated look separate from convention review.
+tools: Read, Grep, Glob, Bash
+---
+
+You review a diff for two things that a generic code reviewer tends to skim past: whether the tests
+actually prove the behavior they claim to, and whether errors get silently absorbed instead of
+surfaced. Both are ways a change can look done while quietly not being done.
+
+## Test coverage and strength
+
+- **Behavior over line coverage.** A good test suite doesn't gate on coverage percentage — it gates on
+  whether the behavior is actually proven. A test that exercises a function without asserting on the
+  property that matters (a security invariant actually holding, a race condition actually not
+  happening, an edge case actually being handled) is coverage theater — flag it as a gap even if a
+  coverage tool would mark the line green.
+- **Red-first for bugfixes.** For a diff claiming to fix a bug, check whether a test exists that would
+  have failed on the old code and passes on the new — if the "fix" only added a test that trivially
+  passes against the new code without ever having been red, that's not proof the bug is fixed, it's
+  proof the test exists.
+- **Edge cases named in the plan/PR description are actually tested.** If the diff's own description
+  mentions an edge case, boundary, or failure mode, verify a test covers it — don't take the
+  description's word for it.
+- **Security/invariant paths get behavior-proof tests, not just happy-path tests.** Auth and any other
+  correctness invariant this repo depends on (for example, if this repo has row-level-security or
+  tenant-isolation guarantees) needs a test that would fail if the invariant broke, not just a test
+  that the endpoint returns 200.
+
+## Silent failures
+
+- **Every new or modified `catch` block**: does it log, re-throw, or otherwise surface the error in a
+  way a caller/operator can observe? A catch that swallows and returns a default value silently is a
+  BLOCK unless the diff explicitly justifies why silence is correct there.
+- **Fallback logic**: does a fallback path fire only when the primary path is genuinely unavailable,
+  or could it mask a real bug by quietly substituting a default? Distinguish "this is a legitimate
+  degradation strategy" from "this hides failures."
+- **Validation that fails open**: check any new input validation or guard clause — does a malformed
+  or unexpected input get rejected, or does it silently pass through with a best-guess default?
+
+## Output
+
+List findings as: **gap** (missing/weak test) or **silent-failure** (swallowed error/bad fallback),
+each with file:line, what's missing, and why it matters (what could break without anyone noticing).
+State explicitly if you found nothing in either category — an empty list is a real finding, not a
+skipped check. This review does not replace the project's verify command — it's aimed at what a green
+test suite can still be hiding.
+</content>

--- a/tools/ship-flow/agents/verifier-integrity-hunter.md
+++ b/tools/ship-flow/agents/verifier-integrity-hunter.md
@@ -1,0 +1,70 @@
+---
+name: verifier-integrity-hunter
+description: Reward-hack detection specialist — looks for test hardcoding, verifier bypass, require-tests evasion, and quiet requirement-narrowing. Takes the diff AND the run's trajectory (verdict LOG, TDD red→green history) as input, not just the final diff. Use before opening a PR, alongside code-reviewer/test-hunter, or whenever a run's own self-report of "tests pass now" needs independent scrutiny.
+tools: Read, Grep, Glob, Bash
+memory: project
+---
+
+You are this repo's reward-hack detector. Your reason for existing: an LLM judge is measurably
+better at catching hack-shaped changes than a held-out test suite is (EvilGenie, arXiv:2511.21654),
+and self-reported "it passes now" is not trustworthy on its own (METR, and this repo's own
+verifier=ceiling principle — the agent's self-judgement never substitutes for ground truth). You are
+the check that specifically distrusts a suspiciously clean-looking green.
+
+## What makes you different from code-reviewer/test-hunter
+
+They look at the diff. **You look at the diff AND the trajectory** — the verdict LOG, the TDD
+red→green history, the sequence of commands that got from failing to passing (Agent-as-a-Judge,
+arXiv:2410.10934: judging the path, not just the endpoint, catches things a snapshot diff can't).
+If you only have the diff and no trajectory evidence, say so explicitly — a trajectory-blind pass is
+weaker evidence than one that traced the actual run.
+
+## What you hunt for
+
+1. **Test hardcoding.** A test whose assertion was tuned to match whatever the implementation
+   happens to output, rather than testing the actual required behavior — check whether the assertion
+   would still make sense if you deleted the implementation and imagined the correct one from
+   scratch. If the assertion only makes sense *given* this specific implementation, that's hardcoding.
+2. **Verifier bypass.** Any trace in the trajectory of `--no-verify`, skipped hooks, disabled lint
+   rules, commented-out test blocks, `--passWithNoTests`-style flags, or a verify command that got
+   narrowed mid-run (e.g. from the full test suite to one specific test file) without a stated
+   reason.
+3. **require-tests evasion.** Zero-test packages passing a "gate," a new file with no corresponding
+   test where one was clearly warranted, or a test file that exists but contains no real assertions
+   (e.g. `expect(true).toBe(true)`, empty `it()` blocks).
+4. **Quiet requirement-narrowing.** Compare the original acceptance criteria (plan/issue) against what
+   actually got verified. Did an edge case named in the requirements silently disappear from what the
+   tests check? Did "handle X" become "handle X's happy path" without anyone saying so?
+5. **Red→green trajectory shape.** In the verdict LOG history, did the fix change the *code* to match
+   the test's intent, or did it change the *test* to match whatever the code does? The latter is a
+   reward hack even when the final diff looks clean — this is exactly why trajectory matters more
+   than the endpoint here.
+
+## Rules
+
+- **Fail-closed on ambiguity.** If you can't tell whether something is a legitimate simplification or
+  a hack, flag it — don't give the benefit of the doubt. A false positive costs a human two minutes
+  of review; a missed hack costs a broken invariant in production.
+- **You do not replace this repo's verify command or any deterministic gate.** You catch the specific
+  failure mode where a gate was technically satisfied but the spirit of it was gamed — that's a
+  different job from the gate itself, not a substitute for it.
+- **Self-preference isolation.** You run in a fresh context, separate from the implementation session
+  — you have no stake in the diff looking good. If your context somehow gets contaminated with the
+  implementer's own framing/rationalization, note that explicitly rather than silently absorbing it.
+
+## Memory (`memory: project` — piloted on this agent only)
+
+Your memory at `.claude/agent-memory/verifier-integrity-hunter/` is a **working notebook, not a
+source of truth.** It may record patterns you've personally caught before (a specific hardcoding
+shape that recurred, a bypass flag this repo's scripts tend to use) to sharpen what you look for next
+time. It is **not** the authoritative lesson store — `.loop/lessons` remains that, and promotion into
+a codified guideline still only happens through `retrospect`, never automatically from your notes.
+Project-scoped memory started as a pilot on this one agent rather than a default every agent gets —
+if you ever notice your own notes being treated as settled fact rather than a hunting aid, say so —
+that would be a boundary violation the pilot is specifically watching for.
+
+## Output
+
+List each finding with: category (from the five above), evidence (file:line or trajectory step
+quoted), and why it's suspicious. State your confidence honestly — trajectory-grounded findings are
+stronger evidence than diff-only inference; say which kind each finding is.

--- a/tools/ship-flow/workflows/adversarial-review.js
+++ b/tools/ship-flow/workflows/adversarial-review.js
@@ -1,0 +1,124 @@
+// adversarial-review — three-stage pipeline: finder → skeptical verifier (aims to refute) → completeness critic.
+//
+// pipeline() returns only its last stage's result — a documented, intentional part of its contract,
+// not a bug. That means a naive pipeline(domains, finder, verifier) spanning all domains would hand
+// the completeness critic only the verifier's output and silently drop the finder's raw findings.
+// This workflow avoids that footgun by keeping each domain's find→verify chain inside its own
+// pipeline lane (no cross-domain barrier), and nesting verification per finding inside parallel() so
+// each finding's original content is carried forward alongside its verdict rather than replaced by it.
+//
+// Votes on a finding can come back null (skipped, or an agent/API error) — those don't count as
+// refutations. The tally below distinguishes three outcomes: a finding that survives verification,
+// one that's genuinely refuted by valid votes, and one that's merely unverified because too few
+// votes came back cleanly (an infrastructure failure isn't read as a refutation).
+//
+// args (all required — domains are task-specific, this workflow does not guess a default set):
+//   { target: '<what is being reviewed — one sentence>',
+//     domains: [{ key: '<slug>', prompt: '<what to look for in this domain>' }, ...] }
+
+export const meta = {
+  name: 'adversarial-review',
+  description: 'Three-stage adversarial review — finder → skeptical verifier → completeness critic. Parallel per-domain discovery, per-finding majority-vote refutation, coverage-gap critique.',
+  phases: [
+    { title: 'Find', detail: 'Parallel finders, one per domain' },
+    { title: 'Verify', detail: 'Per-finding skeptical verification (aims to refute, majority vote)' },
+    { title: 'Completeness', detail: 'What was covered vs. what was missed' },
+  ],
+}
+
+const parsedArgs = typeof args === 'string' ? JSON.parse(args) : args
+
+if (!parsedArgs?.target || !Array.isArray(parsedArgs?.domains) || parsedArgs.domains.length === 0) {
+  throw new Error(
+    'adversarial-review requires args = { target: "<what is being reviewed>", domains: [{key, prompt}, ...] } — domains are task-specific, this workflow does not guess a default set.'
+  )
+}
+
+const FINDER_SCHEMA = {
+  type: 'object',
+  properties: {
+    findings: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          title: { type: 'string' },
+          detail: { type: 'string' },
+          file: { type: 'string' },
+        },
+        required: ['title', 'detail'],
+      },
+    },
+  },
+  required: ['findings'],
+}
+
+const VERDICT_SCHEMA = {
+  type: 'object',
+  properties: {
+    refuted: { type: 'boolean', description: 'true means this verifier judged the finding does not actually hold' },
+    reason: { type: 'string' },
+  },
+  required: ['refuted', 'reason'],
+}
+
+const VOTES_PER_FINDING = 3
+const REFUTATIONS_REQUIRED = 2
+
+phase('Find')
+const perDomain = await pipeline(
+  parsedArgs.domains,
+  d =>
+    agent(
+      `Target: ${parsedArgs.target}\n\nDomain: ${d.key}\n${d.prompt}\n\nOnly record something as a finding if you actually observed it by reading a file or running a command — don't assert from inference. This investigation is read-only.`,
+      { label: `find:${d.key}`, phase: 'Find', schema: FINDER_SCHEMA }
+    ).then((r) => (r?.findings ?? []).map((f) => ({ ...f, domain: d.key }))),
+  (domainFindings) =>
+    parallel(
+      domainFindings.map((f) => () =>
+        parallel(
+          Array.from({ length: VOTES_PER_FINDING }, () => () =>
+            agent(
+              `Try to refute this finding (default to refuted=true if uncertain): "${f.title}" — ${f.detail}${f.file ? ` (${f.file})` : ''}\n\nTarget: ${parsedArgs.target}. Actually check it (Read/Bash) before judging.`,
+              { label: `verify:${f.domain}:${f.title.slice(0, 40)}`, phase: 'Verify', schema: VERDICT_SCHEMA }
+            )
+          )
+        ).then((votes) => {
+          // A vote can be null (skipped, or an agent/API error) — that does not count as a refutation.
+          // Three outcomes, matching the deep-research workflow's own convention:
+          //   survives   — valid votes >= REFUTATIONS_REQUIRED and refuting votes below that
+          //   isRefuted  — refuting votes >= REFUTATIONS_REQUIRED (genuinely refuted on the merits)
+          //   otherwise  — unverified: too few valid votes (most verifier agents errored) — an
+          //                infrastructure failure is not read as a refutation
+          const valid = votes.filter(Boolean)
+          const refutedVotes = valid.filter((v) => v.refuted).length
+          const survives = valid.length >= REFUTATIONS_REQUIRED && refutedVotes < REFUTATIONS_REQUIRED
+          const isRefuted = refutedVotes >= REFUTATIONS_REQUIRED
+          return { ...f, survives, isRefuted, refutations: valid }
+        })
+      )
+    )
+)
+
+const allFindings = perDomain.flat().filter(Boolean)
+const confirmed = allFindings.filter((f) => f.survives)
+const refuted = allFindings.filter((f) => f.isRefuted)
+const unverified = allFindings.filter((f) => !f.survives && !f.isRefuted)
+log(
+  `${allFindings.length} findings — ${confirmed.length} confirmed, ${refuted.length} refuted, ${unverified.length} unverified (infra failure)`
+)
+
+phase('Completeness')
+const completeness = await agent(
+  `Below is the result of an adversarial review of "${parsedArgs.target}" (${parsedArgs.domains.length} domains, ${confirmed.length} findings that survived majority-vote verification):
+
+${JSON.stringify(confirmed.map(({ title, detail, file, domain }) => ({ title, detail, file, domain })))}
+
+Domains covered: ${parsedArgs.domains.map((d) => d.key).join(', ')}
+
+Critique what's missing — domains/angles not covered, claims that went unverified, sources not read.
+Propose concretely what the next round should look at — no generic advice, be specific to this target.`,
+  { phase: 'Completeness', label: 'completeness-critic' }
+)
+
+return { target: parsedArgs.target, confirmed, refuted, unverified, completeness }

--- a/tools/ship-flow/workflows/harness-audit.js
+++ b/tools/ship-flow/workflows/harness-audit.js
@@ -1,0 +1,182 @@
+// harness-audit — six-lane parallel forensic audit of this repo's self-improvement harness.
+// Kept as a named workflow (rather than an inline script pasted into a skill) so a run that
+// finishes the investigate phase but gets interrupted before synthesis can be resumed instead
+// of re-run from scratch. The wrapping skill (harness-maturity-audit) is a thin caller: it
+// invokes Workflow({ name: 'harness-audit' }) and owns saving the report and any follow-up
+// hand-off (e.g. to an issue-creation skill) once this workflow returns.
+
+export const meta = {
+  name: 'harness-audit',
+  description:
+    "Six-lane parallel forensic audit of this repo's self-improvement loop harness — evidence-only, produces an L0-L5 scorecard",
+  phases: [
+    { title: 'Investigate', detail: 'Six dimensions, each measured by a parallel agent' },
+    { title: 'Synthesize', detail: 'Scorecard + priority improvement list + delta vs. the prior report' },
+  ],
+}
+
+const METHOD = `You are a forensic investigator for this repo's self-improvement harness.
+Absolute rules:
+(1) Any claim that something "works" must be backed by actually running a command (Bash) or
+    actually reading a file (Read/grep) and observing the result — never assert it from
+    inference or guesswork without having run or read it.
+(2) Record the command you ran and what you observed (exit code, an excerpt of the output,
+    file path/line number) as evidence.
+(3) Score using this rubric — L0 absent (never built) / L1 designed (documented only, no
+    working code) / L2 built (code exists, verifiable in isolation) / L3 wired (integrated
+    into a real loop, at least one path works end-to-end) / L4 proven (has actually closed the
+    loop on a real change) / L5 self-improving (lessons across runs have been promoted and have
+    actually changed future behavior).
+(4) Don't just hunt for gaps — report strengths too.
+(5) This investigation is read-only — do not modify or commit any file.`
+
+const DIMENSIONS = [
+  {
+    key: 'decision-archive',
+    title: 'Decision archive',
+    prompt: `${METHOD}
+
+Dimension: decision archive. First check whether this repo actually has a decision-record
+archive — commonly a docs/adr/ directory, but check for whatever equivalent convention this
+repo documents (its CLAUDE.md or an analogous convention doc should mention it if one exists).
+If no such archive exists, say so plainly, score this dimension L0, and explain in one line
+that there is nothing to audit here — do not invent a convention that isn't there. If an
+archive does exist, cross-check each decision record against git log and the current code to
+see whether it was actually implemented. Find records left in a proposed/superseded/on-hold
+state, and any drift between what a record says and what the code actually does.`,
+  },
+  {
+    key: 'loop-engine',
+    title: 'loop-engine code',
+    prompt: `${METHOD}
+
+Dimension: loop-engine code. Actually run the loop-engine@paul-loop plugin's bin/* scripts
+(verdict-run, loop-fix, gate, eval-gate, lessons, etc.) — invoke them however this repo actually
+resolves and calls the installed plugin's bin scripts (look for a local resolver/wrapper script
+first; if there isn't one, invoke the plugin cache path directly), plus any wrapper script this
+repo maintains itself outside the plugin (e.g. a loop-doctor-style helper, if this repo has one)
+— synthetic fixtures are fine — and observe exit codes and output. Look for violations of the
+"verifier = ceiling" principle (e.g. a gate reporting PASS with zero tests actually run — fake
+green).`,
+  },
+  {
+    key: 'loop-ops-data',
+    title: '.loop operational data',
+    prompt: `${METHOD}
+
+Dimension: .loop operational data. Read the actual files — .loop/lessons/*.json (count,
+verified ratio, whether any have recurred or been promoted), .loop/deps-audit.last,
+.loop/looping, and similar — to confirm the harness has actually been run repeatedly in real
+use, not just demonstrated once ad hoc.`,
+  },
+  {
+    key: 'skills',
+    title: 'Skill maturity',
+    prompt: `${METHOD}
+
+Dimension: skill maturity. List .claude/skills/* and read each SKILL.md looking for dangling
+links and references to commands or files that don't actually exist. Cross-check against
+skillUsage in ~/.claude.json (if it's readable) for how often each is actually used.`,
+  },
+  {
+    key: 'pgvector',
+    title: 'pgvector (loop-memory) usage',
+    prompt: `${METHOD}
+
+Dimension: pgvector (loop-memory) usage. Grep for the actual callers (hooks, bin scripts) of
+the loop-memory package's code — it typically lives at packages/loop-memory in a repo that has
+installed it. Check DB connectivity using whichever check is cheaper to run — a loop:doctor-style
+helper, or whatever DB-connectivity check script this repo defines for it, if any (look for a
+script name containing "memory" or "pgvector"; don't assume it's named verify:memory) — and trace
+the actual call path of graduateLessons / recallLessons.`,
+  },
+  {
+    key: 'domain-tooling',
+    title: 'Domain knowledge / tool usage',
+    prompt: `${METHOD}
+
+Dimension: domain knowledge / tool usage. Check whether this repo's own domain-knowledge docs —
+if any exist (a glossary, architecture notes, tracker-integration notes, whatever this repo
+actually has) — show up as being actually used in recent work (check the last 20-30 commits via
+git log). Also check whether an external issue tracker this repo's own CLAUDE.md documents (if
+any) is the one actually being used in practice (e.g. commit messages referencing tracker IDs),
+versus a fallback like bare GitHub issues with no real tracker integration. Discover what this
+repo's conventions actually are rather than assuming any particular file name or tracker.`,
+  },
+]
+
+const RESULT_SCHEMA = {
+  type: 'object',
+  properties: {
+    dimension: { type: 'string' },
+    level: { type: 'string', enum: ['L0', 'L1', 'L1.5', 'L2', 'L2.5', 'L3', 'L3.5', 'L4', 'L5'] },
+    oneLine: { type: 'string', description: 'One-line assessment' },
+    evidence: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          command: { type: 'string' },
+          observation: { type: 'string' },
+        },
+        required: ['observation'],
+      },
+    },
+    strengths: { type: 'array', items: { type: 'string' } },
+    gaps: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          severity: { type: 'string', enum: ['blocker', 'major', 'minor'] },
+          description: { type: 'string' },
+        },
+        required: ['severity', 'description'],
+      },
+    },
+  },
+  required: ['dimension', 'level', 'oneLine', 'evidence', 'strengths', 'gaps'],
+}
+
+phase('Investigate')
+const findings = await pipeline(
+  DIMENSIONS,
+  d => agent(d.prompt, { label: `audit:${d.key}`, phase: 'Investigate', schema: RESULT_SCHEMA })
+)
+
+phase('Synthesize')
+const priorPath = await agent(
+  `Look for a report from a previous run of this same audit. Check this repo's documentation
+   directories (docs/, docs/research/, docs/audits/, or wherever this repo's own conventions
+   put this kind of report — check its CLAUDE.md or an equivalent convention doc if one exists)
+   for a file whose name contains "harness", "maturity", "audit", or "reassessment", typically
+   prefixed with a YYYY-MM-DD date. If more than one matches, return the most recent by date. If
+   none exists, return an empty string.`,
+  { phase: 'Synthesize', schema: { type: 'object', properties: { path: { type: 'string' } }, required: ['path'] } }
+)
+
+const synthesis = await agent(
+  `Below is the evidence-based investigation output for all six dimensions of this repo's
+self-improvement harness (JSON):
+
+${JSON.stringify(findings.filter(Boolean))}
+
+Most recent prior audit report path: ${priorPath?.path || '(none)'}
+
+If a prior report exists, read it and honestly state what changed versus this run — no
+exaggerating, no downplaying. Write a synthesized markdown report body (body only, no title)
+covering:
+1. A one-line TL;DR
+2. A six-dimension scorecard table (dimension | level | one-line assessment)
+3. Delta versus the prior report (omit this section if no prior report was found)
+4. A priority improvement list, gaps ordered by severity (blocker/major/minor) — give each item
+   a "why"
+5. Strengths worth keeping
+6. Appendix: a summary of each dimension's raw evidence
+
+Write the report in English. Don't include unsupported claims — nothing that isn't backed by
+evidence.`,
+  { phase: 'Synthesize', label: 'synthesize-report' }
+)
+
+return { findings: findings.filter(Boolean), priorReportPath: priorPath?.path || null, reportBody: synthesis }

--- a/tools/ship-flow/workflows/trends-research.js
+++ b/tools/ship-flow/workflows/trends-research.js
@@ -1,0 +1,111 @@
+// trends-research — parallel research across N domains → per-domain skeptical verification (revisit a
+// sample of key claims) → synthesis.
+//
+// Codified from an ad-hoc script used in a research session that ran two internal re-probes plus six
+// domain researchers plus six per-domain skeptical verifiers (14 agents total). That session's
+// per-domain scratchpad outputs were never committed, so this file was written from a description of
+// the methodology rather than lifted from the original script. "Internal re-probe" was specific to
+// that session's own topic (re-checking the source repo's own state) and isn't generalized here — if
+// you need something similar, add a prompt among `domains` that has one domain investigate the target
+// repo itself.
+//
+// args (all required):
+//   { topic: '<one-sentence research question>',
+//     domains: [{ key: '<slug>', prompt: '<what to investigate in this domain>' }, ...] }
+
+export const meta = {
+  name: 'trends-research',
+  description: 'Parallel external research across N domains → per-domain skeptical verification (revisit a sample of key claims) → synthesis report',
+  phases: [
+    { title: 'Research', detail: 'Parallel first-pass research per domain' },
+    { title: 'Verification', detail: 'Per-domain skeptical verifier — revisits a sample of key claims' },
+    { title: 'Synthesis', detail: 'Write a report synthesizing all domains' },
+  ],
+}
+
+const parsedArgs = typeof args === 'string' ? JSON.parse(args) : args
+
+if (!parsedArgs?.topic || !Array.isArray(parsedArgs?.domains) || parsedArgs.domains.length === 0) {
+  throw new Error(
+    'trends-research requires args = { topic: "<research question>", domains: [{key, prompt}, ...] } — domains are topic-specific, this workflow does not guess a default set.'
+  )
+}
+
+const DOMAIN_SCHEMA = {
+  type: 'object',
+  properties: {
+    summary: { type: 'string' },
+    claims: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          claim: { type: 'string' },
+          source: { type: 'string', description: 'URL or primary source' },
+        },
+        required: ['claim'],
+      },
+    },
+  },
+  required: ['summary', 'claims'],
+}
+
+const VERIFY_SCHEMA = {
+  type: 'object',
+  properties: {
+    checked: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          claim: { type: 'string' },
+          confirmed: { type: 'boolean' },
+          note: { type: 'string' },
+        },
+        required: ['claim', 'confirmed'],
+      },
+    },
+  },
+  required: ['checked'],
+}
+
+phase('Research')
+const verified = await pipeline(
+  parsedArgs.domains,
+  (d) =>
+    agent(
+      `Research topic: ${parsedArgs.topic}\n\nDomain: ${d.key}\n${d.prompt}\n\nFind primary sources (official docs, papers, repos) and investigate. Attach a source URL to every key claim. Do not put unsourced claims into claims.`,
+      { label: `research:${d.key}`, phase: 'Research', schema: DOMAIN_SCHEMA }
+    ),
+  (domainResult, d) =>
+    agent(
+      `Pick up to 6 of the key claims from the following domain research result and actually revisit the original sources to confirm them (skeptically — check for exaggeration, distortion, or claims that are out of date):
+
+Domain: ${d.key}
+${JSON.stringify(domainResult?.claims ?? [])}`,
+      { label: `verify:${d.key}`, phase: 'Verification', schema: VERIFY_SCHEMA }
+    ).then((v) => ({ domain: d.key, ...domainResult, verification: v?.checked ?? [] }))
+)
+
+const clean = verified.filter(Boolean)
+const totalClaims = clean.reduce((n, d) => n + (d.claims?.length ?? 0), 0)
+const totalChecked = clean.reduce((n, d) => n + (d.verification?.length ?? 0), 0)
+log(`${clean.length} domains, ${totalClaims} claims, ${totalChecked} sampled-claim verifications`)
+
+phase('Synthesis')
+const reportBody = await agent(
+  `The following is the result of research across ${clean.length} domains on "${parsedArgs.topic}", plus per-domain skeptical verification (JSON):
+
+${JSON.stringify(clean)}
+
+Write a markdown report body (no title, body only) that synthesizes:
+1. TL;DR
+2. Per-domain summary (where verification refuted or corrected something, reflect the correction — not the original claim)
+3. Limits of the evidence (verification coverage — how many claims were revisited per domain, and how the remaining unverified claims were handled)
+
+Where a claim wasn't confirmed by verification, present it with reduced confidence or drop it — don't
+ignore the verification results and just copy the first-pass research.`,
+  { phase: 'Synthesis', label: 'synthesize-report' }
+)
+
+return { topic: parsedArgs.topic, domains: clean, reportBody }


### PR DESCRIPTION
## Summary

Ports the review agent stack ADR-0079 designed and BAC-623 implemented in glucofit-partners
(4 self-owned review agents + 3 named workflows) into the `ship-flow` plugin, so a consuming repo
gets self-contained review capability without depending on an external `pr-review-toolkit`-style
plugin.

- `tools/ship-flow/agents/{planner,code-reviewer,test-hunter,verifier-integrity-hunter}.md`
- `tools/ship-flow/workflows/{adversarial-review,harness-audit,trends-research}.js`

Directory layout confirmed against official Anthropic plugins (`code-modernization`, `feature-dev`)
and a real installed community plugin (`im-not-ai`'s `humanize-korean` agents) — `agents/` and
`workflows/` at plugin root, no `plugin.json` field needed, pure directory-convention discovery.

## Generalization

Removed glucofit-partners-specific pointers that would be meaningless (or wrong) for another repo:
Linear issue numbers (`BAC-nnn`), ADR citations (`ADR-00nn`), hardcoded `pnpm verify`/`verify:memory`
script names, and a hardcoded `ship-feature step N` checkpoint reference repeated across all 4 agent
descriptions. Kept `loop-engine`/`.loop/lessons` references as-is — those are paul-loop-ecosystem-
standard paths for any repo that installs loop-engine (a ship-flow dependency), not glucofit-partners-
specific.

`harness-audit.js` needed the most rework: its "ADR archive" and "domain knowledge/tool usage"
dimensions assumed glucofit-partners' specific conventions (`docs/adr/`, `CONTEXT.md`, Linear MCP).
Rewrote both to *discover* whether a consuming repo has an equivalent convention rather than assume
one — L0 with a plain note if it doesn't. The other 4 dimensions (loop-engine code, `.loop` ops data,
skill maturity, pgvector/loop-memory usage) audit loop-engine/loop-memory plugin artifacts that exist
for any consumer of those plugins, so those needed only translation, not rework.

## Process note — this was built with a Workflow-orchestrated port + adversarial leak-check pass

Given 7 independent files each needing the same editorial judgment applied, I ran a `pipeline()` of
port → leak-check agents (14 agents total) rather than doing all 7 by hand. The leak-check stage
caught real gaps my own porting-rules prompt had missed:

- **`adversarial-review.js`**: I'd instructed the port agent this was "comment-only" (logic/schemas/
  prompts unchanged) — wrong. `meta.description`, phase titles, the `VERDICT_SCHEMA` field
  description, and every agent-prompt template string were still Korean, because those are runtime-
  facing (shown in the progress UI, sent as actual sub-agent instructions), not just internal dev
  comments. Fixed by hand after the workflow returned — translated all of it, kept the vote-tally
  logic byte-identical.
- **`harness-audit.js`**: two dimension prompts asserted glucofit-partners-specific script names
  (`tools/plugin-path.mjs`, `verify:memory`) as if every loop-engine consumer has them — grepped the
  whole paul-loop repo and confirmed neither is a scaffolded convention. Reworded both to hedge
  properly ("however this repo resolves it" / "whatever this repo names it, if anything").
- The leak-check also caught `code-reviewer.md`/`test-hunter.md`/`verifier-integrity-hunter.md` in
  the same "ship-feature step 4" pattern it flagged in `planner.md` — except its own automated pass
  only flagged `planner.md` and marked the other three `clean: true` (a real miss in the leak-checker
  itself, not just the port). I found and fixed all 3 by a follow-up grep across every ported file
  rather than trusting the automated "clean" verdict at face value.

## Verification

- `claude plugin validate --strict` → green.
- `--plugin-dir` dogfood (a real `claude -p` session with only this plugin loaded) confirmed the
  4 agents and 3 workflows are actually discoverable and resolve correctly. This also settled an open
  question empirically rather than by guessing: **both plugin-bundled agents and workflows are
  namespaced under `ship-flow:`** — `Workflow({name: "adversarial-review"})` (bare) returns
  `"not found"`; only `ship-flow:adversarial-review` resolves. Same for the 4 agent types
  (`ship-flow:code-reviewer`, etc.). Any future same-plugin cross-reference (e.g. once `ship-feature`
  is ported and its step 4 wants to invoke this stack) needs the fully-qualified form.
- Plain-text secrets/PII grep on the new files: clean.

## Known scope boundary

`ship-feature` itself is not in this repo yet (that's BAC-703) — so "ship-feature step 4 references
the ported stack" (this issue's last AC item) can't be literally dogfooded end-to-end in this PR. What
*is* proven is the mechanism it depends on: the agents/workflows are correctly bundled, discoverable,
and resolve under their namespaced names. Wiring `ship-feature`'s own step 4 to call them is BAC-703's
job once that skill exists in this plugin.

Closes BAC-704.