### PR TITLE
하네스 티어0 스모크 게이트 — eval-gate를 loop-fix/lessons 자기검증에 조준 (#7)

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -180,6 +180,7 @@ tools/loop-engine/
   .claude-plugin/plugin.json      # 이 플러그인의 매니페스트
   bin/                            # 명령들 — 플러그인 로드 시 PATH 자동 등록
   lib/                            # bin/ 스크립트가 import하는 공유 헬퍼
+  eval/tier0/                     # 티어0 하네스 자기-스모크 게이트의 골든셋(#7)
   test/                           # 자체 테스트 스위트(bash+node, docker 0) — test/run.sh가 전부 실행
   docs/                           # verdict 계약·lessons 모델·eval-gate·otel 메모
 ```

--- a/README.md
+++ b/README.md
@@ -250,6 +250,7 @@ tools/loop-engine/
   .claude-plugin/plugin.json      # this plugin's manifest
   bin/                            # commands, auto-registered on PATH when the plugin loads
   lib/                            # shared helpers bin/ scripts import
+  eval/tier0/                     # golden dataset for the tier0 harness-self smoke gate (#7)
   test/                           # self-test suite (bash + node, no docker) — test/run.sh runs all of it
   docs/                           # verdict contract, lessons model, eval-gate, otel notes
 tools/ship-flow/                  # delivery-loop skills — see the plugin's own skills/ for docs

--- a/tools/loop-engine/bin/tier0-run.sh
+++ b/tools/loop-engine/bin/tier0-run.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# tier0-run.sh — 티어0 스모크 어댑터(#7): eval-gate.mjs의 기존 --target 계약(STDIN=케이스
+# `input`, STDOUT/exit code=채점 대상)에 맞춰, 하네스 자기 자신(loop-fix.sh / lessons.mjs)이
+# 스펙대로 동작하는지 결정론적으로 검증한다. LLM을 부르지 않는다 — 진짜 "에이전트 런" 시나리오는
+# 비싸고 이 이슈의 취지("티어0" = 가장 싼 결정론적 스모크)에도 안 맞는다. 대신 하네스 스크립트들을
+# 실제로 실행해 관찰 가능한 계약(exit code · 로그 문구 · 기록된 파일)을 검증한다.
+#
+# 계약: STDIN으로 시나리오 id 하나를 받아 격리된 임시 워크스페이스에서 실행하고, 결과(하위 명령의
+# 실제 exit code + 관련 로그/파일 내용)를 STDOUT에 grep 가능한 형태로 찍는다. 이 스크립트 자신의
+# exit code는 "시나리오를 실행할 수 있었는가"만 뜻한다 — 개별 시나리오의 PASS/FAIL 판정은 골든
+# 케이스의 assert(contains/not_contains/...)가 위 STDOUT 텍스트를 보고 내린다("EXIT_CODE=N" 같은
+# 태그로). 이렇게 하면 "exit 1로 끝나야 한다"(loop-fix)와 "usage error로 exit 2여야 한다"(lessons)
+# 를 같은 채점 방식으로 다룰 수 있다. 알려지지 않은 시나리오 id는 실패(exit 1)로 취급한다 — 오타로
+# 케이스가 조용히 미실행되는 것을 방지.
+#
+# Usage: echo "<scenario-id>" | tier0-run.sh
+#   (eval-gate.mjs가 case.input을 STDIN으로 넘긴다 — 직접 실행할 땐 위처럼 파이프한다)
+#
+# bash 3.2 compatible (다른 bin/*.sh와 동일).
+
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+LOOPFIX="$HERE/loop-fix.sh"
+LESSONS_BIN="$HERE/lessons.sh"
+
+SCENARIO="$(cat)"
+
+WORK="$(mktemp -d)" || { echo "tier0-run: mktemp -d failed" >&2; exit 1; }
+cleanup() { rm -rf "$WORK" 2>/dev/null; }
+trap cleanup EXIT
+cd "$WORK" || exit 1
+
+case "$SCENARIO" in
+
+  loop-fix-max-iter)
+    # 계약: verify가 항상 FAIL이면 --max-iter를 소진하고 exit 1 + history.log에 "MAX-ITER"로
+    # 종료해야 한다(loop-fix.sh의 가장 기본적인 하드 정지 기준 보증).
+    "$LOOPFIX" --verify 'exit 1' --fix ':' --max-iter 2 >/dev/null 2>&1
+    code=$?
+    echo "EXIT_CODE=$code"
+    echo "--- history.log ---"
+    cat .loop/history.log 2>/dev/null
+    echo "--- end history.log ---"
+    ;;
+
+  loop-fix-pass-first-try)
+    # 계약: verify가 첫 회부터 PASS면 fixer 없이 exit 0 + "SUCCESS in 1 iteration(s)"로 끝나야 한다.
+    "$LOOPFIX" --verify 'exit 0' --max-iter 5 >/dev/null 2>&1
+    code=$?
+    echo "EXIT_CODE=$code"
+    echo "--- history.log ---"
+    cat .loop/history.log 2>/dev/null
+    echo "--- end history.log ---"
+    ;;
+
+  loop-fix-verified-lesson-on-success)
+    # 계약: verify가 FAIL -> PASS로 수렴하면(loop-fix.sh:372-376, Phase 3), --lessons 디렉터리에
+    # verified:true인 lesson 파일이 기록되어야 한다. fixer는 ':'(no-op) — 여기선 verify 자체가
+    # 호출 횟수로 상태 전이하는 fixture라 fixer 개입이 불필요하다(다른 loop-fix 테스트와 동일 패턴).
+    cat > fake-verify.sh <<'FIXTURE'
+#!/bin/sh
+n=$(cat n 2>/dev/null || echo 0); n=$((n + 1)); echo "$n" > n
+if [ "$n" -eq 1 ]; then
+  echo "FAILED tier0-fixture > first attempt fails on purpose"
+  exit 1
+fi
+echo ok
+exit 0
+FIXTURE
+    "$LOOPFIX" --verify 'sh fake-verify.sh' --fix ':' --lessons lessons --max-iter 3 >/dev/null 2>&1
+    code=$?
+    echo "EXIT_CODE=$code"
+    echo "--- lessons files ---"
+    if ls lessons/*.json >/dev/null 2>&1; then
+      cat lessons/*.json
+    else
+      echo "NONE"
+    fi
+    echo "--- end lessons files ---"
+    ;;
+
+  lessons-record-signature-only)
+    # 계약(#9 병합 전 현재 동작): lessons record는 --signature만으로(--signature-file 없이,
+    # --verified 없이) 성공해야 한다 — record는 서명(signature-file 또는 signature) 존재만 요구
+    # 하고 provenance(verified)는 요구하지 않는다(lessons.mjs의 signatureOf()/record 분기).
+    # ⚠️ #9("증거 무결성 계약 — lessons record fail-closed")가 병합되면 이 계약이 바뀌어 이 케이스가
+    # 깨질 수 있다 — 그때는 #9의 새 계약에 맞춰 이 시나리오와 대응 골든 케이스를 함께 갱신할 것.
+    "$LESSONS_BIN" record --signature "tier0 fixture: sample failure text" --lessons lessons > out.txt 2>&1
+    code=$?
+    echo "EXIT_CODE=$code"
+    echo "--- stdout/stderr ---"
+    cat out.txt
+    echo "--- end stdout/stderr ---"
+    ;;
+
+  lessons-record-missing-signature)
+    # 계약: --signature-file도 --signature도 없는 record는 usage error로 fail-closed, exit 2여야
+    # 한다(lessons.mjs usage()) — 서명 없는 lesson이 조용히 기록되는 일은 없어야 한다.
+    "$LESSONS_BIN" record --lessons lessons > out.txt 2>&1
+    code=$?
+    echo "EXIT_CODE=$code"
+    echo "--- stdout/stderr ---"
+    cat out.txt
+    echo "--- end stdout/stderr ---"
+    ;;
+
+  *)
+    echo "tier0-run: unknown scenario id: $SCENARIO" >&2
+    exit 1
+    ;;
+esac
+
+exit 0

--- a/tools/loop-engine/bin/tier0-run.sh
+++ b/tools/loop-engine/bin/tier0-run.sh
@@ -81,11 +81,12 @@ FIXTURE
     ;;
 
   lessons-record-signature-only)
-    # 계약(#9 병합 전 현재 동작): lessons record는 --signature만으로(--signature-file 없이,
-    # --verified 없이) 성공해야 한다 — record는 서명(signature-file 또는 signature) 존재만 요구
-    # 하고 provenance(verified)는 요구하지 않는다(lessons.mjs의 signatureOf()/record 분기).
-    # ⚠️ #9("증거 무결성 계약 — lessons record fail-closed")가 병합되면 이 계약이 바뀌어 이 케이스가
-    # 깨질 수 있다 — 그때는 #9의 새 계약에 맞춰 이 시나리오와 대응 골든 케이스를 함께 갱신할 것.
+    # 계약: lessons record는 --signature만으로(--signature-file 없이, --verified 없이) 성공해야
+    # 한다 — record는 서명(signature-file 또는 signature) 존재만 요구하고 provenance(verified)는
+    # 요구하지 않는다(lessons.mjs의 signatureOf()/record 분기).
+    # 이 시나리오는 --verified를 쓰지 않으므로 #9("증거 무결성 계약")가 병합돼도 영향받지 않는다 —
+    # #9는 --verified가 --signature-file 없이 쓰였을 때만 거부하고(usage error, exit 2), unverified
+    # record는 명시적으로 그 범위 밖이다(origin/feature/9-evidence-integrity 커밋 ecf77ca 확인).
     "$LESSONS_BIN" record --signature "tier0 fixture: sample failure text" --lessons lessons > out.txt 2>&1
     code=$?
     echo "EXIT_CODE=$code"

--- a/tools/loop-engine/docs/eval-gate.md
+++ b/tools/loop-engine/docs/eval-gate.md
@@ -107,6 +107,8 @@ node bin/eval-gate.mjs --dataset eval/tier0 --target "bash bin/tier0-run.sh" --l
 ```
 
 Regression-locked by `test/eval-gate-tier0.test.sh` (part of `test/run.sh`). One case
-(`lessons-record-signature-only`) documents CURRENT pre-#9 behavior (`lessons record` succeeds
-without `--verified`) and is expected to need updating once #9 ("증거 무결성 계약") lands and makes
-`record` fail closed on unverified input.
+(`lessons-record-signature-only`) documents that `lessons record` succeeds on a hand-typed
+`--signature` alone, without `--signature-file` and without `--verified`. This case is unaffected
+by #9 ("증거 무결성 계약"): #9 only fails closed when `--verified` is combined with a hand-typed
+`--signature` and no `--signature-file` — unverified records (this case's scenario) are explicitly
+out of scope for that change, so no update is needed here once #9 lands.

--- a/tools/loop-engine/docs/eval-gate.md
+++ b/tools/loop-engine/docs/eval-gate.md
@@ -83,3 +83,30 @@ full LLM-judged suites every PR are uneconomical (research nuance).
   (no committed workflow yet; add one when a golden dataset lands).
 - **Loop:** `loop-fix.sh --verify "bin/eval-gate.sh --dataset ... --target ..."` drives a fix loop
   whose ground truth is the eval gate itself.
+
+## Tier 0: the harness-self smoke gate (#7)
+
+`eval-gate` was originally aimed at prompts (STDIN → agent output → STDOUT). `eval/tier0/` +
+`bin/tier0-run.sh` aim the same pattern at the **harness itself**: does `loop-fix.sh` /
+`lessons.mjs` still behave per their own documented contracts (max-iter stops, verified lessons
+get recorded on convergence, `lessons record` fails closed on a missing signature, …)? No LLM is
+called — every case runs the real scripts deterministically in an isolated temp workspace, which
+is what makes this the cheapest ("tier 0") gate: pure bash + node, no docker, safe to run on every
+`verify:loop`-adjacent change.
+
+`bin/tier0-run.sh` is the `--target` adapter: it reads a scenario id from STDIN (the case's
+`input`), runs it, and prints the underlying command's real exit code plus the relevant log/file
+content to STDOUT tagged as `EXIT_CODE=N` — the golden case's `contains`/`not_contains` assertions
+then grade that text. The adapter's own exit code only means "the scenario ran"; an unrecognized
+scenario id is a hard failure (exit 1) so a typo in a case file can't silently no-op.
+
+Run it:
+
+```bash
+node bin/eval-gate.mjs --dataset eval/tier0 --target "bash bin/tier0-run.sh" --log .loop/eval-revisit-call.log
+```
+
+Regression-locked by `test/eval-gate-tier0.test.sh` (part of `test/run.sh`). One case
+(`lessons-record-signature-only`) documents CURRENT pre-#9 behavior (`lessons record` succeeds
+without `--verified`) and is expected to need updating once #9 ("증거 무결성 계약") lands and makes
+`record` fail closed on unverified input.

--- a/tools/loop-engine/eval/tier0/lessons-record-missing-signature.json
+++ b/tools/loop-engine/eval/tier0/lessons-record-missing-signature.json
@@ -1,0 +1,9 @@
+{
+  "id": "lessons-record-missing-signature",
+  "input": "lessons-record-missing-signature",
+  "note": "--signature-file도 --signature도 없는 record는 usage error로 fail-closed, exit 2여야 한다.",
+  "assert": {
+    "contains": ["EXIT_CODE=2"],
+    "not_contains": ["lessons: recorded"]
+  }
+}

--- a/tools/loop-engine/eval/tier0/lessons-record-signature-only.json
+++ b/tools/loop-engine/eval/tier0/lessons-record-signature-only.json
@@ -1,7 +1,7 @@
 {
   "id": "lessons-record-signature-only",
   "input": "lessons-record-signature-only",
-  "note": "현재(#9 병합 전) lessons record는 --signature만으로(--signature-file 없이, --verified 없이) 성공해야 한다. #9(증거 무결성 계약)가 병합되면 이 계약이 바뀔 수 있다 — 그때 이 케이스를 함께 갱신할 것.",
+  "note": "lessons record는 --signature만으로(--signature-file 없이, --verified 없이) 성공해야 한다. 이 케이스는 --verified를 쓰지 않으므로 #9(증거 무결성 계약)가 병합돼도 영향받지 않는다 — #9는 --verified와 --signature-file 부재가 함께일 때만 거부하고(usage error, exit 2), unverified record는 명시적으로 그 범위 밖이다(origin/feature/9-evidence-integrity 커밋 ecf77ca 확인). 갱신 불필요.",
   "assert": {
     "contains": ["EXIT_CODE=0", "lessons: recorded"]
   }

--- a/tools/loop-engine/eval/tier0/lessons-record-signature-only.json
+++ b/tools/loop-engine/eval/tier0/lessons-record-signature-only.json
@@ -1,0 +1,8 @@
+{
+  "id": "lessons-record-signature-only",
+  "input": "lessons-record-signature-only",
+  "note": "현재(#9 병합 전) lessons record는 --signature만으로(--signature-file 없이, --verified 없이) 성공해야 한다. #9(증거 무결성 계약)가 병합되면 이 계약이 바뀔 수 있다 — 그때 이 케이스를 함께 갱신할 것.",
+  "assert": {
+    "contains": ["EXIT_CODE=0", "lessons: recorded"]
+  }
+}

--- a/tools/loop-engine/eval/tier0/loop-fix-max-iter.json
+++ b/tools/loop-engine/eval/tier0/loop-fix-max-iter.json
@@ -1,0 +1,8 @@
+{
+  "id": "loop-fix-max-iter",
+  "input": "loop-fix-max-iter",
+  "note": "verify가 항상 FAIL이면 loop-fix.sh는 --max-iter를 소진하고 exit 1 + 'MAX-ITER'로 끝나야 한다.",
+  "assert": {
+    "contains": ["EXIT_CODE=1", "MAX-ITER"]
+  }
+}

--- a/tools/loop-engine/eval/tier0/loop-fix-pass-first-try.json
+++ b/tools/loop-engine/eval/tier0/loop-fix-pass-first-try.json
@@ -1,0 +1,8 @@
+{
+  "id": "loop-fix-pass-first-try",
+  "input": "loop-fix-pass-first-try",
+  "note": "verify가 첫 회부터 PASS면 loop-fix.sh는 fixer 없이 exit 0 + 'SUCCESS in 1 iteration'으로 끝나야 한다.",
+  "assert": {
+    "contains": ["EXIT_CODE=0", "SUCCESS in 1 iteration"]
+  }
+}

--- a/tools/loop-engine/eval/tier0/loop-fix-verified-lesson-on-success.json
+++ b/tools/loop-engine/eval/tier0/loop-fix-verified-lesson-on-success.json
@@ -1,0 +1,8 @@
+{
+  "id": "loop-fix-verified-lesson-on-success",
+  "input": "loop-fix-verified-lesson-on-success",
+  "note": "verify가 FAIL -> PASS로 수렴하면 --lessons 디렉터리에 verified:true인 lesson 파일이 기록되어야 한다(Phase 3).",
+  "assert": {
+    "contains": ["EXIT_CODE=0", "\"verified\": true"]
+  }
+}

--- a/tools/loop-engine/test/eval-gate-tier0.test.sh
+++ b/tools/loop-engine/test/eval-gate-tier0.test.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Regression test (#7): eval-gate.mjs가 tier0-run.sh 어댑터와 결합해 하네스 자기 자신(loop-fix.sh /
+# lessons.mjs)의 관찰 가능한 계약을 결정론적으로 채점하는지 잠근다. 이 조합이 이슈의 선행조건
+# ("골든셋 1회 실행 검증")을 재현 가능하게 만드는 형태다 — LLM 호출 없음(티어0 = 가장 싼 결정론적
+# 스모크), pure bash + node, docker 0.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+EVAL="$HERE/../bin/eval-gate.mjs"
+TIER0RUN="$HERE/../bin/tier0-run.sh"
+DATASET="$HERE/../eval/tier0"
+
+fail() { echo "FAIL: $1"; exit 1; }
+[ -f "$EVAL" ] || fail "eval-gate.mjs not found at $EVAL"
+[ -x "$TIER0RUN" ] || fail "tier0-run.sh not executable at $TIER0RUN"
+[ -d "$DATASET" ] || fail "tier0 golden dataset dir not found at $DATASET"
+
+WORK="$(mktemp -d)" || fail "mktemp -d failed"
+trap 'rm -rf "$WORK"' EXIT
+
+# ── case 1: 전체 골든셋이 PASS로 채점되어야 한다(결정론적 — k=1 기본값으로 충분, LLM 없음) ─────
+LOG="$WORK/eval.log"
+OUT="$(node "$EVAL" --dataset "$DATASET" --target "bash $TIER0RUN" --log "$LOG" 2>&1)"
+code=$?
+[ "$code" -eq 0 ] || fail "expected the tier0 golden dataset to PASS, got exit $code:
+$OUT"
+printf '%s\n' "$OUT" | grep -q '^VERDICT: PASS$' || fail "expected VERDICT: PASS, got:
+$OUT"
+n_cases="$(find "$DATASET" -name '*.json' | wc -l | tr -d ' ')"
+printf '%s\n' "$OUT" | grep -q "cases=$n_cases k=" || fail "expected cases=$n_cases in SUMMARY, got:
+$OUT"
+
+# ── case 2: 어댑터 자신 — 알려지지 않은 시나리오 id는 실패해야 한다(오타로 인한 무음 통과 방지) ─
+echo "no-such-scenario" | bash "$TIER0RUN" >/dev/null 2>/dev/null
+code=$?
+[ "$code" -ne 0 ] || fail "expected tier0-run.sh to fail on an unknown scenario id"
+
+echo "PASS: eval-gate + tier0-run.sh compose deterministically over the tier0 golden dataset"
+exit 0


### PR DESCRIPTION
## 요약

`eval-gate.mjs`의 `--target` 계약(STDIN=케이스 `input`, STDOUT/exit code=채점 대상)은 이미 프롬프트
대상 범용 계약으로 존재한다(신규 게이트 로직 아님). 이슈가 요구한 건 그 계약에 맞는 **어댑터**를
만들어 하네스 자기 자신(`loop-fix.sh`/`lessons.mjs`)이 스펙대로 동작하는지 LLM 호출 없이 결정론적으로
검증하는 것("티어0" = 가장 싼 스모크).

- `tools/loop-engine/bin/tier0-run.sh` — STDIN으로 시나리오 id를 받아 격리된 임시 워크스페이스에서
  실제 `loop-fix.sh`/`lessons.mjs`를 실행하고, 결과(exit code + 관련 로그/파일)를
  `EXIT_CODE=N` 태그로 STDOUT에 찍는다. 어댑터 자신의 exit code는 "시나리오를 실행할 수 있었는가"만
  의미하고, 개별 시나리오의 PASS/FAIL은 골든 케이스의 `contains`/`not_contains` assert가 판정한다.
  알려지지 않은 시나리오 id는 exit 1(오타로 인한 무음 통과 방지).
- `tools/loop-engine/eval/tier0/*.json` — 5개 골든 케이스:
  - `loop-fix-max-iter`: verify 항상 FAIL → `--max-iter 2`로 exit 1 + `MAX-ITER`
  - `loop-fix-pass-first-try`: verify 첫 회 PASS → exit 0 + `SUCCESS in 1 iteration`
  - `loop-fix-verified-lesson-on-success`: verify FAIL→PASS 수렴 → `--lessons`에 `verified: true` 기록
  - `lessons-record-signature-only`: `--signature`만으로(`--verified` 없이) record 성공 — 이 케이스는
    `--verified`를 쓰지 않으므로 **#9(증거 무결성 계약, `--verified`+`--signature-file` 부재만
    거부)가 병합돼도 영향받지 않는다는 점을 케이스 `note`와 어댑터 주석에 명시**(정정,
    `origin/feature/9-evidence-integrity` 커밋 `ecf77ca` 대조 확인)
  - `lessons-record-missing-signature`: 서명 없는 record는 usage error, exit 2 (fail-closed)
- `tools/loop-engine/test/eval-gate-tier0.test.sh` — 위 조합이 결정론적으로 PASS함을 회귀 잠금 +
  어댑터의 미지 시나리오 fail 경로도 검증. `test/run.sh`에 자동 편입.
- `docs/eval-gate.md`에 "Tier 0" 절 추가, `README.md`/`README.ko.md` 저장소 구조 표에 `eval/` 추가.

**선행조건 충족**: 이슈 본문의 "골든셋 1회 실행 검증(.loop/eval-revisit-call.log)"을 실제로 1회
실행해 PASS를 확인함(아래 출력). `.loop/`는 이 레포 `.gitignore`에 전체 무시 대상(`.loop/` +
`*.log`, 예외 없음 — `.loop/lessons/*.json`이 커밋된다는 코드 주석은 이 레포엔 해당 없음, 실측
`git check-ignore -v` 확인)이라 로그 파일 자체는 커밋하지 않고 재현 커맨드를 `docs/eval-gate.md`에
문서화했다.

## 검증

```
$ bash tools/loop-engine/test/run.sh
...
loop-engine selftest: 17/17 passed
```

```
$ node tools/loop-engine/bin/eval-gate.mjs --dataset tools/loop-engine/eval/tier0 \
    --target "bash tools/loop-engine/bin/tier0-run.sh" --log .loop/eval-revisit-call.log
=== VERDICT ===
VERDICT: PASS
EXIT: 0
SUMMARY: cases=5 k=1 pass_at_k=1.00 pass_caret_k=1.00 trials=5/5
LOG: /Users/paul/dev/paul-loop-7-tier0-smoke-gate/.loop/eval-revisit-call.log
=== END VERDICT ===
```

`claude plugin validate --strict tools/loop-engine`와 `claude plugin validate --strict .` 둘 다
로컬에서 통과 확인.

Closes #7
