### PR TITLE
docs(ship-flow): grounded reopen 규약 — settled ADR/lesson 재오픈엔 id 인용 + 새 증거 요구

### DIFF
--- a/tools/ship-flow/skills/grill-with-docs/SKILL.md
+++ b/tools/ship-flow/skills/grill-with-docs/SKILL.md
@@ -85,4 +85,12 @@ Only offer to create an ADR when all three are true:
 
 If any of the three is missing, skip the ADR. Use the format in [ADR-FORMAT.md](./ADR-FORMAT.md).
 
+### Reopening a settled ADR
+
+If the plan reverses or overrides an existing ADR, that's the same grounded-reopen bar retrospect
+applies to lessons: the user must cite the ADR by id and bring evidence that didn't exist when it was
+written — not "on reflection" or a plain change of preference. Missing either, point back to the
+existing ADR's rationale and ask what the plan does differently. A genuine reversal gets a new ADR that
+supersedes the old one and links back to it — don't rewrite the old ADR in place.
+
 </supporting-info>

--- a/tools/ship-flow/skills/retrospect/SKILL.md
+++ b/tools/ship-flow/skills/retrospect/SKILL.md
@@ -100,6 +100,24 @@ plugin-standard tooling for it, and a repo without such a tool can skip this sec
   keeps the candidate pool from growing monotonically. Fail closed: only a verified + `challenge
   --verdict accept`ed lesson can retire; a content change later re-opens it for fresh review.
 
+### Grounded reopen (retired or rejected lessons)
+
+Retired lessons and `challenge --verdict reject`ed candidates are settled — "let's revisit that" on its
+own doesn't reopen them. A reopen request must:
+
+- **Cite the id.** Name the exact lesson id (or ADR number) under discussion — a vague appeal to "that
+  decision" doesn't identify a target.
+- **Bring new evidence.** Something the original verdict didn't have: a fresh recurrence, a new failure
+  signature, a verified counterexample. "On reflection..." with no new signal isn't evidence.
+- **Not overwrite the record.** Don't edit the retired/rejected entry's fields in place — that erases the
+  audit trail. Open a fresh lesson/challenge cycle instead, or (if this repo's lessons tooling has an
+  `invalidate --superseded-by` command) link the old id forward to the new one; otherwise reference the
+  superseded id in the new entry's `--fix` text. A reversal that belongs at the ADR level gets a new ADR
+  that references the old one, not a rewrite of it.
+
+A reopen missing an id or missing new evidence is an automatic reject in the skeptical pass — the same
+challenge gate as any promotion candidate.
+
 ## Reporting
 
 State what was recorded/recalled and the loop-efficiency trend. When promoting, name the recurring


### PR DESCRIPTION
## Summary

- `retrospect/SKILL.md`: `## Retro & promotion` 섹션에 "Grounded reopen (retired or rejected lessons)" 서브섹션 추가 — retired 또는 `challenge --verdict reject`된 lesson을 재오픈하려면 id로 대상 지목 + 새 증거(재발/실패 시그니처/반례) 필수, 원본 레코드는 직접 덮어쓰지 않고 새 사이클을 연다(또는 이 레포에 `invalidate --superseded-by`가 있다면 연결, 없으면 언급만). 위반 시 스켑틱 패스 자동 거부.
- `grill-with-docs/SKILL.md`: "Offer ADRs sparingly" 뒤에 "Reopening a settled ADR" 서브섹션 추가 — 기존 ADR을 번복하려는 그릴링 세션에 같은 id 인용 + 새 증거 규약 적용, 번복은 새 ADR로 남기고 옛 ADR을 직접 다시 쓰지 않는다.
- 순수 산문(prose) 변경, 코드 변경 없음.

## Test plan

- [x] `claude plugin validate --strict tools/ship-flow` — 매니페스트 정합성 확인:
  ```
  Validating plugin manifest: /Users/paul/dev/paul-loop-8-grounded-challenge/tools/ship-flow/.claude-plugin/plugin.json

  ✔ Validation passed
  ```
- [x] 두 SKILL.md의 YAML frontmatter(`name`/`description`)가 그대로 유효함을 직접 확인 (수정은 frontmatter 아래 본문에만 가함).
- [x] `.claude/rules/**/*.md` 길이 상한 게이트(`check-rules-always-on.mjs`)는 이 경로(`tools/ship-flow/skills/**/SKILL.md`)를 대상으로 하지 않음을 확인 — 적용 대상 아님. 다른 `SKILL.md` 파일들과 줄 수 비교(14~241줄) 결과 이번 두 파일(96·124줄)도 정상 범위.

Closes #8