### PR TITLE
feat(ship-flow): port 9 category-B skills, generalized (BAC-703)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -18,7 +18,7 @@
     {
       "name": "ship-flow",
       "source": "./tools/ship-flow",
-      "description": "Delivery-loop skills (hotfix so far — ship-feature/retrospect/grill-with-docs to follow) parameterized by a consuming repo's own tracker/branch-model config instead of hardcoded to one repo. dependencies: loop-engine.",
+      "description": "Delivery-loop skills — ship-feature (plan-to-PR autonomous loop), hotfix, retrospect, grill-with-docs, deps-audit, to-issues/to-prd, tdd, harness-maturity-audit, improve-codebase-architecture, resolving-merge-conflicts, plus review agents and audit/research workflows — parameterized by a consuming repo's own tracker/branch-model config instead of hardcoded to one repo. dependencies: loop-engine.",
       "version": "0.1.0",
       "keywords": ["delivery", "git-flow", "hotfix", "ship", "release"]
     }

--- a/tools/ship-flow/skills/deps-audit/SKILL.md
+++ b/tools/ship-flow/skills/deps-audit/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: deps-audit
+description: Maintenance check for installed Claude Code extensions (marketplace plugins, skills.sh skills, gstack, and repo-embedded skills). Produces one report answering whether upstream is still maintained, whether the local install is current, and what's unused. Use when the user asks to audit or clean up skills/plugins, find unused skills, check whether things are up to date, check for divergence, or when a weekly heartbeat nudges.
+---
+
+# deps-audit — extension maintenance dashboard
+
+Answers whether each installed extension **(1) is maintained upstream, (2) is your install current, and (3) what's unused**. Sweeps all four install channels — marketplace plugins, skills.sh, gstack, and repo-embedded skills — in one pass.
+
+## Run
+
+Run this repo's installed loop-engine plugin's `deps-audit` script — invoked however this repo resolves plugin bin scripts. The example below uses the `tools/plugin-path.mjs exec` wrapper this plugin itself relies on; a repo that installs loop-engine a different way may invoke it differently:
+
+```bash
+node tools/plugin-path.mjs exec bin/deps-audit.mjs                      # fast — local manifests + usage + gh freshness (no clone)
+node tools/plugin-path.mjs exec bin/deps-audit.mjs --deep                # + skills.sh merge-base divergence (your edits vs staleness)
+node tools/plugin-path.mjs exec bin/deps-audit.mjs --json                # machine-readable
+node tools/plugin-path.mjs exec bin/deps-audit.mjs --refresh-provenance  # regenerate the sidecar (run after `npx skills update`)
+```
+
+If `CLAUDE_PROJECT_DIR` isn't set, it treats CWD as the project (run from the repo root). Each run (including `--json`) stamps `.loop/deps-audit.last` with a timestamp so a weekly heartbeat, if this repo has one, can throttle re-runs.
+
+## What it reads (source of truth)
+
+| Channel | Manifest |
+|---|---|
+| Marketplace plugins | `~/.claude/plugins/{installed_plugins,known_marketplaces}.json` + `~/.claude/settings.json` (enabledPlugins) |
+| skills.sh | `~/.agents/.skill-lock.json` + `~/.agents/.skill-provenance.json` (merge-base sidecar) |
+| gstack | `~/.claude/skills/gstack` (git repo) |
+| Repo-embedded | `<repo>/.claude/skills/*` — provenance = **this project's own git history** |
+| Usage | `~/.claude.json` { `skillUsage`, `pluginUsage` } |
+
+## Reading the report (what each verdict is based on, and its limits)
+
+- **Freshness (`up Nd`)**: days since upstream's last commit. `>365d` surfaces as "possibly unmaintained" in the recommendations. If `gh` isn't authenticated, this column is **blank** (header banner shows `gh:off (freshness unknown)`, fail-open). If the repo is deleted, private, or rate-limited, it shows `lookup✗` + "lookup failed" in the recommendations (it never guesses from a blank freshness column).
+- **Stale/current (fast)**: compares the skills.sh install's base sha against upstream HEAD sha. **sha-based, so it can overcount** (upstream moved but the specific skill file didn't change). **`--deep` is authoritative for content-level verdicts**. If both are unknown, shows `?`.
+- **Divergence (`--deep`)**: reconstructs the install-time commit as the merge base, then diffs `local vs base` = **your edits, isolated**.
+  - `🟡` (edits kept) — real local edits exist → updating needs a 3-way merge.
+  - `🟠` (safe to update) — zero local edits, upstream moved on → **safe to bulk-update**.
+  - `🟢` — already current and unedited.
+  - `⚠️` (can't verdict) — local folder missing, base commit not found, upstream reorganized its paths, or a non-GitHub URL got rejected. These stay "undetermined" rather than being downgraded to clean/stale, and are excluded from bulk-update candidates.
+  - **Trap**: if upstream reorganizes a skill's path, the merge base can resolve to a stub and produce a **false positive** `🟡`. Always eyeball the actual patch before trusting a `🟡` verdict.
+- **Unused (`🗑️`)**: `usageCount==0` and last used `>90d` ago. **Caveat**: `skillUsage` is keyed by name, so a global copy and a project copy of the same name have their usage counts summed together. A plugin with `pluginUsage==0` may still be in use **through a skill or MCP tool it provides** — marked `ⓘ` (cross-check before removing). Only disabled-and-unused is a confirmed removal candidate. **If `~/.claude.json` fails to parse, the unused/removal analysis is skipped entirely** (shown as `use?`) rather than risk a false positive leading to a false deletion.
+- **Repo-embedded `★`** = authored here (first commit isn't a vendor stamp), unmarked = vendored (first commit is `vendor …` — i.e. cloned and left as-is). The signal is the first commit's *message*, not commit count. Shows `?` if the git lookup fails. Provenance is this project's own git history.
+
+## Maintenance workflow (recommended)
+
+1. **Weekly**: when a heartbeat nudges, run `/deps-audit` (fast) as a sweep.
+2. **Update**: `🟠` (zero local edits) is safe to bulk-update via `npx skills update -g`. For `🟡`, eyeball the real patch first, then do a 3-way merge (`~/.agents/.skill-provenance.json`'s `installBaseCommit` is the merge base).
+   → **Run `--refresh-provenance` right after updating** to reset the fast staleness verdict (skip it and the next fast run will false-flag as stale again). Deep self-corrects its base off `updatedAt`, so a stale sidecar doesn't break it.
+3. **Cleanup**: confirmed removal candidates (disabled-and-unused plugins, skills unused for 90d+) go through user approval before `npx skills remove -g -y <name…>` / `claude plugin uninstall <plugin>`. Destructive, so never auto-delete — back up the lock file first. Refresh provenance after removing.
+4. **gstack**: if it's behind, run `/gstack-upgrade` (if this repo's owner uses gstack).
+5. If this repo's owner tracks skill/plugin maintenance notes in some external memory or notes tool, divergence strategy and past corrections are worth logging there — specific skill names rot too fast to be worth hardcoding into this file.
+
+## Discipline
+
+- **Read-only reporter.** This skill never deletes or updates anything — it only produces the judgment inputs. Removal and updates require human approval.
+- **Provenance never touches the lock file** — it lives in a separate sidecar (`~/.agents/.skill-provenance.json`). A skills.sh reinstall overwriting the lock file doesn't affect it.
+- Fail-open: if `gh`, the network, or a file is missing, it reports what it can without crashing.

--- a/tools/ship-flow/skills/grill-with-docs/ADR-FORMAT.md
+++ b/tools/ship-flow/skills/grill-with-docs/ADR-FORMAT.md
@@ -1,0 +1,47 @@
+# ADR Format
+
+ADRs live in `docs/adr/` and use sequential numbering: `0001-slug.md`, `0002-slug.md`, etc.
+
+Create the `docs/adr/` directory lazily — only when the first ADR is needed.
+
+## Template
+
+```md
+# {Short title of the decision}
+
+{1-3 sentences: what's the context, what did we decide, and why.}
+```
+
+That's it. An ADR can be a single paragraph. The value is in recording *that* a decision was made and *why* — not in filling out sections.
+
+## Optional sections
+
+Only include these when they add genuine value. Most ADRs won't need them.
+
+- **Status** frontmatter (`proposed | accepted | deprecated | superseded by ADR-NNNN`) — useful when decisions are revisited
+- **Considered Options** — only when the rejected alternatives are worth remembering
+- **Consequences** — only when non-obvious downstream effects need to be called out
+
+## Numbering
+
+Scan `docs/adr/` for the highest existing number and increment by one.
+
+## When to offer an ADR
+
+All three of these must be true:
+
+1. **Hard to reverse** — the cost of changing your mind later is meaningful
+2. **Surprising without context** — a future reader will look at the code and wonder "why on earth did they do it this way?"
+3. **The result of a real trade-off** — there were genuine alternatives and you picked one for specific reasons
+
+If a decision is easy to reverse, skip it — you'll just reverse it. If it's not surprising, nobody will wonder why. If there was no real alternative, there's nothing to record beyond "we did the obvious thing."
+
+### What qualifies
+
+- **Architectural shape.** "We're using a monorepo." "The write model is event-sourced, the read model is projected into Postgres."
+- **Integration patterns between contexts.** "Ordering and Billing communicate via domain events, not synchronous HTTP."
+- **Technology choices that carry lock-in.** Database, message bus, auth provider, deployment target. Not every library — just the ones that would take a quarter to swap out.
+- **Boundary and scope decisions.** "Customer data is owned by the Customer context; other contexts reference it by ID only." The explicit no-s are as valuable as the yes-s.
+- **Deliberate deviations from the obvious path.** "We're using manual SQL instead of an ORM because X." Anything where a reasonable reader would assume the opposite. These stop the next engineer from "fixing" something that was deliberate.
+- **Constraints not visible in the code.** "We can't use AWS because of compliance requirements." "Response times must be under 200ms because of the partner API contract."
+- **Rejected alternatives when the rejection is non-obvious.** If you considered GraphQL and picked REST for subtle reasons, record it — otherwise someone will suggest GraphQL again in six months.

--- a/tools/ship-flow/skills/grill-with-docs/CONTEXT-FORMAT.md
+++ b/tools/ship-flow/skills/grill-with-docs/CONTEXT-FORMAT.md
@@ -1,0 +1,60 @@
+# CONTEXT.md Format
+
+## Structure
+
+```md
+# {Context Name}
+
+{One or two sentence description of what this context is and why it exists.}
+
+## Language
+
+**Order**:
+{A one or two sentence description of the term}
+_Avoid_: Purchase, transaction
+
+**Invoice**:
+A request for payment sent to a customer after delivery.
+_Avoid_: Bill, payment request
+
+**Customer**:
+A person or organization that places orders.
+_Avoid_: Client, buyer, account
+```
+
+## Rules
+
+- **Be opinionated.** When multiple words exist for the same concept, pick the best one and list the others under `_Avoid_`.
+- **Keep definitions tight.** One or two sentences max. Define what it IS, not what it does.
+- **Only include terms specific to this project's context.** General programming concepts (timeouts, error types, utility patterns) don't belong even if the project uses them extensively. Before adding a term, ask: is this a concept unique to this context, or a general programming concept? Only the former belongs.
+- **Group terms under subheadings** when natural clusters emerge. If all terms belong to a single cohesive area, a flat list is fine.
+
+## Single vs multi-context repos
+
+**Single context (most repos):** One `CONTEXT.md` at the repo root.
+
+**Multiple contexts:** A `CONTEXT-MAP.md` at the repo root lists the contexts, where they live, and how they relate to each other:
+
+```md
+# Context Map
+
+## Contexts
+
+- [Ordering](./src/ordering/CONTEXT.md) — receives and tracks customer orders
+- [Billing](./src/billing/CONTEXT.md) — generates invoices and processes payments
+- [Fulfillment](./src/fulfillment/CONTEXT.md) — manages warehouse picking and shipping
+
+## Relationships
+
+- **Ordering → Fulfillment**: Ordering emits `OrderPlaced` events; Fulfillment consumes them to start picking
+- **Fulfillment → Billing**: Fulfillment emits `ShipmentDispatched` events; Billing consumes them to generate invoices
+- **Ordering ↔ Billing**: Shared types for `CustomerId` and `Money`
+```
+
+The skill infers which structure applies:
+
+- If `CONTEXT-MAP.md` exists, read it to find contexts
+- If only a root `CONTEXT.md` exists, single context
+- If neither exists, create a root `CONTEXT.md` lazily when the first term is resolved
+
+When multiple contexts exist, infer which one the current topic relates to. If unclear, ask.

--- a/tools/ship-flow/skills/grill-with-docs/SKILL.md
+++ b/tools/ship-flow/skills/grill-with-docs/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: grill-with-docs
+description: Grilling session that challenges your plan against the existing domain model, sharpens terminology, and updates documentation (CONTEXT.md, ADRs) inline as decisions crystallise. Use when user wants to stress-test a plan against their project's language and documented decisions.
+---
+
+<what-to-do>
+
+Interview me relentlessly about every aspect of this plan until we reach a shared understanding. Walk down each branch of the design tree, resolving dependencies between decisions one-by-one. For each question, provide your recommended answer.
+
+Ask the questions one at a time, waiting for feedback on each question before continuing.
+
+If a question can be answered by exploring the codebase, explore the codebase instead.
+
+</what-to-do>
+
+<supporting-info>
+
+## Domain awareness
+
+During codebase exploration, also look for existing documentation:
+
+### File structure
+
+Most repos have a single context:
+
+```
+/
+├── CONTEXT.md
+├── docs/
+│   └── adr/
+│       ├── 0001-event-sourced-orders.md
+│       └── 0002-postgres-for-write-model.md
+└── src/
+```
+
+If a `CONTEXT-MAP.md` exists at the root, the repo has multiple contexts. The map points to where each one lives:
+
+```
+/
+├── CONTEXT-MAP.md
+├── docs/
+│   └── adr/                          ← system-wide decisions
+├── src/
+│   ├── ordering/
+│   │   ├── CONTEXT.md
+│   │   └── docs/adr/                 ← context-specific decisions
+│   └── billing/
+│       ├── CONTEXT.md
+│       └── docs/adr/
+```
+
+Create files lazily — only when you have something to write. If no `CONTEXT.md` exists, create one when the first term is resolved. If no `docs/adr/` exists, create it when the first ADR is needed.
+
+## During the session
+
+### Challenge against the glossary
+
+When the user uses a term that conflicts with the existing language in `CONTEXT.md`, call it out immediately. "Your glossary defines 'cancellation' as X, but you seem to mean Y — which is it?"
+
+### Sharpen fuzzy language
+
+When the user uses vague or overloaded terms, propose a precise canonical term. "You're saying 'account' — do you mean the Customer or the User? Those are different things."
+
+### Discuss concrete scenarios
+
+When domain relationships are being discussed, stress-test them with specific scenarios. Invent scenarios that probe edge cases and force the user to be precise about the boundaries between concepts.
+
+### Cross-reference with code
+
+When the user states how something works, check whether the code agrees. If you find a contradiction, surface it: "Your code cancels entire Orders, but you just said partial cancellation is possible — which is right?"
+
+### Update CONTEXT.md inline
+
+When a term is resolved, update `CONTEXT.md` right there. Don't batch these up — capture them as they happen. Use the format in [CONTEXT-FORMAT.md](./CONTEXT-FORMAT.md).
+
+`CONTEXT.md` should be totally devoid of implementation details. Do not treat `CONTEXT.md` as a spec, a scratch pad, or a repository for implementation decisions. It is a glossary and nothing else.
+
+### Offer ADRs sparingly
+
+Only offer to create an ADR when all three are true:
+
+1. **Hard to reverse** — the cost of changing your mind later is meaningful
+2. **Surprising without context** — a future reader will wonder "why did they do it this way?"
+3. **The result of a real trade-off** — there were genuine alternatives and you picked one for specific reasons
+
+If any of the three is missing, skip the ADR. Use the format in [ADR-FORMAT.md](./ADR-FORMAT.md).
+
+</supporting-info>

--- a/tools/ship-flow/skills/harness-maturity-audit/SKILL.md
+++ b/tools/ship-flow/skills/harness-maturity-audit/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: harness-maturity-audit
+description: Audits the maturity of a repo's self-improvement loop harness (verifier=ceiling, Inner/Outer/Meta loops, vector-backed loop memory, skill/tool usage) via six parallel forensic investigation lanes, producing an L0-L5 scorecard and a prioritized improvement list saved as a report. Use when the user asks for a "harness maturity audit", a "loop engineering checkup", a self-improvement loop audit, or wants a periodic checkup after a milestone/epic completes.
+---
+
+# harness-maturity-audit — six-lane parallel harness maturity audit
+
+Measures whether this repo's self-improvement harness (an installed loop-engine plugin, any
+vector-backed loop-memory package, `.claude/{skills,hooks}`, and wherever this repo keeps its
+decision records and research) **actually works the way it claims to, not just how it reads on
+paper.** The one method that makes an audit like this worth repeating — rather than a fresh
+impression each time — is simple: **every claim that something "works" is checked by actually
+running the command and observing its exit code/output. Never asserted from inference or
+guesswork.**
+
+## When to use this
+
+- When a human asks for "a harness maturity audit" / "loop engineering checkup" / similar
+- Right after a milestone or epic completes, as a periodic checkup
+- **When NOT to use this**: for diagnosing one specific bug, use this repo's equivalent of a
+  single-bug-diagnosis skill if it has one (e.g. `diagnose`); for extension/dependency
+  maintenance checks use `deps-audit` if this repo has it installed; for a branch-freshness
+  preflight, use this repo's equivalent check if it has one. This skill is a heavy audit across
+  three axes of the harness as a whole — structure, operation, and self-improvement — not a
+  narrow check.
+
+## Methodology (non-negotiable — this is what makes repeated audits comparable)
+
+- **Execution evidence only.** Investigation agents record as evidence only what they actually
+  observed by reading a file (`Read`/grep) or running a command (`Bash`). Sentences like
+  "this probably works" are not allowed.
+- **L0-L5 rubric** (kept stable across runs so audits stay comparable):
+
+  | Level | Meaning |
+  |:---:|---|
+  | L0 absent | never built |
+  | L1 designed | documented only, no working code |
+  | L2 built | code exists, verifiable in isolation |
+  | L3 wired | integrated into a real loop — at least one path works end-to-end |
+  | L4 proven | has closed the loop at least once on a real change (keystone) |
+  | L5 self-improving | the Outer/Meta loop has actually promoted a lesson across runs and changed future behavior |
+
+- **Report strengths too.** Don't just hunt for gaps — keep the "what's working well" section
+  symmetric with the gap list, the way a fair audit report should read.
+- **Honest delta.** Read the most recent prior audit report for this repo first (if one exists —
+  check wherever this repo keeps durable research/audit docs, commonly named with "maturity",
+  "audit", or "reassessment" in the filename) and explicitly state what changed since then.
+
+## The six investigation dimensions
+
+1. **Decision archive** — whether each decision record (e.g. this repo's ADRs, if it has an
+   ADR-style archive) was actually implemented, whether any are left abandoned/on-hold, and any
+   drift between a record and the current code.
+2. **loop-engine code** — actually runs the installed loop-engine plugin's `bin/*` scripts
+   (verdict-run, loop-fix, gate, eval-gate, lessons, etc.), invoked however this repo actually
+   resolves and calls them, plus any wrapper scripts this repo maintains itself outside the
+   plugin — and observes exit codes/output. Looks for violations of the "verifier = ceiling"
+   principle (fake green, etc.).
+3. **Operational data** — reads this repo's actual `.loop/lessons/*.json` (count, verified
+   ratio, recurrence/promotion) and any other loop-state files it maintains, to confirm the
+   harness has *actually run*, not just that it's wired up.
+4. **Skill maturity** — enumerates this repo's skills, checks each SKILL.md for dangling links
+   or references to commands/files that don't exist, and cross-checks against actual usage
+   frequency data if this repo (or its tooling) tracks that.
+5. **Vector-backed loop memory usage** — if this repo has a loop-memory-style package, greps its
+   actual callers (hooks, bin scripts), checks DB connectivity, and measures real call paths for
+   lesson recall/graduation. If no such package exists, says so and scores L0 rather than
+   inventing one.
+6. **Domain knowledge / tool usage** — whether this repo's domain docs (glossary, agent-facing
+   docs) show up reflected in recent actual work (`git log`), and whether tools this repo's
+   CLAUDE.md mandates (e.g. a specific issue tracker) are actually being used in practice rather
+   than bypassed.
+
+## Execution
+
+**Calls the stored named workflow** — six parallel investigation lanes plus synthesis, with
+resume support (a run that finishes investigation but drops before synthesis doesn't need to
+restart from scratch):
+
+```javascript
+Workflow({ name: 'ship-flow:harness-audit' })
+```
+
+Use `resumeFromRunId` to continue an interrupted prior run (see the Workflow tool's own
+description) — if investigation finished but synthesis was interrupted, resume on top of the
+cached six-dimension results instead of rerunning everything.
+
+## After the workflow returns — save the report + route follow-up
+
+Once you have the workflow result (`reportBody`):
+
+1. **Save it as a durable repo artifact.** If this repo has an established convention for where
+   durable research/audit docs live (check its CLAUDE.md or an equivalent contributor doc), save
+   it there, named for today's date and the audit subject (e.g.
+   `<date>-loop-harness-maturity-audit.md`). If no such convention is apparent, ask the user
+   where it should go rather than guessing — the point is that this is a repo artifact meant to
+   be found again later, not scratch output. Put a title and a methodology footnote at the top
+   of the file (link to the prior report if one was found, and note "actual command execution +
+   N-agent parallel forensic investigation, not inference").  If a second run happens on the
+   same day, the filename collides — ask the user whether to overwrite the first run's result or
+   distinguish by timestamp; don't silently overwrite.
+2. **Show the user the prioritized improvement list and ask what they want next**:
+   - Leave it as a report for a human to review later
+   - Continue straight into `to-issues` to turn blocker/major items into issues (the report
+     content is already in context, so `to-issues` can pick it up without extra arguments)
+3. If the user chooses `to-issues`, this skill hands off everything downstream (approval,
+   publishing) to `to-issues` entirely — it doesn't publish anything itself.
+
+## Discipline
+
+- **Read-only.** The six investigation agents don't modify or commit files — they only produce
+  judgment material.
+- **Keep it comparable.** Use the same rubric (L0-L5) and the same severity vocabulary
+  (blocker/major/minor) as prior reports so the delta is meaningful. Don't invent a new scale.
+- **The honest delta is the point.** Finding a prior report and then ignoring it defeats this
+  skill's reason for existing — repeatable comparison.

--- a/tools/ship-flow/skills/improve-codebase-architecture/DEEPENING.md
+++ b/tools/ship-flow/skills/improve-codebase-architecture/DEEPENING.md
@@ -1,0 +1,37 @@
+# Deepening
+
+How to deepen a cluster of shallow modules safely, given its dependencies. Assumes the vocabulary in [LANGUAGE.md](LANGUAGE.md) — **module**, **interface**, **seam**, **adapter**.
+
+## Dependency categories
+
+When assessing a candidate for deepening, classify its dependencies. The category determines how the deepened module is tested across its seam.
+
+### 1. In-process
+
+Pure computation, in-memory state, no I/O. Always deepenable — merge the modules and test through the new interface directly. No adapter needed.
+
+### 2. Local-substitutable
+
+Dependencies that have local test stand-ins (PGLite for Postgres, in-memory filesystem). Deepenable if the stand-in exists. The deepened module is tested with the stand-in running in the test suite. The seam is internal; no port at the module's external interface.
+
+### 3. Remote but owned (Ports & Adapters)
+
+Your own services across a network boundary (microservices, internal APIs). Define a **port** (interface) at the seam. The deep module owns the logic; the transport is injected as an **adapter**. Tests use an in-memory adapter. Production uses an HTTP/gRPC/queue adapter.
+
+Recommendation shape: *"Define a port at the seam, implement an HTTP adapter for production and an in-memory adapter for testing, so the logic sits in one deep module even though it's deployed across a network."*
+
+### 4. True external (Mock)
+
+Third-party services (Stripe, Twilio, etc.) you don't control. The deepened module takes the external dependency as an injected port; tests provide a mock adapter.
+
+## Seam discipline
+
+- **One adapter means a hypothetical seam. Two adapters means a real one.** Don't introduce a port unless at least two adapters are justified (typically production + test). A single-adapter seam is just indirection.
+- **Internal seams vs external seams.** A deep module can have internal seams (private to its implementation, used by its own tests) as well as the external seam at its interface. Don't expose internal seams through the interface just because tests use them.
+
+## Testing strategy: replace, don't layer
+
+- Old unit tests on shallow modules become waste once tests at the deepened module's interface exist — delete them.
+- Write new tests at the deepened module's interface. The **interface is the test surface**.
+- Tests assert on observable outcomes through the interface, not internal state.
+- Tests should survive internal refactors — they describe behaviour, not implementation. If a test has to change when the implementation changes, it's testing past the interface.

--- a/tools/ship-flow/skills/improve-codebase-architecture/HTML-REPORT.md
+++ b/tools/ship-flow/skills/improve-codebase-architecture/HTML-REPORT.md
@@ -1,0 +1,123 @@
+# HTML Report Format
+
+The architectural review is rendered as a single self-contained HTML file in the OS temp directory. Tailwind and Mermaid both come from CDNs. Mermaid handles graph-shaped diagrams reliably; hand-built divs and inline SVG handle the more editorial visuals (mass diagrams, cross-sections). Mix the two — don't lean on Mermaid for everything, it'll start to look generic.
+
+## Scaffold
+
+```html
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Architecture review — {{repo name}}</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script type="module">
+      import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs";
+      mermaid.initialize({ startOnLoad: true, theme: "neutral", securityLevel: "loose" });
+    </script>
+    <style>
+      /* small custom layer for things Tailwind doesn't cover cleanly:
+         dashed seam lines, hand-drawn-feeling arrow heads, etc. */
+      .seam { stroke-dasharray: 4 4; }
+      .leak { stroke: #dc2626; }
+      .deep { background: linear-gradient(135deg, #0f172a, #1e293b); }
+    </style>
+  </head>
+  <body class="bg-stone-50 text-slate-900 font-sans">
+    <main class="max-w-5xl mx-auto px-6 py-12 space-y-12">
+      <header>...</header>
+      <section id="candidates" class="space-y-10">...</section>
+      <section id="top-recommendation">...</section>
+    </main>
+  </body>
+</html>
+```
+
+## Header
+
+Repo name, date, and a compact legend: solid box = module, dashed line = seam, red arrow = leakage, thick dark box = deep module. No introduction paragraph — straight into the candidates.
+
+## Candidate card
+
+The diagrams carry the weight. Prose is sparse, plain, and uses the glossary terms ([LANGUAGE.md](LANGUAGE.md)) without ceremony.
+
+Each candidate is one `<article>`:
+
+- **Title** — short, names the deepening (e.g. "Collapse the Order intake pipeline").
+- **Badge row** — recommendation strength (`Strong` = emerald, `Worth exploring` = amber, `Speculative` = slate), plus a tag for the dependency category (`in-process`, `local-substitutable`, `ports & adapters`, `mock`).
+- **Files** — monospaced list, `font-mono text-sm`.
+- **Before / After diagram** — the centrepiece. Two columns, side by side. See patterns below.
+- **Problem** — one sentence. What hurts.
+- **Solution** — one sentence. What changes.
+- **Wins** — bullets, ≤6 words each. e.g. "Tests hit one interface", "Pricing logic stops leaking", "Delete 4 shallow wrappers".
+- **ADR callout** (if applicable) — one line in an amber-tinted box.
+
+No paragraphs of explanation. If the diagram needs a paragraph to be understood, redraw the diagram.
+
+## Diagram patterns
+
+Pick the pattern that fits the candidate. Mix them. Don't make every diagram look the same — variety is part of the point.
+
+### Mermaid graph (the workhorse for dependencies / call flow)
+
+Use a Mermaid `flowchart` or `graph` when the point is "X calls Y calls Z, and look at the mess." Wrap it in a Tailwind-styled card so it doesn't feel parachuted in. Style with classDef to colour leakage edges red and the deep module dark. Sequence diagrams work well for "before: 6 round-trips; after: 1."
+
+```html
+<div class="rounded-lg border border-slate-200 bg-white p-4">
+  <pre class="mermaid">
+    flowchart LR
+      A[OrderHandler] --> B[OrderValidator]
+      B --> C[OrderRepo]
+      C -.leak.-> D[PricingClient]
+      classDef leak stroke:#dc2626,stroke-width:2px;
+      class C,D leak
+  </pre>
+</div>
+```
+
+### Hand-built boxes-and-arrows (when Mermaid's layout fights you)
+
+Modules as `<div>`s with borders and labels. Arrows as inline SVG `<line>` or `<path>` elements positioned absolutely over a relative container. Reach for this when you want the "after" diagram to feel like one thick-bordered deep module with greyed-out internals — Mermaid won't render that with the right weight.
+
+### Cross-section (good for layered shallowness)
+
+Stack horizontal bands (`h-12 border-l-4`) to show layers a call passes through. Before: 6 thin layers each doing nothing. After: 1 thick band labelled with the consolidated responsibility.
+
+### Mass diagram (good for "interface as wide as implementation")
+
+Two rectangles per module — one for interface surface area, one for implementation. Before: interface rectangle is nearly as tall as the implementation rectangle (shallow). After: interface rectangle is short, implementation rectangle is tall (deep).
+
+### Call-graph collapse
+
+Before: a tree of function calls rendered as nested boxes. After: the same tree collapsed into one box, with the now-internal calls shown faded inside it.
+
+## Style guidance
+
+- Lean editorial, not corporate-dashboard. Generous whitespace. Serif optional for headings (`font-serif` works well with stone/slate).
+- Colour sparingly: one accent (emerald or indigo) plus red for leakage and amber for warnings.
+- Keep diagrams ~320px tall so before/after sits comfortably side by side without scrolling.
+- Use `text-xs uppercase tracking-wider` for module labels inside diagrams — they should read as schematic, not as UI.
+- The only scripts are the Tailwind CDN and the Mermaid ESM import. The report is otherwise static — no app code, no interactivity beyond Mermaid's own rendering.
+
+## Top recommendation section
+
+One larger card. Candidate name, one sentence on why, anchor link to its card. That's it.
+
+## Tone
+
+Plain English, concise — but the architectural nouns and verbs come straight from [LANGUAGE.md](LANGUAGE.md). Concision is not an excuse to drift.
+
+**Use exactly:** module, interface, implementation, depth, deep, shallow, seam, adapter, leverage, locality.
+
+**Never substitute:** component, service, unit (for module) · API, signature (for interface) · boundary (for seam) · layer, wrapper (for module, when you mean module).
+
+**Phrasings that fit the style:**
+
+- "Order intake module is shallow — interface nearly matches the implementation."
+- "Pricing leaks across the seam."
+- "Deepen: one interface, one place to test."
+- "Two adapters justify the seam: HTTP in prod, in-memory in tests."
+
+**Wins bullets** name the gain in glossary terms: *"locality: bugs concentrate in one module"*, *"leverage: one interface, N call sites"*, *"interface shrinks; implementation absorbs the wrappers"*. Don't write *"easier to maintain"* or *"cleaner code"* — those terms aren't in the glossary and don't earn their place.
+
+No hedging, no throat-clearing, no "it's worth noting that…". If a sentence could be a bullet, make it a bullet. If a bullet could be cut, cut it. If a term isn't in [LANGUAGE.md](LANGUAGE.md), reach for one that is before inventing a new one.

--- a/tools/ship-flow/skills/improve-codebase-architecture/INTERFACE-DESIGN.md
+++ b/tools/ship-flow/skills/improve-codebase-architecture/INTERFACE-DESIGN.md
@@ -1,0 +1,44 @@
+# Interface Design
+
+When the user wants to explore alternative interfaces for a chosen deepening candidate, use this parallel sub-agent pattern. Based on "Design It Twice" (Ousterhout) — your first idea is unlikely to be the best.
+
+Uses the vocabulary in [LANGUAGE.md](LANGUAGE.md) — **module**, **interface**, **seam**, **adapter**, **leverage**.
+
+## Process
+
+### 1. Frame the problem space
+
+Before spawning sub-agents, write a user-facing explanation of the problem space for the chosen candidate:
+
+- The constraints any new interface would need to satisfy
+- The dependencies it would rely on, and which category they fall into (see [DEEPENING.md](DEEPENING.md))
+- A rough illustrative code sketch to ground the constraints — not a proposal, just a way to make the constraints concrete
+
+Show this to the user, then immediately proceed to Step 2. The user reads and thinks while the sub-agents work in parallel.
+
+### 2. Spawn sub-agents
+
+Spawn 3+ sub-agents in parallel using the Agent tool. Each must produce a **radically different** interface for the deepened module.
+
+Prompt each sub-agent with a separate technical brief (file paths, coupling details, dependency category from [DEEPENING.md](DEEPENING.md), what sits behind the seam). The brief is independent of the user-facing problem-space explanation in Step 1. Give each agent a different design constraint:
+
+- Agent 1: "Minimize the interface — aim for 1–3 entry points max. Maximise leverage per entry point."
+- Agent 2: "Maximise flexibility — support many use cases and extension."
+- Agent 3: "Optimise for the most common caller — make the default case trivial."
+- Agent 4 (if applicable): "Design around ports & adapters for cross-seam dependencies."
+
+Include both [LANGUAGE.md](LANGUAGE.md) vocabulary and CONTEXT.md vocabulary in the brief so each sub-agent names things consistently with the architecture language and the project's domain language.
+
+Each sub-agent outputs:
+
+1. Interface (types, methods, params — plus invariants, ordering, error modes)
+2. Usage example showing how callers use it
+3. What the implementation hides behind the seam
+4. Dependency strategy and adapters (see [DEEPENING.md](DEEPENING.md))
+5. Trade-offs — where leverage is high, where it's thin
+
+### 3. Present and compare
+
+Present designs sequentially so the user can absorb each one, then compare them in prose. Contrast by **depth** (leverage at the interface), **locality** (where change concentrates), and **seam placement**.
+
+After comparing, give your own recommendation: which design you think is strongest and why. If elements from different designs would combine well, propose a hybrid. Be opinionated — the user wants a strong read, not a menu.

--- a/tools/ship-flow/skills/improve-codebase-architecture/LANGUAGE.md
+++ b/tools/ship-flow/skills/improve-codebase-architecture/LANGUAGE.md
@@ -1,0 +1,53 @@
+# Language
+
+Shared vocabulary for every suggestion this skill makes. Use these terms exactly — don't substitute "component," "service," "API," or "boundary." Consistent language is the whole point.
+
+## Terms
+
+**Module**
+Anything with an interface and an implementation. Deliberately scale-agnostic — applies equally to a function, class, package, or tier-spanning slice.
+_Avoid_: unit, component, service.
+
+**Interface**
+Everything a caller must know to use the module correctly. Includes the type signature, but also invariants, ordering constraints, error modes, required configuration, and performance characteristics.
+_Avoid_: API, signature (too narrow — those refer only to the type-level surface).
+
+**Implementation**
+What's inside a module — its body of code. Distinct from **Adapter**: a thing can be a small adapter with a large implementation (a Postgres repo) or a large adapter with a small implementation (an in-memory fake). Reach for "adapter" when the seam is the topic; "implementation" otherwise.
+
+**Depth**
+Leverage at the interface — the amount of behaviour a caller (or test) can exercise per unit of interface they have to learn. A module is **deep** when a large amount of behaviour sits behind a small interface. A module is **shallow** when the interface is nearly as complex as the implementation.
+
+**Seam** _(from Michael Feathers)_
+A place where you can alter behaviour without editing in that place. The *location* at which a module's interface lives. Choosing where to put the seam is its own design decision, distinct from what goes behind it.
+_Avoid_: boundary (overloaded with DDD's bounded context).
+
+**Adapter**
+A concrete thing that satisfies an interface at a seam. Describes *role* (what slot it fills), not substance (what's inside).
+
+**Leverage**
+What callers get from depth. More capability per unit of interface they have to learn. One implementation pays back across N call sites and M tests.
+
+**Locality**
+What maintainers get from depth. Change, bugs, knowledge, and verification concentrate at one place rather than spreading across callers. Fix once, fixed everywhere.
+
+## Principles
+
+- **Depth is a property of the interface, not the implementation.** A deep module can be internally composed of small, mockable, swappable parts — they just aren't part of the interface. A module can have **internal seams** (private to its implementation, used by its own tests) as well as the **external seam** at its interface.
+- **The deletion test.** Imagine deleting the module. If complexity vanishes, the module wasn't hiding anything (it was a pass-through). If complexity reappears across N callers, the module was earning its keep.
+- **The interface is the test surface.** Callers and tests cross the same seam. If you want to test *past* the interface, the module is probably the wrong shape.
+- **One adapter means a hypothetical seam. Two adapters means a real one.** Don't introduce a seam unless something actually varies across it.
+
+## Relationships
+
+- A **Module** has exactly one **Interface** (the surface it presents to callers and tests).
+- **Depth** is a property of a **Module**, measured against its **Interface**.
+- A **Seam** is where a **Module**'s **Interface** lives.
+- An **Adapter** sits at a **Seam** and satisfies the **Interface**.
+- **Depth** produces **Leverage** for callers and **Locality** for maintainers.
+
+## Rejected framings
+
+- **Depth as ratio of implementation-lines to interface-lines** (Ousterhout): rewards padding the implementation. We use depth-as-leverage instead.
+- **"Interface" as the TypeScript `interface` keyword or a class's public methods**: too narrow — interface here includes every fact a caller must know.
+- **"Boundary"**: overloaded with DDD's bounded context. Say **seam** or **interface**.

--- a/tools/ship-flow/skills/improve-codebase-architecture/SKILL.md
+++ b/tools/ship-flow/skills/improve-codebase-architecture/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: improve-codebase-architecture
+description: Find deepening opportunities in a codebase, informed by the domain language in CONTEXT.md and the decisions in docs/adr/. Use when the user wants to improve architecture, find refactoring opportunities, consolidate tightly-coupled modules, or make a codebase more testable and AI-navigable.
+---
+
+# Improve Codebase Architecture
+
+Surface architectural friction and propose **deepening opportunities** — refactors that turn shallow modules into deep ones. The aim is testability and AI-navigability.
+
+## Glossary
+
+Use these terms exactly in every suggestion. Consistent language is the point — don't drift into "component," "service," "API," or "boundary." Full definitions in [LANGUAGE.md](LANGUAGE.md).
+
+- **Module** — anything with an interface and an implementation (function, class, package, slice).
+- **Interface** — everything a caller must know to use the module: types, invariants, error modes, ordering, config. Not just the type signature.
+- **Implementation** — the code inside.
+- **Depth** — leverage at the interface: a lot of behaviour behind a small interface. **Deep** = high leverage. **Shallow** = interface nearly as complex as the implementation.
+- **Seam** — where an interface lives; a place behaviour can be altered without editing in place. (Use this, not "boundary.")
+- **Adapter** — a concrete thing satisfying an interface at a seam.
+- **Leverage** — what callers get from depth.
+- **Locality** — what maintainers get from depth: change, bugs, knowledge concentrated in one place.
+
+Key principles (see [LANGUAGE.md](LANGUAGE.md) for the full list):
+
+- **Deletion test**: imagine deleting the module. If complexity vanishes, it was a pass-through. If complexity reappears across N callers, it was earning its keep.
+- **The interface is the test surface.**
+- **One adapter = hypothetical seam. Two adapters = real seam.**
+
+This skill is _informed_ by the project's domain model. The domain language gives names to good seams; ADRs record decisions the skill should not re-litigate.
+
+## Process
+
+### 1. Explore
+
+**Scope before you scan — YAGNI.** Deepening a module pays off by making future changes to it easier, so put extra weight on the parts of the codebase that have recently changed. Decide *where* to look before you look:
+
+- If the user named a direction — a module, a subsystem, a pain point — take it, and skip the inference below.
+- Otherwise, walk back a good stretch of the commit history (`git log --oneline`) to find the codebase's hot spots — the files and areas that keep coming up — and let those paths pull your attention first. If the changes are scattered with no clear hot spot, widen the net.
+
+Read the project's domain glossary and any ADRs in the area you're touching first.
+
+Then use the Agent tool with `subagent_type=Explore` to walk the codebase. Don't follow rigid heuristics — explore organically and note where you experience friction:
+
+- Where does understanding one concept require bouncing between many small modules?
+- Where are modules **shallow** — interface nearly as complex as the implementation?
+- Where have pure functions been extracted just for testability, but the real bugs hide in how they're called (no **locality**)?
+- Where do tightly-coupled modules leak across their seams?
+- Which parts of the codebase are untested, or hard to test through their current interface?
+
+Apply the **deletion test** to anything you suspect is shallow: would deleting it concentrate complexity, or just move it? A "yes, concentrates" is the signal you want.
+
+### 2. Present candidates as an HTML report
+
+Write a self-contained HTML file to the OS temp directory so nothing lands in the repo. Resolve the temp dir from `$TMPDIR`, falling back to `/tmp` (or `%TEMP%` on Windows), and write to `<tmpdir>/architecture-review-<timestamp>.html` so each run gets a fresh file. Open it for the user — `xdg-open <path>` on Linux, `open <path>` on macOS, `start <path>` on Windows — and tell them the absolute path.
+
+The report uses **Tailwind via CDN** for layout and styling, and **Mermaid via CDN** for diagrams where a graph/flow/sequence reliably communicates the structure. Mix Mermaid with hand-crafted CSS/SVG visuals — use Mermaid when relationships are graph-shaped (call graphs, dependencies, sequences), and hand-built divs/SVG when you want something more editorial (mass diagrams, cross-sections, collapse animations). Each candidate gets a **before/after visualisation**. Be visual.
+
+For each candidate, the same template as before, but rendered as a card:
+
+- **Files** — which files/modules are involved
+- **Problem** — why the current architecture is causing friction
+- **Solution** — plain English description of what would change
+- **Benefits** — explained in terms of locality and leverage, and how tests would improve
+- **Before / After diagram** — side-by-side, custom-drawn, illustrating the shallowness and the deepening
+- **Recommendation strength** — one of `Strong`, `Worth exploring`, `Speculative`, rendered as a badge
+
+End the report with a **Top recommendation** section: which candidate you'd tackle first and why.
+
+**Use CONTEXT.md vocabulary for the domain, and [LANGUAGE.md](LANGUAGE.md) vocabulary for the architecture.** If `CONTEXT.md` defines "Order," talk about "the Order intake module" — not "the FooBarHandler," and not "the Order service."
+
+**ADR conflicts**: if a candidate contradicts an existing ADR, only surface it when the friction is real enough to warrant revisiting the ADR. Mark it clearly in the card (e.g. a warning callout: _"contradicts ADR-0007 — but worth reopening because…"_). Don't list every theoretical refactor an ADR forbids.
+
+See [HTML-REPORT.md](HTML-REPORT.md) for the full HTML scaffold, diagram patterns, and styling guidance.
+
+Do NOT propose interfaces yet. After the file is written, ask the user: "Which of these would you like to explore?"
+
+### 3. Grilling loop
+
+Once the user picks a candidate, drop into a grilling conversation. Walk the design tree with them — constraints, dependencies, the shape of the deepened module, what sits behind the seam, what tests survive.
+
+Side effects happen inline as decisions crystallize:
+
+- **Naming a deepened module after a concept not in `CONTEXT.md`?** Add the term to `CONTEXT.md` — same discipline as `/grill-with-docs` (see [CONTEXT-FORMAT.md](../grill-with-docs/CONTEXT-FORMAT.md)). Create the file lazily if it doesn't exist.
+- **Sharpening a fuzzy term during the conversation?** Update `CONTEXT.md` right there.
+- **User rejects the candidate with a load-bearing reason?** Offer an ADR, framed as: _"Want me to record this as an ADR so future architecture reviews don't re-suggest it?"_ Only offer when the reason would actually be needed by a future explorer to avoid re-suggesting the same thing — skip ephemeral reasons ("not worth it right now") and self-evident ones. See [ADR-FORMAT.md](../grill-with-docs/ADR-FORMAT.md).
+- **Want to explore alternative interfaces for the deepened module?** See [INTERFACE-DESIGN.md](INTERFACE-DESIGN.md).

--- a/tools/ship-flow/skills/resolving-merge-conflicts/SKILL.md
+++ b/tools/ship-flow/skills/resolving-merge-conflicts/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: resolving-merge-conflicts
+description: "Use when you need to resolve an in-progress git merge/rebase conflict."
+---
+
+1. **See the current state** of the merge/rebase. Check git history, and the conflicting files.
+
+2. **Find the primary sources** for each conflict. Understand deeply why each change was made, and what the original intent was. Read the commit messages, check the PRs, check original issues/tickets.
+
+3. **Resolve each hunk.** Preserve both intents where possible. Where incompatible, pick the one matching the merge's stated goal and note the trade-off. Do **not** invent new behaviour. Always resolve; never `--abort`.
+
+4. Discover the project's **automated checks** and run them — typically typecheck, then tests, then format. Fix anything the merge broke.
+
+5. **Finish the merge/rebase.** Stage everything and commit. If rebasing, continue the rebase process until all commits are rebased.

--- a/tools/ship-flow/skills/retrospect/SKILL.md
+++ b/tools/ship-flow/skills/retrospect/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: retrospect
+description: Turn loop outcomes into a verified-lessons memory — record what fixed a failure, recall it next time, and promote recurring lessons into skills/guidelines. Use when the user wants the loop to learn from past runs, capture a fix as a reusable lesson, see why runs keep failing, or decide what to codify into a skill or CLAUDE.md.
+---
+
+# retrospect — the learning layer (verified lessons)
+
+Make runs get smarter over time. A failure becomes a lesson (Reflexion); a *recurring, verified*
+lesson becomes a skill/guideline candidate (Voyager). Full reference: loop-engine@paul-loop's
+docs/lessons.md (in the plugin, not this repo).
+
+## The one rule
+
+**Only the verifier decides what is a lesson.** Record a lesson as `--verified` ONLY when ground
+truth (tests/build/the eval gate passing) confirmed the fix — never on your own say-so. Only verified
+lessons are recalled as authoritative; only recurring ones get promoted. This keeps hallucinated
+"fixes" out of the memory and out of your guidelines.
+
+## In a fix loop (automatic)
+
+```bash
+node tools/plugin-path.mjs exec bin/loop-fix.sh --verify "npm test" --fix '<agent>' --protect "**/*.test.*" --lessons .loop/lessons
+```
+`loop-fix` recalls past verified fixes for the current failure into your prompt, and records a
+verified lesson when it converges. Nothing else to do — just point `--lessons` at a (committed) dir.
+
+## By hand (in-session)
+
+- **Recall before you fix:** `node tools/plugin-path.mjs exec bin/lessons.sh recall --signature-file .loop/last-verdict.txt --lessons <dir>`.
+  If a past run solved this exact failure, start from that, then re-verify (don't trust the memory —
+  the verifier still decides).
+- **Record after green:** once the verifier passes, `node tools/plugin-path.mjs exec bin/lessons.sh record --signature-file <first-failure>
+  --fix "<what worked>" --source <loop-fix|diagnose|review> --iterations <N> --verified --gate "<verify cmd>" --lessons <dir>`.
+  `--gate` (e.g. this repo's verify command) attributes the recurrence to that verify gate so
+  `promote --runs` can annotate the candidate when the gate regresses — without it, regressions only
+  show in their own section.
+- **Never** record `--verified` for a fix the verifier didn't confirm.
+- **Tag the kind of lesson:** add `--category domain` when the lesson is about product/domain behavior
+  (not process/tooling) — e.g. a business-rule bug, not a flaky test or a build config gotcha. Omit it
+  and it defaults to `engineering` (the vast majority of lessons). `recall`/`stats` accept the same flag
+  to filter/aggregate by category.
+
+## Semantic recall (optional) — beyond exact-signature
+
+**Routing:** the file recall above is **signature recall** — an exact match on the normalized failure
+signature, no similarity, no ranking. Its only legitimate caller is a **machine** passing verifier
+output verbatim (`--signature-file`, which is exactly what `loop-fix` does). A hand-typed, paraphrased,
+or natural-language query is tool misuse for signature recall — that's a job for **semantic recall**
+instead, if this repo has it wired up (see below). A signature-recall miss names this on stderr (the
+normalized key it looked up + this same routing hint) — but stdout and the exit code are unchanged,
+since `loop-fix` still pipes recall through `2>/dev/null`.
+
+The file recall above only matches the *exact* normalized failure fingerprint — a paraphrased or
+slightly-different failure misses past fixes. Some repos layer a **semantic memory** store (embeddings
++ a vector DB) on top of the file-based lessons to catch *similar* failures, wired to run automatically
+via hooks rather than an explicit call. If this repo has such a layer, it typically works like this:
+
+- A SessionStart hook graduates verified file-lessons into the vector store (idempotent).
+- A UserPromptSubmit hook injects semantically-near verified lessons for your prompt.
+- It activates only when an embedding API key (e.g. `OPENAI_API_KEY`/`GEMINI_API_KEY`) and the vector
+  DB are both reachable; otherwise it should no-op silently (fail-open) rather than block you. A common
+  convention for an explicit off-switch is an env var like `LOOP_RECALL_OFF=1`.
+- If a key is set but the vector DB isn't reachable, a heartbeat-style check may nudge once — that's
+  the signal this layer went dark.
+- For a manual query, check this repo's semantic-memory setup for its own recall command (it should
+  mirror the file recall's `--query`/`--json` shape) — it should load the same config the hooks do, and
+  refuse rather than silently querying with a meaningless stub embedder if no key is visible either way.
+- Either way, file lessons stay canonical; a semantic layer is at best a richer copy. The verifier is
+  still the ceiling — a recalled lesson is a hint, not a pass.
+
+## Domain lessons from an external ideas tool (optional)
+
+Some repo owners also keep an external ideas/scratch-capture tool outside this repo (gstack is one
+example) where product/domain insights surface during other work. A durable one is worth cross-posting
+into `.loop/lessons` by hand, using the same recording flow as any other domain lesson:
+
+```bash
+node tools/plugin-path.mjs exec bin/lessons.sh record --signature-file <...> --fix "<what worked>" \
+  --source <tool-name> --category domain --lessons <dir>
+```
+
+Mark it `--verified` immediately only if a human directly confirmed the insight; anything merely
+observed, inferred, or model-suggested still has to clear the same recurring + `lessons challenge` bar
+as any engineering lesson before it's trusted. This is a per-repo/per-owner convenience — there's no
+plugin-standard tooling for it, and a repo without such a tool can skip this section entirely.
+
+## Retro & promotion (where self-improvement compounds)
+
+- `node tools/plugin-path.mjs exec bin/lessons.sh stats --lessons <dir>` — avg iterations-to-green, recurrence counts, top recurring blockers.
+  Use it to see whether the loop is actually getting faster.
+- `node tools/plugin-path.mjs exec bin/lessons.sh promote --min-count 3 --lessons <dir>` — recurring verified lessons worth codifying. Hand
+  each to `write-a-skill` (make the fix a reusable skill) or fold it into `CLAUDE.md` (a guideline),
+  then the loop stops re-solving it from scratch. Add `--runs .loop/runs` to fold in deterministic gate-regression
+  signals: a `[REGRESSION: <gate> PASS→FAIL]` line — distinct from the `[N×]` recurrence count — marks
+  candidates whose gate regressed in the runs ledger, and unattributed regressions list in their own section. The
+  ledger is forgeable (trust boundary), so a regression is candidate INPUT only — the skeptical challenge gate stands.
+- `node tools/plugin-path.mjs exec bin/lessons.sh retire --id <id> --ref "<where>" --lessons <dir>` — **after** you've codified an accepted
+  candidate into a skill/`CLAUDE.md`, retire it so it stops re-surfacing (the promote listing, `--codify`,
+  or a heartbeat-style "promotion candidate" nudge if this repo has one). This is the terminal gate that
+  keeps the candidate pool from growing monotonically. Fail closed: only a verified + `challenge
+  --verdict accept`ed lesson can retire; a content change later re-opens it for fresh review.
+
+## Reporting
+
+State what was recorded/recalled and the loop-efficiency trend. When promoting, name the recurring
+blocker and propose the concrete skill or guideline — don't auto-edit guidelines from a single run.

--- a/tools/ship-flow/skills/ship-feature/SKILL.md
+++ b/tools/ship-flow/skills/ship-feature/SKILL.md
@@ -1,0 +1,241 @@
+---
+name: ship-feature
+description: This plugin's autonomous-by-default feature delivery sequence and single entrypoint — the agent isolates a worktree, plans, TDDs, runtime-verifies, self-reviews, opens the PR and STOPS for the human to merge, then turns verified lessons into a harness-improvement PR. Risk gating at each step is decided by a deterministic classifier, not by the agent's own scoring. Use when the user delegates a task, feature, bug, or tracked issue to take from plan to an open PR following the standard flow (plan → tdd → runtime-verify → review → PR → improve), or asks to "ship"/"deliver"/"land" a feature.
+---
+
+# ship-feature — this plugin's single entrypoint (autonomous, human only where the gate calls for it)
+
+The procedure for taking one unit of work (a feature, a bug, a tracked issue) from **plan to an open
+PR, and from a merged PR to a harness-improvement PR** with the agent running autonomously the whole
+way. Each step's *content* is owned by the skill/agent it delegates to — this skill only fixes the
+**order, the gates, and where a human steps in**.
+
+> **Git procedure (branch model, worktrees, merge, rebase) lives in this repo's own CLAUDE.md (or
+> equivalent constitution doc), not here.** If this repo was set up via this plugin's `setup` skill,
+> that doc was generated from `templates/CLAUDE.md.template` and already covers this. This skill
+> references it rather than duplicating it — a duplicated copy drifts the moment the branch model
+> changes.
+
+## Config
+
+Reads `.claude/ship-flow.config.json` at the consuming repo's root (written by this plugin's `setup`
+skill — see `hotfix`'s SKILL.md for the field list). If it doesn't exist yet, ask the user for
+`branchModel`, `integrationBranch`/`releaseBranch`, and `verifyCommand` before proceeding — don't guess.
+`trackerName`, if set, names this repo's issue tracker (Linear is the worked example throughout this
+file, since that's what this skill was originally built against — substitute this repo's actual tracker
+and its equivalent mechanics: create/update issue, assignee, blocking-issue links, status transitions).
+
+## Execution mode — autonomous by default
+
+The agent runs step 0 → PR **without stopping**. There are exactly **three** places it calls a human:
+
+1. **The merge/deploy boundary** — it opens a `feature/* → integrationBranch` (or the trunk-based
+   equivalent) PR and **stops**. Landing on a shared branch is `reversibility=none`, so a human reviews
+   and merges — the agent never approves its own code onto a shared branch. **Release
+   (`integrationBranch → releaseBranch`) is out of this skill's scope** — a human decides that
+   separately, and this plugin's `hotfix` skill handles that two-stage flow (including its own
+   merge/deploy stop points) if needed.
+2. **Any step where the risk gate returns REQUIRE** — see [Risk gate](#risk-gate--the-rules-classify-not-the-agent)
+   below. The agent stops *before* running that step and waits for human approval.
+3. **Genuinely stuck, ambiguous, or unable to self-recover** — only when the agent can't resolve a gate
+   on its own or a real judgment call is needed.
+
+Every other verification failure (red) is something the agent **loops back on itself** — it doesn't ask
+a human.
+
+> "Autonomous" means *the agent*, not *no human in the loop*: nobody is watching every step, but an
+> intelligent agent is making judgment calls throughout the loop, which is what makes the runtime-verify
+> step's model-produced verdict trustworthy.
+
+## Invariants (skipping these breaks the contract — non-negotiable)
+
+- **Worktree isolation first.** The main worktree's HEAD is always the integration branch (git-flow) or
+  the release branch (trunk-based) — never check a work branch out there. Before the first edit:
+  `git fetch origin` → `git worktree add -b <branch> <sibling-path-outside-repo> origin/<base>`. **Don't
+  base a new worktree on a local branch** — the server is the source of truth.
+- **Reward-hack guard — if this repo has one, it's always armed, structurally.** If loop-engine@paul-loop
+  (or an equivalent) provides a reward-hack guard hook on working branches, it arms by branch condition
+  automatically — this skill doesn't turn it on or off, and there's nothing to disarm before handing off
+  to a human. If a legitimate edit to a protected file (test/config/verifier files) gets denied, open a
+  reasoned window per that guard's convention, make the edit, close the window, and record the reason in
+  the PR body.
+- **This repo's verify command is the one automatic gate.** A `feature/* → integrationBranch` PR
+  typically doesn't trigger CI in a git-flow setup that skips CI at that stage (a common cost-control
+  pattern — check `ciSkipOnIntegrationPR` in the config) — if so, nothing catches a skipped local gate
+  before the change lands on the integration branch. If this repo also gates its own harness/consumer
+  wiring with a separate command (e.g. a `verify:loop`-style script), that needs to be green too whenever
+  harness-consumer files were touched — step 6 especially.
+- **Verify (runtime) means observing the running app**, not re-running the verify command — that already
+  happened inside step 2. Step 3 asks "did the app actually get built/started and exercised at the
+  changed surface," not "did the test suite pass again."
+- **A human merges.** The agent gets to an open PR and no further. No local `git merge`/`git pull` toward
+  a shared branch, no direct push — if this repo has a merge guardrail hook and/or server-side branch
+  protection, they'll block it anyway.
+- **The agent doesn't self-score risk.** Classification comes from a deterministic rule set first; the
+  agent's own input can only push a classification **up**, never down (below). Self-grading turns the
+  gate into decoration.
+- **Harness improvements land as PRs only.** This session doesn't directly edit and commit to this
+  repo's CLAUDE.md / `.claude/**` — step 6 submits only accepted lessons, as a **separate PR**, and
+  stops there.
+- **Issues live in this repo's tracker.** Use whatever this repo's `trackerName` config says (Linear is
+  the worked example below); don't fall back to ad-hoc GitHub issues if a real tracker is configured.
+
+## Risk gate — the rules classify, not the agent
+
+If this plugin (via loop-engine@paul-loop) provides a deterministic risk classifier, its decision rule is
+three-valued: `reversibility=none` or an unclassified dimension → `REQUIRE` (wait for human approval);
+reversible but `blast=high OR cost=high` → `DENY_AND_LOG` (deny by default without waiting on a human,
+but log the verdict evidence into the PR — human review happens at the PR/merge boundary instead); anything
+else → `AUTO`. The gap that matters is **who assigns blast/reversibility/cost** — inside this skill,
+that would otherwise be the same agent doing the work, which turns self-scoring into a rubber stamp. So
+classification is derived **from the change itself** (paths/commands/stage) by the classifier first, and
+agent input is folded in as `final = max(rule, agent)` — **only allowed to raise** the classification,
+never lower it:
+
+```bash
+<however this repo invokes its installed loop-engine plugin's bin scripts> classify-risk.sh --from-git --stage <plan|implement|pr|improve> \
+  --action "<what is about to happen>" \
+  [--agent-blast-radius low|medium|high --agent-reversibility full|partial|none --agent-cost low|medium|high]
+# exit 0  = AUTO         → proceed autonomously
+# exit 10 = REQUIRE      → stop before running that step, get human approval
+# exit 11 = DENY_AND_LOG → on the verdict channel (here): log evidence (--render-md) into the PR and
+#                          proceed; on a command-execution channel (a PreToolUse hook, if wired): block
+#                          the command instead — the two channels intentionally mean different things
+```
+
+(`<however this repo invokes its installed loop-engine plugin's bin scripts>` — a repo-local
+resolver/wrapper if this repo has one, e.g. `node tools/plugin-path.mjs exec bin/<name>`; otherwise
+invoke the plugin's installed bin path directly. If this repo layers its own `risk-rules.json` on top of
+loop-engine's defaults, `classify-risk.sh` picks it up automatically.)
+
+- **Surface the rules typically cover**: schema migrations (`reversibility=none`) · row-level-security or
+  equivalent tenant-isolation schema · auth/guards · outbound send/call · the harness/constitution layer
+  (`.claude/**`, this repo's CLAUDE.md, `docs/adr/**`, loop-engine tooling) · CI/deploy · workspace-root
+  config · 11+ files touched. Below that threshold, with **≤10 files and 0 commands and no rule match**,
+  a low-risk app-code baseline applies (`low/full/low` → AUTO); everything else unmatched (an unmatched
+  *command*, or 11+ files with no classification) is **fail-closed REQUIRE** — silence isn't AUTO.
+- **Merge, deploy, and release are never classified as anything but REQUIRE** — `--stage
+  merge|deploy|release|send` and merge/deploy *commands* are always `reversibility=none` regardless of
+  other input.
+- **The track is a classification output**, not a separate axis. Whatever `TRACK:` line the classifier
+  prints is the routing decision:
+
+  | TRACK | Meaning | Steps |
+  |---|---|---|
+  | `risky` | Matched a rule | Full sequence + whatever `DEEP_GATES:` the output names |
+  | `standard` | No rule match | Full sequence, deep gates only if this repo's own verify table says they're affected |
+  | `docs-only` | No runtime surface touched | Steps 2-3 can be skipped |
+
+  Skipping a step always leaves a one-line reason in the PR body (so it's auditable after the fact).
+
+## Sequence (0 → PR is autonomous, merge is human, post-merge is `improve`)
+
+### 0. Worktree isolation — `git worktree`
+If this repo tracks issues externally (Linear, GitHub Issues, etc.), claim the issue to yourself first
+— before creating the worktree — by assigning it and moving it into an in-progress state. If this repo
+runs concurrent sessions regularly, claiming first is what stops two sessions from picking up the same
+issue (worktree isolation alone only prevents git conflicts, not duplicate starts).
+
+`git fetch origin && git worktree add -b <type>/<slug> <sibling-path-outside-repo> origin/<base>`. Check
+`git worktree list` first if concurrent work is common in this repo. A fresh worktree has no installed
+dependencies — install them. Every following step happens inside this worktree.
+
+### 1. Implementation plan — `Plan` agent / `grill-with-docs` if there's a design decision
+Plan what to build and how to slice it. **If there's a new design decision involved**, use
+`grill-with-docs` to sharpen it against the domain model and record it (ADR + `CONTEXT.md`) — no
+implementation yet. Plain CRUD doesn't need that; a `Plan` agent pass is enough.
+
+Once the plan is set, **derive the track from the paths it touches** — there's no diff yet, so pass the
+planned paths directly: `<loop-engine classify-risk.sh> --no-gate --path <planned paths>...` → the
+resulting `TRACK:`/`DEEP_GATES:` scope the remaining steps.
+→ **Gate:** success criteria (what "done" verifiably means) has to be written down before moving on.
+
+**If the plan itself exceeds one session's budget** (the scope is too large to pin down a single
+verifiable "done"), don't jump straight to implementation — split the issue into a map of decision
+tickets first: one separate tracked issue per still-open question (blocked-by links pointing at
+whichever decision has to resolve first), and work through the sharpest one first. That's just a
+planning artifact — each resolved decision ticket re-enters this skill from step 0 properly, with the
+full risk gate, worktree isolation, and verify still applying (splitting the plan doesn't bypass the
+gate).
+
+> **Token efficiency**: if exploring the codebase needs 3+ rounds of grep/read, delegate to an
+> Explore-type agent instead of doing it in the main context — keep raw file dumps and grep output out
+> of the main conversation.
+
+### 2. Implementation — `tdd` (red → green)
+Implement the plan red→green. Security/invariant paths (RLS, authorization, or whatever this repo's
+equivalent is) need **behavior-proof tests**, not just coverage. This repo's verify command is this
+loop's convergence criterion.
+→ **Gate:** verify command green + whatever `DEEP_GATES:` step 1 identified (re-checked against the
+actual diff with `--from-git`). Red loops back autonomously.
+
+### 3. Runtime verify
+Build and run the app, drive the changed surface (CLI/API/GUI — whatever applies) through it, and
+confirm **what was intended actually works**. This produces runtime evidence, not a re-run of the test
+suite.
+→ **Gate:** PASS. FAIL → **loop back to step 2**. SKIP (no runtime surface exists) passes with a
+one-line reason.
+
+### 4. Review and fix
+Run this plugin's review agents (`code-reviewer`, `test-hunter`, `verifier-integrity-hunter`) against
+the diff. If this repo also runs a separate general-purpose PR-review tool, run both — during any
+period where both are in use, treat this plugin's agents as complementary, not a replacement. Fix what
+they flag autonomously.
+→ **Gate:** Critical/Important findings resolved. Re-run the step-2 gate after fixing, then re-review.
+
+> **Token efficiency**: review agents run in their own context — don't pull their raw internal
+> deliberation into the main context, just the findings summary.
+
+### 5. Open the PR → `integrationBranch` (or `releaseBranch` if trunk-based) and **stop** — hand off to a human
+Right before opening the PR, get the final verdict against the real diff: `<loop-engine
+classify-risk.sh> --from-git --stage pr --action "PR→<base>" --render-md` — paste the output markdown
+block (verdict table + its audit marker, if the classifier emits one) **verbatim into the PR body**
+rather than transcribing it by hand. If it's REQUIRE, put the reason at the very top of the PR body —
+what a human needs to see is exactly why the gate called for them.
+
+`git push -u origin <branch>` → open the PR against this repo's integration branch (summary, verification
+evidence, gate verdict, any SKIP reasons) → **comment the PR link on the tracked issue**. **Stop here** —
+a human reviews and merges. If this PR doesn't trigger CI, the PR body is the only verification record a
+human will see, so make sure step 2's gate results are actually in it.
+→ **After a human merges:** clean up the worktree/branch (remove any dedicated deep-gate resources first
+if this repo uses per-worktree isolated containers for them, confirm no stash leftovers) + update the
+tracked issue (status, merge SHA) → **step 6**. Release (`integrationBranch → releaseBranch`) is a
+separate decision — `hotfix` or this repo's own release procedure.
+
+### 6. `improve` — lessons → skeptical review → harness-improvement PR (post-merge, also stops at a PR)
+Record what the verifier actually confirmed as fixed as a lesson (this plugin's `retrospect` skill, if
+ported into this repo), and only promote **recurring** ones as codification candidates. The core
+safeguard is **the proposer isn't the approver** — if the same judgment that nominated a candidate also
+accepts it, that's a rubber stamp. A separate skeptical pass tries to *refute* each candidate; when
+uncertain, the default is reject.
+
+```bash
+L() { <loop-engine bin resolver> lessons.sh "$@"; }; D='.loop/lessons'
+L promote --min-count 3 --lessons $D                                   # candidates + id (verified+recurring floor)
+L challenge --id <id> --verdict accept|reject --reason "…" --lessons $D # ← the separate skeptical pass records this
+L promote --codify --lessons $D                                        # only accepted ones come out
+L retire --id <id> --ref "<where it landed>" --lessons $D              # retire from the pool after codifying
+```
+
+Landing an accepted lesson in CLAUDE.md/a skill happens **as a PR, not a direct edit**: new worktree off
+the integration branch → edit → `<loop-engine classify-risk.sh> --from-git --stage improve` (harness
+files rule-match to `blast=high` → always REQUIRE) → open the PR and **stop**. Anything irreversible is a
+merge, not an edit — autonomy covers getting to the PR; that door is the human boundary.
+→ **Gate:** zero codifications without an accept verdict · zero direct commits to this repo's
+CLAUDE.md/`.claude/**` from this session.
+
+## Token efficiency
+- **Delegate mechanical, judgment-free work** (lint/type-error fix loops, straightforward renames) to a
+  cheaper model — there's no reason to spend a top-tier model on repetitive fixes that don't need
+  judgment.
+- **Check context size at step boundaries.** Crossing the step 2→3 or 3→4 gate after accumulating long
+  test output or long review results is a good point to consider delegating or compacting — worktree
+  isolation makes single sessions run long.
+
+## Failures and conflicts (handled autonomously)
+- Gate red → loop back on that step autonomously. Only call a human if the agent can't resolve it itself.
+- Human-side merge reports out-of-date/CONFLICTING → in the worktree, **standalone** `git fetch origin
+  <base>` → **standalone** `git rebase origin/<base>` → re-verify → `git push --force-with-lease`.
+  `<base>` is **that PR's base** (the integration branch, or the release branch for a release PR). **Run
+  each command as its own independent call** — chaining `git merge`/`git pull` with anything else is
+  liable to trip a merge guardrail hook regardless of direction, if this repo has one.

--- a/tools/ship-flow/skills/tdd/SKILL.md
+++ b/tools/ship-flow/skills/tdd/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: tdd
+description: Test-driven development with red-green-refactor loop. Use when user wants to build features or fix bugs using TDD, mentions "red-green-refactor", wants integration tests, or asks for test-first development.
+---
+
+# Test-Driven Development
+
+## Philosophy
+
+**Core principle**: Tests should verify behavior through public interfaces, not implementation details. Code can change entirely; tests shouldn't.
+
+**Good tests** are integration-style: they exercise real code paths through public APIs. They describe _what_ the system does, not _how_ it does it. A good test reads like a specification - "user can checkout with valid cart" tells you exactly what capability exists. These tests survive refactors because they don't care about internal structure.
+
+**Bad tests** are coupled to implementation. They mock internal collaborators, test private methods, or verify through external means (like querying a database directly instead of using the interface). The warning sign: your test breaks when you refactor, but behavior hasn't changed. If you rename an internal function and tests fail, those tests were testing implementation, not behavior.
+
+**Tautological tests** restate the implementation inside the assertion, so they pass by construction and give zero confidence. When the expected value is computed the way the code computes it — `expect(add(a, b)).toBe(a + b)`, snapshotting a figure you derived by hand the same way the code does, asserting a constant equals itself — the test can never disagree with the code: break the code wrong and the assertion breaks wrong with it. The expected value must come from an independent source of truth — a known-good literal, a worked example, the spec.
+
+See [tests.md](tests.md) for examples and [mocking.md](mocking.md) for mocking guidelines.
+
+## Reward-Hack Guard
+
+If this repo has a reward-hack guard armed on working branches (a hook that blocks Edit/Write/Bash
+mutation of test/config/snapshot files while a loop is in progress, so "fix the code under test, not
+the test" is mechanical instead of a promise) — respect its window-opening convention rather than
+working around it. The `loop-engine@paul-loop` plugin's own guard, where installed, arms by branch
+condition (any branch outside the repo's integration/release branches) with no manual arm/disarm step:
+
+- **RED (writing the failing test)** *is* a legitimate protected-file edit: open a reasoned window
+  first — check this repo's guard docs for the exact command (loop-engine's convention is
+  `echo '<reason> — tdd red: <what test>' > .loop/guard-off`; empty file is invalid, the window
+  expires after 30 minutes) — write the test, then close the window before starting GREEN.
+- **GREEN/refactor of production code** needs no window — source files aren't protected. If you feel
+  the urge to edit the test during GREEN, that is exactly the reward-hack the guard exists to stop;
+  if the test itself is genuinely wrong, reopen a window with the reason and state that reason in the
+  PR body.
+- A loop-runner script may own a separate "loop in progress" sentinel that overrides the guard-off
+  window during its own runs — never create or remove that sentinel yourself if one exists.
+
+## Anti-Pattern: Horizontal Slices
+
+**DO NOT write all tests first, then all implementation.** This is "horizontal slicing" - treating RED as "write all tests" and GREEN as "write all code."
+
+This produces **crap tests**:
+
+- Tests written in bulk test _imagined_ behavior, not _actual_ behavior
+- You end up testing the _shape_ of things (data structures, function signatures) rather than user-facing behavior
+- Tests become insensitive to real changes - they pass when behavior breaks, fail when behavior is fine
+- You outrun your headlights, committing to test structure before understanding the implementation
+
+**Correct approach**: Vertical slices via tracer bullets. One test → one implementation → repeat. Each test responds to what you learned from the previous cycle. Because you just wrote the code, you know exactly what behavior matters and how to verify it.
+
+```
+WRONG (horizontal):
+  RED:   test1, test2, test3, test4, test5
+  GREEN: impl1, impl2, impl3, impl4, impl5
+
+RIGHT (vertical):
+  RED→GREEN: test1→impl1
+  RED→GREEN: test2→impl2
+  RED→GREEN: test3→impl3
+  ...
+```
+
+## Workflow
+
+### 1. Planning
+
+When exploring the codebase, read `CONTEXT.md` (if it exists) so that test names and interface vocabulary match the project's domain language, and respect ADRs in the area you're touching.
+
+Before writing any code:
+
+- [ ] Confirm with user what interface changes are needed
+- [ ] Confirm with user which behaviors to test (prioritize)
+- [ ] Confirm the exact **seams** under test (the public boundary you'll observe behavior at) — no test gets written at an unconfirmed seam
+- [ ] Identify opportunities for [deep modules](deep-modules.md) (small interface, deep implementation)
+- [ ] Design interfaces for [testability](interface-design.md)
+- [ ] List the behaviors to test (not implementation steps)
+- [ ] Get user approval on the plan
+
+Ask: "What should the public interface look like? Which seams should we test, and which behaviors are most important there?"
+
+**You can't test everything.** Confirm with the user exactly which behaviors matter most. Focus testing effort on critical paths and complex logic, not every possible edge case.
+
+### 2. Tracer Bullet
+
+Write ONE test that confirms ONE thing about the system:
+
+```
+RED:   Write test for first behavior → test fails
+GREEN: Write minimal code to pass → test passes
+```
+
+This is your tracer bullet - proves the path works end-to-end.
+
+### 3. Incremental Loop
+
+For each remaining behavior:
+
+```
+RED:   Write next test → fails
+GREEN: Minimal code to pass → passes
+```
+
+Rules:
+
+- One test at a time
+- Only enough code to pass current test
+- Don't anticipate future tests
+- Keep tests focused on observable behavior
+
+### 4. Refactor
+
+After all tests pass, look for [refactor candidates](refactoring.md):
+
+- [ ] Extract duplication
+- [ ] Deepen modules (move complexity behind simple interfaces)
+- [ ] Apply SOLID principles where natural
+- [ ] Consider what new code reveals about existing code
+- [ ] Run tests after each refactor step
+
+**Never refactor while RED.** Get to GREEN first.
+
+## Checklist Per Cycle
+
+```
+[ ] Test describes behavior, not implementation
+[ ] Test uses public interface only
+[ ] Test would survive internal refactor
+[ ] Expected values are independent literals, not recomputed from the code
+[ ] Code is minimal for this test
+[ ] No speculative features added
+```

--- a/tools/ship-flow/skills/tdd/deep-modules.md
+++ b/tools/ship-flow/skills/tdd/deep-modules.md
@@ -1,0 +1,33 @@
+# Deep Modules
+
+From "A Philosophy of Software Design":
+
+**Deep module** = small interface + lots of implementation
+
+```
+┌─────────────────────┐
+│   Small Interface   │  ← Few methods, simple params
+├─────────────────────┤
+│                     │
+│                     │
+│  Deep Implementation│  ← Complex logic hidden
+│                     │
+│                     │
+└─────────────────────┘
+```
+
+**Shallow module** = large interface + little implementation (avoid)
+
+```
+┌─────────────────────────────────┐
+│       Large Interface           │  ← Many methods, complex params
+├─────────────────────────────────┤
+│  Thin Implementation            │  ← Just passes through
+└─────────────────────────────────┘
+```
+
+When designing interfaces, ask:
+
+- Can I reduce the number of methods?
+- Can I simplify the parameters?
+- Can I hide more complexity inside?

--- a/tools/ship-flow/skills/tdd/interface-design.md
+++ b/tools/ship-flow/skills/tdd/interface-design.md
@@ -1,0 +1,31 @@
+# Interface Design for Testability
+
+Good interfaces make testing natural:
+
+1. **Accept dependencies, don't create them**
+
+   ```typescript
+   // Testable
+   function processOrder(order, paymentGateway) {}
+
+   // Hard to test
+   function processOrder(order) {
+     const gateway = new StripeGateway();
+   }
+   ```
+
+2. **Return results, don't produce side effects**
+
+   ```typescript
+   // Testable
+   function calculateDiscount(cart): Discount {}
+
+   // Hard to test
+   function applyDiscount(cart): void {
+     cart.total -= discount;
+   }
+   ```
+
+3. **Small surface area**
+   - Fewer methods = fewer tests needed
+   - Fewer params = simpler test setup

--- a/tools/ship-flow/skills/tdd/mocking.md
+++ b/tools/ship-flow/skills/tdd/mocking.md
@@ -1,0 +1,59 @@
+# When to Mock
+
+Mock at **system boundaries** only:
+
+- External APIs (payment, email, etc.)
+- Databases (sometimes - prefer test DB)
+- Time/randomness
+- File system (sometimes)
+
+Don't mock:
+
+- Your own classes/modules
+- Internal collaborators
+- Anything you control
+
+## Designing for Mockability
+
+At system boundaries, design interfaces that are easy to mock:
+
+**1. Use dependency injection**
+
+Pass external dependencies in rather than creating them internally:
+
+```typescript
+// Easy to mock
+function processPayment(order, paymentClient) {
+  return paymentClient.charge(order.total);
+}
+
+// Hard to mock
+function processPayment(order) {
+  const client = new StripeClient(process.env.STRIPE_KEY);
+  return client.charge(order.total);
+}
+```
+
+**2. Prefer SDK-style interfaces over generic fetchers**
+
+Create specific functions for each external operation instead of one generic function with conditional logic:
+
+```typescript
+// GOOD: Each function is independently mockable
+const api = {
+  getUser: (id) => fetch(`/users/${id}`),
+  getOrders: (userId) => fetch(`/users/${userId}/orders`),
+  createOrder: (data) => fetch('/orders', { method: 'POST', body: data }),
+};
+
+// BAD: Mocking requires conditional logic inside the mock
+const api = {
+  fetch: (endpoint, options) => fetch(endpoint, options),
+};
+```
+
+The SDK approach means:
+- Each mock returns one specific shape
+- No conditional logic in test setup
+- Easier to see which endpoints a test exercises
+- Type safety per endpoint

--- a/tools/ship-flow/skills/tdd/refactoring.md
+++ b/tools/ship-flow/skills/tdd/refactoring.md
@@ -1,0 +1,10 @@
+# Refactor Candidates
+
+After TDD cycle, look for:
+
+- **Duplication** → Extract function/class
+- **Long methods** → Break into private helpers (keep tests on public interface)
+- **Shallow modules** → Combine or deepen
+- **Feature envy** → Move logic to where data lives
+- **Primitive obsession** → Introduce value objects
+- **Existing code** the new code reveals as problematic

--- a/tools/ship-flow/skills/tdd/tests.md
+++ b/tools/ship-flow/skills/tdd/tests.md
@@ -1,0 +1,77 @@
+# Good and Bad Tests
+
+## Good Tests
+
+**Integration-style**: Test through real interfaces, not mocks of internal parts.
+
+```typescript
+// GOOD: Tests observable behavior
+test("user can checkout with valid cart", async () => {
+  const cart = createCart();
+  cart.add(product);
+  const result = await checkout(cart, paymentMethod);
+  expect(result.status).toBe("confirmed");
+});
+```
+
+Characteristics:
+
+- Tests behavior users/callers care about
+- Uses public API only
+- Survives internal refactors
+- Describes WHAT, not HOW
+- One logical assertion per test
+
+## Bad Tests
+
+**Implementation-detail tests**: Coupled to internal structure.
+
+```typescript
+// BAD: Tests implementation details
+test("checkout calls paymentService.process", async () => {
+  const mockPayment = jest.mock(paymentService);
+  await checkout(cart, payment);
+  expect(mockPayment.process).toHaveBeenCalledWith(cart.total);
+});
+```
+
+Red flags:
+
+- Mocking internal collaborators
+- Testing private methods
+- Asserting on call counts/order
+- Test breaks when refactoring without behavior change
+- Test name describes HOW not WHAT
+- Verifying through external means instead of interface
+
+```typescript
+// BAD: Bypasses interface to verify
+test("createUser saves to database", async () => {
+  await createUser({ name: "Alice" });
+  const row = await db.query("SELECT * FROM users WHERE name = ?", ["Alice"]);
+  expect(row).toBeDefined();
+});
+
+// GOOD: Verifies through interface
+test("createUser makes user retrievable", async () => {
+  const user = await createUser({ name: "Alice" });
+  const retrieved = await getUser(user.id);
+  expect(retrieved.name).toBe("Alice");
+});
+```
+
+**Tautological tests**: Expected value restates the implementation, so the test passes by construction.
+
+```typescript
+// BAD: Expected value is recomputed the way the code computes it
+test("calculateTotal sums line items", () => {
+  const items = [{ price: 10 }, { price: 5 }];
+  const expected = items.reduce((sum, i) => sum + i.price, 0);
+  expect(calculateTotal(items)).toBe(expected);
+});
+
+// GOOD: Expected value is an independent, known literal
+test("calculateTotal sums line items", () => {
+  expect(calculateTotal([{ price: 10 }, { price: 5 }])).toBe(15);
+});
+```

--- a/tools/ship-flow/skills/to-issues/SKILL.md
+++ b/tools/ship-flow/skills/to-issues/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: to-issues
+description: Break a plan, spec, or PRD into independently-grabbable issues on the project issue tracker using tracer-bullet vertical slices. Use when user wants to convert a plan into issues, create implementation tickets, or break down work into issues.
+---
+
+# To Issues
+
+Break a plan into independently-grabbable issues using vertical slices (tracer bullets).
+
+## Tracker
+
+This skill is tracker-agnostic — it targets whatever issue tracker this repo actually uses. Before
+drafting anything, work out which one:
+
+- Check `.claude/ship-flow.config.json` for a `trackerName` field (this plugin's `setup` skill records
+  one during onboarding, if the repo has an external tracker).
+- Check the repo for its own tracker-integration doc, if it has one — that's the source of truth for
+  the exact conventions this repo expects (required fields, labels, project/team assignment, how
+  dependency links work).
+- If neither exists, ask the user which tracker this repo uses and how issues should be filed there
+  before continuing. Don't guess.
+
+The worked example throughout this skill (the issue-creation call, the `blockedBy` dependency link,
+the `ENG-123`-style identifier) uses Linear, because that's what this skill was originally built and
+proven against — it's illustrative, not the only tracker this applies to. Adapting it to GitHub Issues,
+Jira, or anything else means substituting that tracker's own mechanics for title/description/labels and
+for however it expresses "this issue is blocked by that one" (a native link where the tracker has one,
+a body-text reference where it doesn't).
+
+## Process
+
+### 1. Gather context
+
+Work from whatever is already in the conversation context. If the user passes an issue reference (issue number, URL, or path) as an argument, fetch it from the issue tracker and read its full body and comments.
+
+### 2. Explore the codebase (optional)
+
+If you have not already explored the codebase, do so to understand the current state of the code. Issue titles and descriptions should use the project's domain glossary vocabulary (e.g. a `CONTEXT.md`, if this repo has one), and respect any documented architecture decisions in the area you're touching (e.g. `docs/adr/`, if this repo has one).
+
+### 3. Draft vertical slices
+
+Break the plan into **tracer bullet** issues. Each issue is a thin vertical slice that cuts through ALL integration layers end-to-end, NOT a horizontal slice of one layer.
+
+Slices may be 'HITL' or 'AFK'. HITL slices require human interaction, such as an architectural decision or a design review. AFK slices can be implemented and merged without human interaction. Prefer AFK over HITL where possible.
+
+<vertical-slice-rules>
+- Each slice delivers a narrow but COMPLETE path through every layer (schema, API, UI, tests)
+- A completed slice is demoable or verifiable on its own
+- Prefer many thin slices over few thick ones
+- Each slice is sized to fit in a single fresh context window
+</vertical-slice-rules>
+
+**Wide refactors are the exception to vertical slicing.** A **wide refactor** is one mechanical change — rename a column, retype a shared symbol — whose **blast radius** fans across the whole codebase, so a single edit breaks thousands of call sites at once and no vertical slice can land green. Don't force it into a tracer bullet; sequence it as **expand–contract**. First expand: add the new form beside the old so nothing breaks. Then migrate the call sites over in batches sized by blast radius (per package, per directory), each batch its own issue blocked by the expand, keeping the verify command green batch to batch because the old form still exists. Finally contract: delete the old form once no caller remains, in an issue blocked by every migrate batch.
+
+### 4. Quiz the user
+
+Present the proposed breakdown as a numbered list. For each slice, show:
+
+- **Title**: short descriptive name
+- **Type**: HITL / AFK
+- **Blocked by**: which other slices (if any) must complete first
+- **User stories covered**: which user stories this addresses (if the source material has them)
+
+Ask the user:
+
+- Does the granularity feel right? (too coarse / too fine)
+- Are the dependency relationships correct?
+- Should any slices be merged or split further?
+- Are the correct slices marked as HITL and AFK?
+
+Iterate until the user approves the breakdown.
+
+### 5. Publish the issues to the issue tracker
+
+For each approved slice, publish a new issue to this repo's issue tracker. Check this repo's own tracker-integration doc, if it has one, for the exact conventions it expects (team/project routing, required fields) — apply this repo's own required labels/conventions, if any. Use the issue body template below.
+
+These issues are considered ready for AFK agents — if this repo's tracker has a triage-state or label vocabulary for that, apply it here (check the tracker-integration doc if unsure which value to use) unless instructed otherwise.
+
+Publish issues in dependency order (blockers first) so you can reference real issue identifiers in the "Blocked by" field.
+
+**Set the blocking edge as a native dependency link where the tracker supports one, not just body text.** The example below is Linear: after creating a blocking issue, create the blocked issue with `mcp__plugin_linear_linear__save_issue`'s `blockedBy` parameter (issue identifier, e.g. `ENG-123`) — this is append-only and shows up in Linear's UI as a real dependency, not prose someone has to keep in sync by hand. If this repo's tracker has no equivalent native link, the "Blocked by" section in the body is the only record of the dependency — keep it accurate. Keep that body section either way, for readability when skimming the issue alone.
+
+<issue-template>
+## Parent
+
+A reference to the parent issue on the issue tracker (if the source was an existing issue, otherwise omit this section).
+
+## What to build
+
+A concise description of this vertical slice. Describe the end-to-end behavior, not layer-by-layer implementation.
+
+Avoid specific file paths or code snippets — they go stale fast. Exception: if a prototype produced a snippet that encodes a decision more precisely than prose can (state machine, reducer, schema, type shape), inline it here and note briefly that it came from a prototype. Trim to the decision-rich parts — not a working demo, just the important bits.
+
+## Acceptance criteria
+
+- [ ] Criterion 1
+- [ ] Criterion 2
+- [ ] Criterion 3
+
+## Blocked by
+
+- A reference to the blocking ticket (if any)
+
+Or "None - can start immediately" if no blockers.
+
+</issue-template>
+
+Do NOT close or modify any parent issue.

--- a/tools/ship-flow/skills/to-prd/SKILL.md
+++ b/tools/ship-flow/skills/to-prd/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: to-prd
+description: Turn the current conversation context into a PRD and publish it as a document in this repo's issue tracker (creating the project first if none exists yet). Use when user wants to create a PRD from the current context.
+---
+
+# to-prd — publish a PRD from conversation context
+
+This skill takes the current conversation context and codebase understanding and produces a PRD. Do NOT interview the user — just synthesize what you already know.
+
+## Process
+
+1. Explore the repo to understand the current state of the codebase, if you haven't already. Use the project's domain glossary vocabulary throughout the PRD (e.g. a root `CONTEXT.md`, if this repo keeps one), and respect any ADRs in the area you're touching.
+
+2. Sketch out the seams at which you're going to test the feature. Existing seams should be preferred to new ones. Use the highest seam possible. If new seams are needed, propose them at the highest point you can.
+
+Check with the user that these seams match their expectations.
+
+3. Write the PRD using the template below, then publish it as a **document in the project** (not as an issue):
+   - Determine the target project on this repo's issue tracker (Linear's Project is the worked example — other trackers may call the equivalent grouping an epic, milestone, or something else). **If no project exists yet for this work, create the project first**, then create the PRD document under it.
+   - Create the PRD as a **project document**, if this repo's tracker has a document/PRD concept — Linear's Document feature is the worked example. If the tracker has no separate document concept, the closest equivalent (e.g. a pinned top-level issue) is fine. The PRD document doesn't need this repo's issue-workflow labels, if it uses them — those apply to issues, not documents. Any actionable label marking work ready to pick up belongs on the slice issues produced later by `to-issues`, which reference this PRD document as their source.
+
+<prd-template>
+
+## Problem Statement
+
+The problem that the user is facing, from the user's perspective.
+
+## Solution
+
+The solution to the problem, from the user's perspective.
+
+## User Stories
+
+A LONG, numbered list of user stories. Each user story should be in the format of:
+
+1. As an <actor>, I want a <feature>, so that <benefit>
+
+<user-story-example>
+1. As a mobile bank customer, I want to see balance on my accounts, so that I can make better informed decisions about my spending
+</user-story-example>
+
+This list of user stories should be extremely extensive and cover all aspects of the feature.
+
+## Implementation Decisions
+
+A list of implementation decisions that were made. This can include:
+
+- The modules that will be built/modified
+- The interfaces of those modules that will be modified
+- Technical clarifications from the developer
+- Architectural decisions
+- Schema changes
+- API contracts
+- Specific interactions
+
+Do NOT include specific file paths or code snippets. They may end up being outdated very quickly.
+
+Exception: if a prototype produced a snippet that encodes a decision more precisely than prose can (state machine, reducer, schema, type shape), inline it within the relevant decision and note briefly that it came from a prototype. Trim to the decision-rich parts — not a working demo, just the important bits.
+
+## Testing Decisions
+
+A list of testing decisions that were made. Include:
+
+- A description of what makes a good test (only test external behavior, not implementation details)
+- Which modules will be tested
+- Prior art for the tests (i.e. similar types of tests in the codebase)
+
+## Out of Scope
+
+A description of the things that are out of scope for this PRD.
+
+## Further Notes
+
+Any further notes about the feature.
+
+</prd-template>


### PR DESCRIPTION
## Summary

Ports the remaining category-B skills (skills that need generalization, per this repo's own harness-maturity-audit-style report on the origin repo) from glucofit-partners' `.claude/skills/` into the `ship-flow` plugin: **grill-with-docs, retrospect, deps-audit, to-issues, to-prd, resolving-merge-conflicts, harness-maturity-audit, improve-codebase-architecture, tdd**, and **ship-feature** — the flagship plan-to-PR autonomous delivery loop and this plugin's single entrypoint (BAC-702's `hotfix` was ported earlier).

`ship-feature` and `tdd` are hand-authored/hand-edited directly rather than run through the Workflow port pipeline, given their size and centrality — same approach BAC-705 used for `CLAUDE.md.template`.

## Generalization approach (same pattern as BAC-704/705)

- glucofit-partners' `BAC-nnn`/`ADR-00nn` citations → plain-prose descriptions of what they established, not untraceable pointers.
- Issue tracker made config-driven: reads `.claude/ship-flow.config.json`'s `trackerName` (from the `setup` skill) or this repo's own tracker-integration doc if it has one; Linear is kept as the concrete worked example throughout (that's what these skills were built and proven against), never asserted as the only option.
- `node tools/plugin-path.mjs exec bin/<name>` invocations hedged to "however this repo resolves its installed loop-engine plugin's bin scripts" — that wrapper path is glucofit-partners' own resolver, not a paul-loop-ecosystem-standard convention (confirmed via repo-wide grep in BAC-704, same finding applies here).
- `harness-maturity-audit`'s workflow call fixed to the plugin-qualified `Workflow({ name: 'ship-flow:harness-audit' })` — bare names don't resolve across plugin boundaries (empirically confirmed in BAC-704).
- `tdd`'s reward-hack-guard section hedged to "if this repo has one" rather than asserting `.claude/hooks/protect-during-loop.mjs` exists universally — same treatment `ship-feature`'s own invariants section got.

## What was already generic (near-verbatim port, verified via grep before copying)

`grill-with-docs` (+ its `CONTEXT-FORMAT.md`/`ADR-FORMAT.md`), `improve-codebase-architecture` (+ its 4 companion files), `resolving-merge-conflicts`, and `tdd`'s 5 companion files had zero glucofit-partners-specific markers — copied directly rather than spending a port+leak-check pass on files that didn't need one.

## Workflow port + leak-check

The other 5 skills went through a `pipeline(port, leak-check)` Workflow (same shape as BAC-704's). 4 came back clean; `to-issues` was flagged for two literal `BAC-123` example-identifier leaks (the source repo's actual Linear prefix, used as "the worked example" identifier) — fixed by hand to the tracker-neutral `ENG-123`.

## Scope note — 9 skills ported here, not 11

The origin repo's own maturity-audit report groups skills into categories with an elided "…등" (etc.) list rather than an exhaustive one. I read every ambiguous skill's actual `SKILL.md` content firsthand (not just the report's summary) and am excluding three the report's phrasing might suggest belong here:

- **`setup-dev-env`** — glucofit-partners' own onboarding checklist (Docker ports, `apps/api/.env`, specific plugin installs). Superseded in spirit by this plugin's own `setup` skill from BAC-705, which covers the equivalent ground for a ship-flow-adopting repo.
- **`mattpocock-skills-sync`** and **`setup-matt-pocock-skills`** — both solve glucofit-partners' specific problem of vendoring copies of `mattpocock/skills` and auditing drift against that upstream (a `skills-lock.json` file, `gh api repos/mattpocock/skills/...` calls). `ship-flow` isn't a vendor-sync consumer of that upstream — its own skills are hand-authored/ported, not synced on a schedule — so this problem doesn't generalize into it. (`setup-matt-pocock-skills` is also literally the *upstream* mattpocock/skills project's own generic setup skill, vendored unmodified — porting a third-party skill into a new plugin under different authorship raises questions this PR doesn't need to answer, since it isn't needed here anyway.)

Documenting this transparently rather than forcing a match to the report's number.

## Verification

- `claude plugin validate --strict` — plugin manifest and marketplace manifest both pass.
- `claude plugin details ship-flow` (installed temporarily from this worktree via a local marketplace, then fully uninstalled + marketplace removed to restore prior state) — 12 skills + 4 agents, ~2,054 always-on tokens/session, per-skill on-invoke costs 280 tokens (`resolving-merge-conflicts`) to ~6k (`ship-feature`, expected as the largest skill).
- Repo-wide grep sweep across every new file for `BAC-[0-9]`, `ADR-00[0-9]`, `glucofit`, `파트너스`, `PRO-[0-9]`, and any Korean-character remnants — clean (one incidental `ADR-0007` hit in `improve-codebase-architecture` is illustrative example prose, not a real citation).
- No secrets/credential-shaped strings in any new file (manual grep ahead of CI's gitleaks pass).
- This repo has no `package.json`/test suite of its own to affect — `loop-engine` (the only plugin with bin/tests) wasn't touched.

## Test plan
- [ ] CI green (`claude plugin validate --strict` + gitleaks, per this repo's `.github/workflows/`)
- [ ] Human review + merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)