### PR TITLE
feat(ship-flow): add templates/ + interactive setup skill (BAC-705)

### DIFF
--- a/tools/ship-flow/skills/setup/SKILL.md
+++ b/tools/ship-flow/skills/setup/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: setup
+description: One-time interactive setup for this plugin in a consuming repo — interviews the user, writes `.claude/ship-flow.config.json`, and installs (or offers to install) a CLAUDE.md constitution, a CI workflow, and branch protection from this plugin's templates/. Use once per repo, when a repo first adopts ship-flow, or when re-running to fill in config that was skipped the first time.
+---
+
+# setup — one-time ship-flow bootstrap
+
+This plugin's skills (`hotfix`, and others as they're added) read `.claude/ship-flow.config.json` at
+the consuming repo's root. This skill is how that file — and the repo-level scaffolding it depends on
+(a CLAUDE.md, a CI workflow, branch protection) — gets created in the first place.
+
+**This skill is not part of the day-to-day delivery loop.** Run it once when adopting this plugin in a
+repo; re-run it later only to fill in something skipped the first time or to change a config value.
+
+## What this plugin can and can't install
+
+A plugin's own root-level `CLAUDE.md` is **not** loaded as project context by Claude Code (confirmed
+against the official plugin spec) — so the constitution layer can't just ship inside the plugin and
+work automatically. That's why this skill exists: it *copies* a template into the consuming repo's own
+`CLAUDE.md`, where it will actually be loaded.
+
+| Can install directly | Needs this skill to copy/patch into place |
+|---|---|
+| Skills, agents, workflows (this plugin itself) | `CLAUDE.md` (constitution) |
+| | CI workflow (`.github/workflows/ci.yml` or equivalent) |
+| | Branch protection (a GitHub API call, not a file) |
+| | `turbo.json`/verify-script wiring (repo-specific, example only) |
+
+## Sequence
+
+### 1. Check for existing config
+Read `.claude/ship-flow.config.json` if it exists. If it does, tell the user what's already set and
+ask whether they want to reconfigure or just fill gaps — don't silently overwrite it.
+
+### 2. Interview
+Ask one question at a time (don't front-load all of them — a wrong early answer, like the wrong branch
+model, changes what later questions even mean):
+
+1. **Branch model**: `git-flow` (a shared integration branch + a release branch, e.g.
+   develop→main) or `trunk-based` (a single shared branch). If git-flow: what are the two branch
+   names? If trunk-based: what's the one branch name?
+2. **Package manager**: what does this repo use (`pnpm`/`npm`/`yarn`/`cargo`/`uv`/other)?
+3. **Verify command**: what single command does this repo run to check "is this change good" —
+   typecheck+lint+test, or whatever this repo actually has? (If the repo has nothing yet, offer
+   `templates/turbo-verify-wiring.example.md` as a starting point — see step 4.)
+4. **Project name**: what should the `CLAUDE.md` template call this repo?
+5. **Issue tracker** (optional): does this repo use an external tracker (Linear, Jira, bare GitHub
+   Issues, none)? Only asked if relevant — don't force an answer if the repo has no tracker at all.
+
+Write answers into `.claude/ship-flow.config.json` as you go (don't wait until the end — a skill that
+dies partway through step 3 shouldn't lose steps 1-2's answers):
+
+```json
+{
+  "branchModel": "git-flow",
+  "integrationBranch": "develop",
+  "releaseBranch": "main",
+  "packageManager": "pnpm",
+  "verifyCommand": "pnpm verify",
+  "projectName": "my-project",
+  "trackerName": "Linear"
+}
+```
+
+(`integrationBranch`/`ciSkipOnIntegrationPR`/`deployHook` are `hotfix`'s existing fields — leave them
+as `hotfix`'s own doc describes if this is a fresh file. `trunk-based` repos omit `integrationBranch`.)
+
+### 3. Install `CLAUDE.md`
+Read `${CLAUDE_PLUGIN_ROOT}/templates/CLAUDE.md.template`, substitute every `{{PLACEHOLDER}}` with the
+interview's answers (see the template's own placeholder list at its end for what's expected), and
+write the result to the consuming repo's `CLAUDE.md`.
+
+**If a `CLAUDE.md` already exists**: don't overwrite it silently. Show the user a diff-style summary of
+what the template would add/change and ask whether to merge, skip, or replace.
+
+### 4. Offer CI + turbo wiring (optional — ask, don't assume)
+Ask whether to install a starting CI workflow from `${CLAUDE_PLUGIN_ROOT}/templates/ci.yml.template`
+(substituting `{{RELEASE_BRANCH}}` and `{{VERIFY_COMMAND}}` from the config) at
+`.github/workflows/ci.yml`. If the repo already has a CI workflow, don't overwrite it — point out
+`templates/ci.yml.template`'s `ci-gate` pattern (the always-run aggregator, and why it exists) as
+something worth adopting into their existing workflow instead, and stop there.
+
+If the repo is (or will be) a turbo monorepo with no verify wiring yet, point at
+`${CLAUDE_PLUGIN_ROOT}/templates/turbo-verify-wiring.example.md` as a starting point — this one is
+reference material to adapt by hand, not something this skill copies verbatim (task names vary too
+much repo to repo to template safely).
+
+### 5. Offer branch protection — human stop point, always
+**Never run `templates/branch-protect.sh` without an explicit `AskUserQuestion` confirmation first,
+every time** — this changes a real GitHub repo setting, and a past "yes" to a different question isn't
+consent for this one. Show the user the exact command this would run (repo, branch, flags) before
+asking.
+
+If confirmed, run it once per branch that needs protecting (the release branch always; the integration
+branch too, if git-flow and the user wants it protected).
+
+### 6. Confirm
+Report what was installed/changed and what was skipped (and why — e.g. "CLAUDE.md already existed, so
+I left it — here's what the template would have added"). If anything from steps 3-5 was skipped, say
+so explicitly rather than letting the user assume everything happened.
+
+## Testing this skill itself
+
+If you're validating this skill's own correctness (not running it for a real repo): run it against a
+genuinely empty scratch repository (a fresh `git init`, nothing else) and confirm that after it
+finishes, a real verify-like gate actually runs and exits non-zero on a deliberately broken change —
+that's the concrete, checkable version of "the interview actually produced a working setup," not just
+"the files got written."

--- a/tools/ship-flow/templates/CLAUDE.md.template
+++ b/tools/ship-flow/templates/CLAUDE.md.template
@@ -1,0 +1,113 @@
+# CLAUDE.md — {{PROJECT_NAME}} development conventions
+
+Single source of truth for how anyone (human or AI agent) touches this repo's code. This is the
+constitution layer — always loaded, always in force. Merge with any personal/global guidelines you
+also use; on conflict, this file wins for this repo.
+
+---
+
+## 0. How to read this — don't mix enforced (gate) with advisory (judgment)
+
+| Marker | Meaning | Where it's enforced |
+|---|---|---|
+| ✅ **Gate** | A machine blocks the merge. Violation = RED | lint · typecheck · test · {{VERIFY_COMMAND}} |
+| 🔶 **Guidance** | Needs judgment. Lives only as prose here | code review + agent judgment |
+
+Lesson behind this split: a one-line fact from official docs becomes a gate; a design opinion becomes
+guidance. Don't blur the two — "enforce a design opinion via lint" produces gates nobody can satisfy,
+and "leave a hard factual constraint as prose" produces violations nobody catches.
+
+---
+
+## 1. Package manager & verification (read this first)
+
+- **Package manager: {{PACKAGE_MANAGER}} only.** {{PACKAGE_MANAGER_NOTES}}
+- Dependencies are installed in the package that uses them, not the repo root — the root holds only
+  shared tooling config.
+- Verify command — **the verifier is the ceiling. An agent's self-judgment never substitutes for a
+  PASS from this command.**
+
+  | Command | What it does | When |
+  |---|---|---|
+  | `{{VERIFY_COMMAND}}` | {{VERIFY_DESCRIPTION}} | Always, before any PR |
+
+  {{DEEP_GATES_TABLE}}
+
+### Test strategy (🔶 guidance)
+
+- Prefer proving *behavior*, not chasing a coverage percentage. A test that exercises a code path
+  without asserting on the property that actually matters is coverage theater.
+- Security/invariant-critical paths (auth, tenant isolation, anything a mistake in which is expensive
+  to discover later) need a test that would actually fail if the invariant broke — not just a test
+  that the happy path returns 200.
+
+---
+
+## 2. Package/module boundaries {{BOUNDARY_ENFORCEMENT_MARKER}}
+
+- Import other internal packages through their public entrypoint only — no deep-path imports that
+  reach past what the package intentionally exports. {{BOUNDARY_ENFORCEMENT_NOTES}}
+
+---
+
+## 3. Secrets & environment (🔶 guidance, tighten to ✅ once you have a validator)
+
+- Validate required environment/config at boot (fail fast on missing/malformed values) rather than
+  discovering a missing secret at first use in production.
+- `.env` (or equivalent) is local-only. Non-local secrets live in a secret manager, not committed
+  config.
+
+---
+
+## 4. The loop — where this convention is learned and lives
+
+- **One loop entrypoint.** Pick a single skill (this plugin ships `ship-feature`) that carries an
+  issue from plan → implementation → verified PR, rather than several competing entrypoints. Fewer
+  entrypoints means the risk gates and lesson-capture steps below can't be silently bypassed by using
+  a different door in.
+- **The verifier is the ceiling.** `{{VERIFY_COMMAND}}`'s exit code is the truth, never an agent's own
+  report of "tests pass now."
+- **Lessons.** Only a verifier-confirmed fix gets recorded as a lesson. A lesson that recurs is a
+  promotion candidate; promotion goes through a skeptical second pass (a different judgment than the
+  one that proposed it) before it gets codified back into this file — never a single pass grading its
+  own homework.
+- **Risk classification is rule-driven, not self-reported.** Whatever changes a diff touches (schema
+  migrations, auth paths, this file itself, CI/deploy config, N+ files) should map to a
+  deterministic risk tier via a rule table, not an agent's own claim about how risky its change is.
+  Merge/deploy/release actions are always the highest tier regardless of anything else about the
+  diff — a human approves those, every time.
+- **Branch model: {{BRANCH_MODEL}}.** {{BRANCH_MODEL_NOTES}}
+- **Worktree isolation (if concurrent work on this repo is common).** The main checkout's HEAD stays
+  on {{RELEASE_OR_INTEGRATION_BRANCH}} — new work starts in its own `git worktree add`, not a
+  `checkout -b` in the shared checkout. This is what lets two people/agents work on this repo at the
+  same time without one's uncommitted changes breaking the other's `git` operations.
+- **Merge happens on the server, not locally.** Push the branch, open a PR, let a human (or the
+  required CI checks) approve it there. A local `git merge`/`git push` straight to the shared branch
+  skips the review surface this whole loop exists to provide.
+
+---
+
+## 5. Knowledge ownership — what lives where
+
+**Test: if it needs to be reproducible, it belongs in the repo.** Anyone who clones this repo should
+get the same quality of collaboration, regardless of who (or which AI agent) is doing the work.
+
+| This kind of knowledge... | ...lives here |
+|---|---|
+| A decision, its reasoning, and the trade-off you picked | a decision record (e.g. `docs/adr/`) |
+| Domain terms / ubiquitous language | a glossary (e.g. `CONTEXT.md`) |
+| A gate or MUST-follow convention | this file |
+| A verified fix worth remembering | the lesson store this loop uses |
+| Current issue status, who's doing what, deadlines | your issue tracker ({{TRACKER_NAME}}), not this file |
+| Personal preferences, working style | your own personal agent config, not this repo |
+
+Don't let project state (what's in progress, who owns what) leak into this file — it goes stale the
+moment it's written and the tracker is already the source of truth for it.
+
+---
+
+## Placeholders this template still has open
+
+Search this file for `{{...}}` — the setup skill that installed this file should have already filled
+them in from an interview. If any remain, that interview was skipped or incomplete; fill them by hand
+or re-run the setup skill.

--- a/tools/ship-flow/templates/branch-protect.sh
+++ b/tools/ship-flow/templates/branch-protect.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# branch-protect.sh — idempotently apply GitHub branch protection to one branch.
+#
+# The real boundary against an unreviewed change landing on a shared branch is server-side branch
+# protection, not a local pre-commit hook (a hook is best-effort and bypassable — see any local
+# "guardrail" this repo may also have). This script is what actually sets that boundary.
+#
+# Usage:
+#   branch-protect.sh <owner/repo> <branch> --require-pr [--required-check "<job name>"] \
+#                      [--include-admins] [--no-force-push] [--no-delete]
+#
+# Examples:
+#   # Release branch: PR required, a named CI job must pass, admins included, no force-push/delete.
+#   branch-protect.sh myorg/myrepo main --require-pr --required-check "CI gate" \
+#                      --include-admins --no-force-push --no-delete
+#
+#   # Integration branch: PR required, no CI requirement (e.g. this repo doesn't run CI on PRs into
+#   # it — a common cost-control pattern), still no force-push/delete.
+#   branch-protect.sh myorg/myrepo develop --require-pr --no-force-push --no-delete
+#
+# Requires: `gh` authenticated with admin access to the target repo.
+#
+# Idempotent: re-running with the same arguments produces the same protection config — safe to run
+# again if you're not sure it applied, or to adjust one flag without hand-editing GitHub's API body.
+
+set -euo pipefail
+
+REPO="${1:?usage: branch-protect.sh <owner/repo> <branch> [flags...]}"
+BRANCH="${2:?usage: branch-protect.sh <owner/repo> <branch> [flags...]}"
+shift 2
+
+REQUIRE_PR=false
+REQUIRED_CHECK=""
+INCLUDE_ADMINS=false
+NO_FORCE_PUSH=false
+NO_DELETE=false
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --require-pr) REQUIRE_PR=true; shift ;;
+    --required-check) REQUIRED_CHECK="$2"; shift 2 ;;
+    --include-admins) INCLUDE_ADMINS=true; shift ;;
+    --no-force-push) NO_FORCE_PUSH=true; shift ;;
+    --no-delete) NO_DELETE=true; shift ;;
+    *) echo "unknown flag: $1" >&2; exit 1 ;;
+  esac
+done
+
+# Build the required_status_checks block — omitted entirely (null) if no check was named, since an
+# empty-but-present block behaves differently from "no status check requirement" in the API.
+if [ -n "$REQUIRED_CHECK" ]; then
+  STATUS_CHECKS_JSON=$(printf '{"strict": true, "contexts": [], "checks": [{"context": "%s"}]}' "$REQUIRED_CHECK")
+else
+  STATUS_CHECKS_JSON="null"
+fi
+
+PR_REVIEWS_JSON="null"
+if [ "$REQUIRE_PR" = "true" ]; then
+  PR_REVIEWS_JSON='{"required_approving_review_count": 0}'
+fi
+
+BODY=$(cat <<JSON
+{
+  "required_status_checks": ${STATUS_CHECKS_JSON},
+  "enforce_admins": ${INCLUDE_ADMINS},
+  "required_pull_request_reviews": ${PR_REVIEWS_JSON},
+  "restrictions": null,
+  "allow_force_pushes": $([ "$NO_FORCE_PUSH" = "true" ] && echo false || echo true),
+  "allow_deletions": $([ "$NO_DELETE" = "true" ] && echo false || echo true),
+  "required_linear_history": false,
+  "block_creations": false
+}
+JSON
+)
+
+echo "Applying branch protection: $REPO@$BRANCH"
+echo "$BODY" | gh api -X PUT "repos/${REPO}/branches/${BRANCH}/protection" --input - >/dev/null
+echo "Done. Verify with: gh api repos/${REPO}/branches/${BRANCH}/protection"

--- a/tools/ship-flow/templates/ci.yml.template
+++ b/tools/ship-flow/templates/ci.yml.template
@@ -1,0 +1,69 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [{{RELEASE_BRANCH}}]
+  workflow_dispatch:
+
+# Cancel a superseded run on re-push — without this, every re-push adds cost on top of the runs it
+# obsoletes rather than replacing them.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: verify
+    if: ${{ github.event_name == 'pull_request' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      # Add your language/package-manager setup step here (e.g. actions/setup-node + your package
+      # manager's cache).
+      - run: {{VERIFY_COMMAND}}
+
+  # ── Add more jobs here as this repo grows ──────────────────────────────────────
+  # A common next step: path-filtered jobs that only run when a specific area changed (e.g. a docker
+  # integration test that only needs to re-run when the DB schema or the API changed). If you add one,
+  # add it to `ci-gate`'s `needs` and to the aggregation logic below — see the comment on `ci-gate` for
+  # why a job that's missing from the gate creates a silent hole.
+
+  # ── always-run summary gate ──────────────────────────────────────────────────
+  # Why this job exists, not just the jobs above: pointing your branch protection's required check
+  # directly at a job name creates two holes that only show up under real concurrent use:
+  #   1. A job skipped by a path filter is treated by GitHub as "required check satisfied" — even when
+  #      the skip wasn't actually legitimate for that PR. Point the required check at a per-job name
+  #      and a mis-scoped path filter can land unreviewed changes.
+  #   2. A required check that's still *pending* when someone clicks merge doesn't block the merge —
+  #      the final failure can arrive after the merge already happened.
+  # Fix: one job (this one) uses `needs: [...]` + `if: always()` to wait for and aggregate every other
+  # job's result, and your branch protection's required check points at THIS job's name only. When you
+  # add a job above, add it to `needs:` and to the aggregation logic below — a job left out of both is
+  # a silent hole in the gate (identical to problem 1, just self-inflicted instead of GitHub's own
+  # default behavior).
+  ci-gate:
+    name: CI gate
+    needs: [verify]
+    if: ${{ always() && github.event_name == 'pull_request' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: aggregate required job results
+        env:
+          VERIFY: ${{ needs.verify.result }}
+        run: |
+          fail=0
+          # A job with no path filter (like `verify` above) must always succeed on a pull_request —
+          # `skipped` here would mean the workflow itself is misconfigured, not a legitimate skip.
+          for pair in "verify:$VERIFY"; do
+            job="${pair%%:*}"; result="${pair#*:}"
+            if [ "$result" = "success" ]; then
+              echo "gate: $job=success"
+            else
+              echo "::error::gate: $job=$result (must be success on a pull_request)"; fail=1
+            fi
+          done
+          # If you add a path-filtered job, its skip needs to be judged against the SAME path-filter
+          # output that decided to skip it — success always passes; skipped only passes if the filter
+          # output says this PR's change scope legitimately didn't need it; anything else (failure,
+          # cancelled, or skipped-when-the-filter-said-required) fails the gate.
+          exit "$fail"

--- a/tools/ship-flow/templates/turbo-verify-wiring.example.md
+++ b/tools/ship-flow/templates/turbo-verify-wiring.example.md
@@ -1,0 +1,53 @@
+# Example: wiring a `verify` command in a turbo monorepo
+
+This is an example, not a file this plugin installs verbatim — adapt the task names to what your repo
+actually has (typecheck/lint/test are common; add build, or drop test if you don't have any yet, etc).
+If your repo isn't a turbo monorepo, the only thing that matters for the rest of this plugin is that
+`{{VERIFY_COMMAND}}` in your `CLAUDE.md`/`ship-flow.config.json` resolves to *something* that exits
+non-zero on failure — a single `npm test`, a Makefile target, whatever fits.
+
+## `turbo.json`
+
+```json
+{
+  "$schema": "https://turbo.build/schema.json",
+  "globalDependencies": ["<your linter config>", "<your tsconfig base>", "<your lockfile>"],
+  "tasks": {
+    "typecheck": { "dependsOn": ["^typecheck"] },
+    "lint": {},
+    "test": { "dependsOn": ["^typecheck"] },
+    "build": { "cache": false, "outputs": ["dist/**", "!dist/**/*.map"] }
+  }
+}
+```
+
+`dependsOn: ["^typecheck"]` means "typecheck this package's dependencies before typechecking/testing
+this package" — it's what makes turbo's dependency-graph-aware caching and `--affected` actually safe
+to use instead of a full run.
+
+## Root `package.json`
+
+```json
+{
+  "scripts": {
+    "verify": "pnpm install --frozen-lockfile && turbo run typecheck lint test"
+  }
+}
+```
+
+- `--frozen-lockfile` (or your package manager's equivalent) is a cheap CI-relevant safety check —
+  it fails if `package.json` and the lockfile have drifted, instead of silently installing whatever
+  resolves.
+- If this repo also has this plugin's loop harness wired in (a `.loop`-based lesson store, a
+  risk-classification rule table, etc.), chain that harness's own self-check onto the end of `verify`
+  the same way — the harness's own regression coverage should ride the same gate everything else does,
+  not a separate one nobody remembers to run.
+
+## `--affected` in CI (optional, cost optimization for large monorepos)
+
+Once a monorepo gets large enough that a full `turbo run` on every PR is slow/expensive, `turbo run
+... --affected` only runs tasks for packages that actually changed (plus their dependents). The
+trade-off: base it on a safety fallback, not blind trust — a change to a root-level file (lockfile,
+root `package.json`, `turbo.json` itself) can affect every package in ways `--affected`'s git-diff
+heuristic won't always catch, so treat any root-file change as "fall back to a full run," not just
+"trust `--affected`."


### PR DESCRIPTION
## Summary

Adds `templates/` (CLAUDE.md constitution, CI workflow, branch-protection script, a turbo-verify
wiring reference doc) plus a new `setup` skill that interviews a consuming repo's user and installs
them — the pieces a plugin can't just bundle as a loadable component, since a plugin's own root
`CLAUDE.md` isn't loaded as project context (confirmed against the official plugin spec).

- `tools/ship-flow/templates/CLAUDE.md.template`
- `tools/ship-flow/templates/ci.yml.template`
- `tools/ship-flow/templates/branch-protect.sh`
- `tools/ship-flow/templates/turbo-verify-wiring.example.md`
- `tools/ship-flow/skills/setup/SKILL.md`

## Design notes

**CLAUDE.md.template** is a distillation of glucofit-partners' own CLAUDE.md's *Framework* layer
(gate-vs-guidance legend, verify-as-ceiling, lessons/risk-classification/worktree-isolation loop
discipline, knowledge-ownership routing), stripped of everything Product-specific (NestJS/Next.js
conventions, RLS/multi-tenancy, Korean hospital-SaaS domain content). It's a skeleton with
`{{PLACEHOLDER}}`s the setup skill's interview fills in, not a copy of glucofit-partners' actual file.

**ci.yml.template** is deliberately NOT a port of glucofit-partners' real `ci.yml` — that one is
tightly coupled to its own db/api/e2e domain packages and RLS/auth integration tests, none of which
generalize. Instead it extracts just the durable, hard-won pattern: an always-run `ci-gate` job that
aggregates every other job's result, because pointing branch protection's required check directly at
a per-job name has two real failure modes glucofit-partners hit in production (documented in the
template's comments): a path-filter-skipped job reads to GitHub as "required check satisfied" even
when the skip wasn't legitimate for that PR, and a still-*pending* check doesn't block someone from
clicking merge before the final result arrives.

**branch-protect.sh** didn't exist as reusable code anywhere — glucofit-partners set its own
protection up by hand via ad-hoc `gh api` calls documented across two ADRs. This is new authorship
that codifies those same rules (PR required, no force-push/delete, admin inclusion, a named required
status check) into one idempotent, parameterized script.

**setup** reuses `hotfix`'s existing `.claude/ship-flow.config.json` rather than inventing a second
config file — extends it with `packageManager`/`verifyCommand`/`projectName`/`trackerName`. Branch
protection is a hard stop point requiring `AskUserQuestion` confirmation every time (it changes a real
GitHub setting) — never inferred from an earlier unrelated "yes."

## Verification

- `claude plugin validate --strict` → green.
- Ran the setup skill for real: `claude -p --plugin-dir tools/ship-flow` (non-interactive, fixed
  interview answers standing in for what would normally be `AskUserQuestion` prompts) against a
  genuinely empty scratch repo (`git init`, nothing else). Skipped step 5 (branch protection) — no
  real GitHub remote to test that against.
- **Did not trust the nested session's own self-report.** Its `permission_denials` showed the first
  `Write` to `.claude/ship-flow.config.json` was denied; it silently retried and its final report
  claimed all 3 files were written successfully. Checked the scratch repo's filesystem directly:
  confirmed independently that `.claude/ship-flow.config.json`, `CLAUDE.md` (0 leftover
  `{{placeholders}}`), and `.github/workflows/ci.yml` (0 leftover placeholders, correct substitution)
  were all actually present and correct.
- Ran the wired verify command myself, directly, outside the nested session: `npm run typecheck &&
  npm run lint && npm run test` → exit 0 on the passing scratch repo. Then deliberately broke the
  `test` script (`exit 1`) and re-ran: exit 1. A real gate, not a no-op that always reports green.

Closes BAC-705.