### PR TITLE
fix(test): guard mktemp against silent sandbox EPERM failure (loop-engine)

### DIFF
--- a/tools/loop-engine/bin/verdict-run.sh
+++ b/tools/loop-engine/bin/verdict-run.sh
@@ -147,7 +147,7 @@ now_ms() {
 # git 명령이 하나라도 실패하면(unborn HEAD·index.lock 경합 등) rc!=0 — 호출부가 fail-closed
 # 처리한다(무음 강등 금지: status-only로 조용히 좁아지는 fail-open 차단).
 workspace_digest() {
-  _t="$(mktemp)" || return 1
+  _t="$(mktemp "${TMPDIR:-/tmp}/tmp.XXXXXXXX")" || return 1
   {
     git rev-parse HEAD \
       && git status --porcelain=v1 -z \

--- a/tools/loop-engine/test/auto-arm.test.sh
+++ b/tools/loop-engine/test/auto-arm.test.sh
@@ -17,7 +17,7 @@ LOOPFIX="$HERE/../bin/loop-fix.sh"
 fail() { echo "FAIL: $1"; exit 1; }
 [ -x "$LOOPFIX" ] || fail "loop-fix.sh not executable at $LOOPFIX"
 
-WORK="$(mktemp -d)"
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/tmp.XXXXXXXX")" || fail "mktemp -d failed"
 trap 'rm -rf "$WORK"' EXIT
 cd "$WORK" || fail "cannot cd into work dir"
 mkdir -p .loop

--- a/tools/loop-engine/test/classify-risk-rules.test.sh
+++ b/tools/loop-engine/test/classify-risk-rules.test.sh
@@ -21,7 +21,7 @@ CR="$ROOT/tools/loop-engine/bin/classify-risk.mjs"
 fail() { echo "FAIL: $1"; exit 1; }
 [ -f "$CR" ] || fail "classify-risk.mjs not found at $CR"
 
-DIR="$(mktemp -d)"
+DIR="$(mktemp -d "${TMPDIR:-/tmp}/tmp.XXXXXXXX")" || fail "mktemp -d failed"
 trap 'rm -rf "$DIR"' EXIT
 
 # ── 1) no rules anywhere → ordinary small changeset is the app-code-low-risk baseline (AUTO) ────

--- a/tools/loop-engine/test/context-budget.test.sh
+++ b/tools/loop-engine/test/context-budget.test.sh
@@ -14,7 +14,7 @@ BUDGET="$ROOT/tools/loop-engine/bin/context-budget.mjs"
 fail() { echo "FAIL: $1"; exit 1; }
 [ -f "$BUDGET" ] || fail "context-budget.mjs not found at $BUDGET"
 
-DIR="$(mktemp -d)"
+DIR="$(mktemp -d "${TMPDIR:-/tmp}/tmp.XXXXXXXX")" || fail "mktemp -d failed"
 MOCK_PID=""
 trap 'if [ -n "$MOCK_PID" ]; then kill "$MOCK_PID" 2>/dev/null; wait "$MOCK_PID" 2>/dev/null; fi; rm -rf "$DIR"' EXIT
 

--- a/tools/loop-engine/test/gstack-scan.test.sh
+++ b/tools/loop-engine/test/gstack-scan.test.sh
@@ -22,7 +22,7 @@ SCAN="$ROOT/tools/loop-engine/bin/gstack-scan.mjs"
 fail() { echo "FAIL: $1"; exit 1; }
 [ -f "$SCAN" ] || fail "gstack-scan.mjs not found at $SCAN"
 
-DIR="$(mktemp -d)"
+DIR="$(mktemp -d "${TMPDIR:-/tmp}/tmp.XXXXXXXX")" || fail "mktemp -d failed"
 trap 'rm -rf "$DIR"' EXIT
 LESSONS="$DIR/lessons"
 FIXTURE="$DIR/learnings.jsonl"

--- a/tools/loop-engine/test/lessons-category.test.sh
+++ b/tools/loop-engine/test/lessons-category.test.sh
@@ -14,7 +14,7 @@ LESSONS="$ROOT/tools/loop-engine/bin/lessons.mjs"
 fail() { echo "FAIL: $1"; exit 1; }
 [ -f "$LESSONS" ] || fail "lessons.mjs not found at $LESSONS"
 
-DIR="$(mktemp -d)"
+DIR="$(mktemp -d "${TMPDIR:-/tmp}/tmp.XXXXXXXX")" || fail "mktemp -d failed"
 trap 'rm -rf "$DIR"' EXIT
 L() { node "$LESSONS" "$@" --lessons "$DIR"; }
 

--- a/tools/loop-engine/test/lessons-recall.test.sh
+++ b/tools/loop-engine/test/lessons-recall.test.sh
@@ -20,14 +20,14 @@ LESSONS="$ROOT/tools/loop-engine/bin/lessons.mjs"
 fail() { echo "FAIL: $1"; exit 1; }
 [ -f "$LESSONS" ] || fail "lessons.mjs not found at $LESSONS"
 
-DIR="$(mktemp -d)"
+DIR="$(mktemp -d "${TMPDIR:-/tmp}/tmp.XXXXXXXX")" || fail "mktemp -d failed"
 trap 'rm -rf "$DIR"' EXIT
 
 node "$LESSONS" record --signature "FAIL: widget exploded at boot" --verified --fix "reboot the widget" --title "widget boot fix" --lessons "$DIR" >/dev/null \
   || fail "record failed"
 
 # 1) HIT: stdout has the lesson, stderr is silent (no noise on the success path).
-OUT="$(mktemp)"; ERR="$(mktemp)"
+OUT="$(mktemp "${TMPDIR:-/tmp}/tmp.XXXXXXXX")" || fail "mktemp failed"; ERR="$(mktemp "${TMPDIR:-/tmp}/tmp.XXXXXXXX")" || fail "mktemp failed"
 node "$LESSONS" recall --signature "FAIL: widget exploded at boot" --lessons "$DIR" >"$OUT" 2>"$ERR"
 rc=$?
 [ "$rc" = "0" ] || fail "recall hit must exit 0; got rc=$rc"
@@ -37,7 +37,7 @@ rm -f "$OUT" "$ERR"
 
 # 2) MISS (no lesson for this signature): stdout empty + exit 0 (unchanged contract), stderr has the
 #    normalized signature key + a semantic-recall routing hint (ADR-0062).
-OUT="$(mktemp)"; ERR="$(mktemp)"
+OUT="$(mktemp "${TMPDIR:-/tmp}/tmp.XXXXXXXX")" || fail "mktemp failed"; ERR="$(mktemp "${TMPDIR:-/tmp}/tmp.XXXXXXXX")" || fail "mktemp failed"
 node "$LESSONS" recall --signature "FAIL: gadget fizzled at shutdown" --lessons "$DIR" >"$OUT" 2>"$ERR"
 rc=$?
 [ "$rc" = "0" ] || fail "recall miss must still exit 0; got rc=$rc"
@@ -48,7 +48,7 @@ rm -f "$OUT" "$ERR"
 
 # 3) MISS via --category mismatch: same silent-stdout/exit-0 contract, stderr names the key + mismatch —
 #    but NOT the semantic-recall hint (the signature DID match; this isn't the "wrong store" case above).
-OUT="$(mktemp)"; ERR="$(mktemp)"
+OUT="$(mktemp "${TMPDIR:-/tmp}/tmp.XXXXXXXX")" || fail "mktemp failed"; ERR="$(mktemp "${TMPDIR:-/tmp}/tmp.XXXXXXXX")" || fail "mktemp failed"
 node "$LESSONS" recall --signature "FAIL: widget exploded at boot" --category domain --lessons "$DIR" >"$OUT" 2>"$ERR"
 rc=$?
 [ "$rc" = "0" ] || fail "recall category-miss must exit 0; got rc=$rc"

--- a/tools/loop-engine/test/lessons-retire.test.sh
+++ b/tools/loop-engine/test/lessons-retire.test.sh
@@ -15,7 +15,7 @@ LESSONS="$ROOT/tools/loop-engine/bin/lessons.mjs"
 fail() { echo "FAIL: $1"; exit 1; }
 [ -f "$LESSONS" ] || fail "lessons.mjs not found at $LESSONS"
 
-DIR="$(mktemp -d)"
+DIR="$(mktemp -d "${TMPDIR:-/tmp}/tmp.XXXXXXXX")" || fail "mktemp -d failed"
 trap 'rm -rf "$DIR"' EXIT
 L() { node "$LESSONS" "$@" --lessons "$DIR"; }
 
@@ -77,7 +77,7 @@ printf '%s' "$SOUT3" | grep -q "open_candidates=1" || fail "rejected lesson must
 TSX="$ROOT/packages/loop-memory/node_modules/.bin/tsx"
 LESSONS_TS="$ROOT/packages/loop-memory/src/lessons.ts"
 if [ -x "$TSX" ] && [ -f "$LESSONS_TS" ]; then
-  BAC580_DIR="$(mktemp -d)"
+  BAC580_DIR="$(mktemp -d "${TMPDIR:-/tmp}/tmp.XXXXXXXX")" || fail "mktemp -d failed"
   BAC580_LESSONS_DIR="$BAC580_DIR/lessons"
   mkdir -p "$BAC580_LESSONS_DIR"
   BAC580_PROBE="$BAC580_DIR/probe.mjs"

--- a/tools/loop-engine/test/loop-fix-infra-exempt.test.sh
+++ b/tools/loop-engine/test/loop-fix-infra-exempt.test.sh
@@ -9,7 +9,7 @@ LOOPFIX="$HERE/../bin/loop-fix.sh"
 fail() { echo "FAIL: $1"; exit 1; }
 [ -x "$LOOPFIX" ] || fail "loop-fix.sh not executable at $LOOPFIX"
 
-WORK="$(mktemp -d)"
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/tmp.XXXXXXXX")" || fail "mktemp -d failed"
 trap 'rm -rf "$WORK"' EXIT
 
 # ── case 1: 인프라 실패 2회 → 3회차 PASS. --max-iter 1이어도 면제 재시도로 성공해야 한다 ────

--- a/tools/loop-engine/test/loop-fix-progress-clock.test.sh
+++ b/tools/loop-engine/test/loop-fix-progress-clock.test.sh
@@ -10,7 +10,7 @@ LOOPFIX="$HERE/../bin/loop-fix.sh"
 fail() { echo "FAIL: $1"; exit 1; }
 [ -x "$LOOPFIX" ] || fail "loop-fix.sh not executable at $LOOPFIX"
 
-WORK="$(mktemp -d)"
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/tmp.XXXXXXXX")" || fail "mktemp -d failed"
 trap 'rm -rf "$WORK"' EXIT
 
 # ── case 1: 원장 이상(파손 current 포인터 → unknown 강등 + 원장 부재) + hung verify →

--- a/tools/loop-engine/test/loop-fix-stall-dual.test.sh
+++ b/tools/loop-engine/test/loop-fix-stall-dual.test.sh
@@ -10,7 +10,7 @@ LOOPFIX="$HERE/../bin/loop-fix.sh"
 fail() { echo "FAIL: $1"; exit 1; }
 [ -x "$LOOPFIX" ] || fail "loop-fix.sh not executable at $LOOPFIX"
 
-WORK="$(mktemp -d)"
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/tmp.XXXXXXXX")" || fail "mktemp -d failed"
 trap 'rm -rf "$WORK"' EXIT
 
 # ── case 1: FAIL 문구 동결 + 카운트 전진 → stall하면 안 된다(조기 포기 오탐) ────────────────

--- a/tools/loop-engine/test/otel-receiver.test.sh
+++ b/tools/loop-engine/test/otel-receiver.test.sh
@@ -15,7 +15,7 @@ fail() { echo "FAIL: $1"; exit 1; }
 [ -f "$RECV" ] || fail "otel-receiver.mjs not found at $RECV"
 [ -f "$METRICS" ] || fail "otel-metrics.mjs not found at $METRICS"
 
-TMP="$(mktemp -d)"
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/tmp.XXXXXXXX")" || fail "mktemp -d failed"
 RECVPID=""
 trap '[ -n "$RECVPID" ] && kill "$RECVPID" 2>/dev/null; rm -rf "$TMP"' EXIT
 

--- a/tools/loop-engine/test/regression-signals.test.sh
+++ b/tools/loop-engine/test/regression-signals.test.sh
@@ -16,7 +16,7 @@ fail() { echo "FAIL: $1"; exit 1; }
 [ -f "$SIGNALS" ] || fail "regression-signals.mjs not found at $SIGNALS"
 [ -f "$LESSONS" ] || fail "lessons.mjs not found at $LESSONS"
 
-DIR="$(mktemp -d)"
+DIR="$(mktemp -d "${TMPDIR:-/tmp}/tmp.XXXXXXXX")" || fail "mktemp -d failed"
 trap 'rm -rf "$DIR"' EXIT
 
 # ── T1) PASS 후 FAIL (한 게이트) → 회귀 1건, 필드 정확, 텍스트 REGRESSION 줄 ────────────────

--- a/tools/loop-engine/test/run-ledger.test.sh
+++ b/tools/loop-engine/test/run-ledger.test.sh
@@ -17,7 +17,7 @@ fail() { echo "FAIL: $1"; exit 1; }
 [ -f "$LIB" ] || fail "run-ledger.mjs not found at $LIB"
 [ -f "$APPEND" ] || fail "ledger-append.mjs not found at $APPEND"
 
-DIR="$(mktemp -d)"
+DIR="$(mktemp -d "${TMPDIR:-/tmp}/tmp.XXXXXXXX")" || fail "mktemp -d failed"
 trap 'chmod -R u+w "$DIR" 2>/dev/null; rm -rf "$DIR"' EXIT
 
 append_evt() { # $1=root $2=args-json

--- a/tools/loop-engine/test/run-metrics.test.sh
+++ b/tools/loop-engine/test/run-metrics.test.sh
@@ -15,7 +15,7 @@ fail() { echo "FAIL: $1"; exit 1; }
 [ -f "$METRICS" ] || fail "run-metrics.mjs not found at $METRICS"
 [ -f "$SURFACES" ] || fail "boundary-surfaces.mjs not found at $SURFACES"
 
-DIR="$(mktemp -d)"
+DIR="$(mktemp -d "${TMPDIR:-/tmp}/tmp.XXXXXXXX")" || fail "mktemp -d failed"
 trap 'rm -rf "$DIR"' EXIT
 
 # ── 0) 제외 목록이 코드에 명시 — merge/deploy/send 전부 + 판정 함수 행위 ────────────────────

--- a/tools/loop-engine/test/sanitize.test.sh
+++ b/tools/loop-engine/test/sanitize.test.sh
@@ -17,7 +17,7 @@ LESSONS="$ROOT/tools/loop-engine/bin/lessons.mjs"
 fail() { echo "FAIL: $1"; exit 1; }
 [ -f "$S" ] || fail "sanitize.mjs not found at $S"
 
-DIR="$(mktemp -d)"
+DIR="$(mktemp -d "${TMPDIR:-/tmp}/tmp.XXXXXXXX")" || fail "mktemp -d failed"
 trap 'rm -rf "$DIR"' EXIT
 
 # T1: blocklist 키 낙하 — 값은 마커로 치환, 비민감 키는 보존. 케이스/구분자 변형(api_key/API-KEY)도 매치.

--- a/tools/loop-engine/test/verdict-mutation-guard.test.sh
+++ b/tools/loop-engine/test/verdict-mutation-guard.test.sh
@@ -10,7 +10,7 @@ VR="$HERE/../bin/verdict-run.sh"
 fail() { echo "FAIL: $1"; exit 1; }
 [ -x "$VR" ] || fail "verdict-run.sh not executable at $VR"
 
-WORK="$(mktemp -d)"
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/tmp.XXXXXXXX")" || fail "mktemp -d failed"
 trap 'rm -rf "$WORK"' EXIT
 
 mkrepo() {


### PR DESCRIPTION
## Summary

Applies the same mktemp fix already shipped in glucofit-partners (BAC-718/BAC-720) to this repo's own `tools/loop-engine/test/*.test.sh` suite, plus one production fix uncovered while verifying it.

Bare `mktemp -d`/`mktemp` ignores `$TMPDIR` under some sandboxed environments (notably Claude Code's Bash sandbox) and falls back to a default temp path the sandbox denies, failing with EPERM. Left unguarded, `VAR="$(mktemp -d)"` doesn't stop the script — it silently continues with `VAR` empty, letting fake-repo setup (`git init`/`git commit`) run against the wrong path. glucofit-partners hit this for real: 4 empty commits leaked into a live worktree before the gap was found and fixed there.

- **Test hardening** (16 files, `tools/loop-engine/test/*.test.sh`): every `mktemp`/`mktemp -d` call site changed to
  ```sh
  VAR="$(mktemp -d "${TMPDIR:-/tmp}/tmp.XXXXXXXX")" || fail "mktemp -d failed"
  ```
  using each script's own existing `fail()` helper. No `set -e` — this codebase's scripts widely rely on the `VAR="$(cmd)"; rc=$?` idiom to capture intentional non-zero exits from hooks under test, and `set -e` breaks that (confirmed by trying it first, regressing the suite, and reverting).

- **Real bug found and fixed**: `bin/verdict-run.sh`'s `workspace_digest()` (used by `--guard-mutation`) had the same bare `mktemp` call. Under this sandbox it failed, which made `workspace_digest` return 1, which made the pre-verify digest computation fail, which made `--guard-mutation` fail-closed with exit 2 instead of correctly detecting the mutation and exiting 1. This wasn't just a test-script issue — it was a real bug in the digest computation that the test fix surfaced (`verdict-mutation-guard.test.sh` case1 went from `exit 2` to the correct `exit 1` once this was fixed). Same one-line fix applied.

## Verify

```
bash tools/loop-engine/test/run.sh
```

Before this PR: 12/16 (run without the fix at all — most files failed even earlier, at fake-repo setup, with `mktemp: mkdtemp failed ... Operation not permitted`).
After this PR: **13/16**, remaining 3 are pre-existing and unrelated to mktemp (confirmed by stashing individual files' fix and reproducing under this sandbox):

- `context-budget.test.sh`, `otel-receiver.test.sh` — both fail on `srv.listen(0, '127.0.0.1', ...)` / socket bind EPERM. Same sandbox network-deny class already tracked as a separate known gap in glucofit-partners (BAC-721-adjacent). Nothing to do with mktemp.
- `loop-fix-progress-clock.test.sh` case1 — the watchdog-kill timing case doesn't complete within its 30s budget under this sandbox (looks like process-tree signaling behaves differently here, not a temp-dir issue). Confirmed pre-existing: reverting just this file's one-line mktemp fix reproduces a *different* failure (mktemp EPERM at setup), not this one — so the timing failure exists independently of this diff.

## Test plan

- [x] All 16 `tools/loop-engine/test/*.test.sh` mktemp call sites guarded (`grep` swept for unguarded `mktemp` — none remain)
- [x] `bin/verdict-run.sh`'s `workspace_digest()` mktemp call guarded — confirmed fixes `verdict-mutation-guard.test.sh` case1
- [x] Full suite re-run: 13/16, verified the 3 remaining failures are pre-existing/environmental and unrelated to this diff (reproduced with the fix reverted per-file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)