### PR TITLE
feat(lessons): invalidate/mark-clean commands for corpus hygiene (#6)

### DIFF
--- a/tools/loop-engine/bin/lessons.mjs
+++ b/tools/loop-engine/bin/lessons.mjs
@@ -45,6 +45,19 @@
 //                   (Phase 4, TERMINAL) retire an accepted+codified lesson from the promotion pool so it
 //                   stops re-surfacing (promote listing / --codify / loop-doctor). Fail closed: only a
 //                   verified lesson with a recorded `challenge --verdict accept` may retire.
+//   lessons invalidate --id <key> [--reason "<why>"] [--superseded-by <id2>] [--by "<who>"] [--lessons <dir>]
+//                   Mark a lesson WRONG (the lesson itself was incorrect) — distinct from `retire`
+//                   (the lesson was RIGHT but is now superseded/codified). An invalidated lesson is
+//                   EXCLUDED, fail-closed, from every downstream surface: recall (never recalled, even
+//                   if verified) and promote (candidates listing / --codify). --superseded-by (optional)
+//                   fail-closed-checks the target id exists before writing.
+//   lessons mark-clean --gate "<verify cmd>" [--lessons <dir>]
+//                   Exit-code-derived counter: bump clean_pass_count on every lesson attributed to --gate
+//                   (via gate_history) that is neither invalidated nor retired — how many times that gate
+//                   has passed CLEANLY, i.e. without this lesson's fix being needed again. `record`'s
+//                   fail-recurrence path resets it to 0 (a recurrence means the lesson is NOT stable yet).
+//                   `promote`'s listing annotates lessons crossing CLEAN_RETIRE_THRESHOLD as retirement
+//                   candidates — informational only, never auto-invalidates/retires.
 //   lessons stats   [--category engineering|domain] [--lessons <dir>]
 //
 // category: `engineering` (process/tooling lesson, the default) or `domain` (product/domain lesson).
@@ -61,7 +74,7 @@ import { sanitizeText } from '../lib/sanitize.mjs'   // BAC-628 기록 시점 re
 // 전체를 무음 무력화). loop-fix가 record를 `>/dev/null 2>&1`+`&&` 체인으로, recall을 `2>/dev/null`+
 // exit 무시로 부르므로(loop-fix.sh:373-376·452) 정적 import 크래시는 루프 메모리의 기록·회상 두 경로를
 // 소리 없이 죽인다. 이 의존체는 promote --runs(옵트인)와 --gate 정규화에만 필요 — 실패 시 그 둘만
-// 강등(경고 1줄)하고 본연 명령(record/recall/promote/stats/challenge/retire)은 산다.
+// 강등(경고 1줄)하고 본연 명령(record/recall/promote/stats/challenge/retire/invalidate/mark-clean)은 산다.
 let regressionSignals = null
 try {
   regressionSignals = await import('../lib/regression-signals.mjs')
@@ -71,15 +84,15 @@ try {
 
 function usage(msg) {
   if (msg) process.stderr.write(`lessons: ${msg}\n`)
-  process.stderr.write('Usage: lessons <record|recall|promote|retire|stats> [options]  (see header)\n')
+  process.stderr.write('Usage: lessons <record|recall|promote|stats|challenge|retire|invalidate|mark-clean> [options]  (see header)\n')
   process.exit(2)
 }
 
 const argv = process.argv.slice(2)
 const cmd = argv.shift()
-if (!cmd || !['record', 'recall', 'promote', 'stats', 'challenge', 'retire'].includes(cmd)) usage(`unknown or missing command ${JSON.stringify(cmd || '')}`)
+if (!cmd || !['record', 'recall', 'promote', 'stats', 'challenge', 'retire', 'invalidate', 'mark-clean'].includes(cmd)) usage(`unknown or missing command ${JSON.stringify(cmd || '')}`)
 
-const opt = { lessons: process.env.LESSONS_DIR || '.loop/lessons', sigFile: '', sig: '', fix: '', title: '', source: '', category: '', iterations: null, verified: false, minCount: 3, includeUnverified: false, id: '', verdict: '', reason: '', by: '', ref: '', codify: false, gate: '', runs: '' }
+const opt = { lessons: process.env.LESSONS_DIR || '.loop/lessons', sigFile: '', sig: '', fix: '', title: '', source: '', category: '', iterations: null, verified: false, minCount: 3, includeUnverified: false, id: '', verdict: '', reason: '', by: '', ref: '', codify: false, gate: '', runs: '', supersededBy: '' }
 for (let i = 0; i < argv.length; i++) {
   const a = argv[i]
   const val = () => { if (i + 1 >= argv.length) usage(`${a} requires a value`); return argv[++i] }
@@ -104,6 +117,7 @@ for (let i = 0; i < argv.length; i++) {
     case '--codify': opt.codify = true; break
     case '--gate': opt.gate = val(); break
     case '--runs': opt.runs = val(); break
+    case '--superseded-by': opt.supersededBy = val(); break
     default: usage(`unknown arg ${a}`)
   }
 }
@@ -120,6 +134,7 @@ opt.reason = sanitizeText(opt.reason)
 opt.by = sanitizeText(opt.by)
 opt.ref = sanitizeText(opt.ref)
 opt.gate = sanitizeText(opt.gate)
+opt.supersededBy = sanitizeText(opt.supersededBy)
 // 게이트 키 정규화(BAC-631) — 원장 payload.cmd와 같은 규칙(lib normalizeGateKey: `sh -c ` 래퍼 제거 +
 // 절단 수렴)으로 맞춰야 promote --runs 교차 참조가 어긋나지 않는다. loop-fix 경로의 cmd는
 // "sh -c pnpm verify"로 착지하므로 raw 문자열 비교는 영구 미매칭이었다(리뷰). lib 로드 실패 시엔
@@ -194,6 +209,17 @@ function coerce(l) {
         .filter(([k, v]) => k && v && typeof v === 'object' && Number.isInteger(v.count) && v.count > 0)
         .map(([k, v]) => [k, { count: v.count, first_seen: typeof v.first_seen === 'string' ? v.first_seen : '', last_seen: typeof v.last_seen === 'string' ? v.last_seen : '' }]))
     : {}
+  // invalidation (BAC-571 port, issue #6) — distinct from `retired` (right but unused/superseded):
+  // this marks the lesson itself WRONG. `invalid_at` is authoritative only when it is a non-empty
+  // string (read-time default '' = NOT invalidated) — fail closed, same pattern as retired.at above.
+  l.invalid_at = (typeof l.invalid_at === 'string' && l.invalid_at) ? l.invalid_at : ''
+  l.invalid_reason = typeof l.invalid_reason === 'string' ? l.invalid_reason : ''
+  l.superseded_by = typeof l.superseded_by === 'string' ? l.superseded_by : ''
+  l.invalidated_by = typeof l.invalidated_by === 'string' ? l.invalidated_by : ''
+  // clean_pass_count: exit-code-derived counter (`mark-clean`) of how many times this lesson's gate
+  // passed WITHOUT this lesson's fix being needed again. Missing/corrupt coerces to 0 — read-time
+  // default, no migration needed for pre-existing lessons.
+  l.clean_pass_count = Number.isInteger(l.clean_pass_count) && l.clean_pass_count >= 0 ? l.clean_pass_count : 0
   return l
 }
 function ensureDir() { mkdirSync(opt.lessons, { recursive: true }) }
@@ -236,6 +262,9 @@ if (cmd === 'record') {
     if (existing) {
       existing.count += 1
       existing.last_seen = nowIso()
+      // fail-recurrence: this signature came back, so any "clean since" streak (mark-clean) is no
+      // longer true — a recurrence is evidence the lesson is NOT yet stable. Reset to 0.
+      existing.clean_pass_count = 0
       existing.verified = existing.verified || opt.verified
       if (opt.iterations != null) existing.iterations.push(opt.iterations)
       // Trust fix/title/source updates only from a VERIFIED record (or while the lesson is not yet
@@ -336,10 +365,66 @@ if (cmd === 'retire') {
   process.exit(0)
 }
 
+if (cmd === 'invalidate') {
+  // Mark a lesson WRONG — distinct from `retire` (right but superseded/codified). This is the OTHER
+  // terminal-ish state: unlike retire, invalidate carries no floor (a bad lesson can be caught before
+  // it is ever verified or recurring). Fail closed downstream: an invalidated lesson must never surface
+  // via recall (checked ahead of the verified check), nor via promote (candidates listing / --codify).
+  if (!opt.id) usage('invalidate needs --id <lesson-key> (run "lessons promote" to see ids)')
+  const res = withLock(() => {
+    const l = readLesson(opt.id)
+    if (!l) return { err: 'notfound' }
+    // Fail closed: a --superseded-by pointing at a non-existent id would silently record a dangling
+    // reference (promote/recall trust it as a hint, never dereference it, but a typo here should not
+    // land silently — same "don't write what can't be true" discipline as retire's notcleared gate).
+    if (opt.supersededBy && !readLesson(opt.supersededBy)) return { err: 'supersedednotfound' }
+    l.invalid_at = nowIso()
+    l.invalid_reason = opt.reason || ''
+    l.superseded_by = opt.supersededBy || ''
+    l.invalidated_by = opt.by || 'human'
+    writeLesson(l)
+    return { ok: `invalidated ${opt.id}${opt.reason ? ` — ${opt.reason}` : ''}${opt.supersededBy ? ` (superseded by ${opt.supersededBy})` : ''}` }
+  })
+  if (res.err === 'notfound') usage(`no lesson with id ${opt.id} (run "lessons promote --lessons ${opt.lessons}" to see candidate ids)`)
+  if (res.err === 'supersedednotfound') usage(`superseded-by target ${opt.supersededBy} does not exist`)
+  process.stdout.write(`lessons: ${res.ok}\n`)
+  process.exit(0)
+}
+
+if (cmd === 'mark-clean') {
+  // Exit-code-derived counter: the caller (loop-fix / a gate wrapper) tells us --gate passed CLEANLY
+  // this run, so every lesson attributed to that gate (gate_history) that is still an ACTIVE candidate
+  // (not already invalidated, not already retired) gets its clean_pass_count bumped. `record`'s
+  // fail-recurrence path resets this to 0, so this is genuinely "consecutive clean passes since the
+  // last recurrence" — not a lifetime total.
+  if (!opt.gate) usage('mark-clean needs --gate "<verify cmd>"')
+  const n = withLock(() => {
+    let marked = 0
+    for (const l of allLessons()) {
+      if (Object.hasOwn(l.gate_history, opt.gate) && !l.invalid_at && !l.retired) {
+        l.clean_pass_count += 1
+        writeLesson(l)
+        marked++
+      }
+    }
+    return marked
+  })
+  process.stdout.write(`lessons: marked ${n} lesson(s) clean for gate ${opt.gate}\n`)
+  process.exit(0)
+}
+
 if (cmd === 'recall') {
   const s = signatureOf()
   if (!s) usage('recall needs --signature-file or --signature with at least one FAIL line')
   const l = readLesson(s.key)
+  // Invalidated lessons are NEVER recalled — checked ahead of the verified check, because a WRONG
+  // lesson that happens to also be `verified` must still not surface (fail closed; the whole point of
+  // invalidate is "this was verified once, but it's wrong now"). Same silent-stdout/exit-0 contract as
+  // a plain miss, but the stderr line says INVALIDATED (not "no lesson") so it's diagnosable.
+  if (l && l.invalid_at) {
+    process.stderr.write(`lessons: lesson ${s.key} is INVALIDATED (${l.invalid_reason})${l.superseded_by ? `, superseded by ${l.superseded_by}` : ''} — not recalled\n`)
+    process.exit(0)
+  }
   // Signature recall is an EXACT match on the normalized failure key — no similarity, no ranking
   // (ADR-0062). A miss stays silent on stdout/exit-code (loop-fix pipes this through `2>/dev/null`),
   // but writes ONE stderr line: the key it looked up, and a routing hint since a miss is often a
@@ -360,15 +445,23 @@ if (cmd === 'recall') {
   process.exit(0)
 }
 
+// Informational-only threshold for promote's "retirement candidate" annotation (issue #6): a lesson
+// whose gate has passed this many times CLEANLY (mark-clean) since its last recurrence is a signal the
+// lesson may no longer be needed — never an auto-retire/invalidate, same "signal only" spirit as the
+// --runs REGRESSION annotation below.
+const CLEAN_RETIRE_THRESHOLD = 5
+
 if (cmd === 'promote') {
   // The deterministic FLOOR for the candidate pool: verified (ground-truth) + recurring (count>=N).
   const pool = allLessons()
     .filter(l => l.count >= opt.minCount && (l.verified || opt.includeUnverified))
     .sort((a, b) => b.count - a.count)
-  // Retired lessons have already been codified into a skill/CLAUDE.md — they must not re-surface as
-  // candidates (listing) nor be re-emitted for codification (--codify). Partition them out.
+  // Retired lessons have already been codified into a skill/CLAUDE.md (right but superseded) — they
+  // must not re-surface as candidates (listing) nor be re-emitted for codification (--codify).
+  // Invalidated lessons (WRONG, issue #6) get the same fail-closed exclusion. Partition both out.
   const retiredCount = pool.filter(l => l.retired).length
-  const candidates = pool.filter(l => !l.retired)
+  const invalidatedCount = pool.filter(l => l.invalid_at).length
+  const candidates = pool.filter(l => !l.retired && !l.invalid_at)
 
   if (opt.codify) {
     // The codification OUTPUT (Phase 4): emit ONLY candidates a separate skeptical evaluator has
@@ -379,7 +472,10 @@ if (cmd === 'promote') {
     // that flag may relax recall/listing, but ONLY ground-truth-verified lessons may ever be codified
     // into a skill/guideline (the verifier is the ceiling). A self-reported, never-verified "fix" must
     // not reach write-a-skill / CLAUDE.md even if a skeptic accepted it. Fail closed.
-    const accepted = candidates.filter(l => l.verified === true && l.challenge && l.challenge.verdict === 'accept')
+    // !l.invalid_at is re-asserted here too even though `candidates` already excludes it — this is the
+    // single most safety-critical filter in the file (an invalidated lesson reaching write-a-skill /
+    // CLAUDE.md would codify a KNOWN-WRONG lesson), so it gets defense-in-depth, not just one filter.
+    const accepted = candidates.filter(l => l.verified === true && !l.invalid_at && l.challenge && l.challenge.verdict === 'accept')
     if (accepted.length === 0) {
       process.stdout.write('lessons: 0 candidate(s) cleared for codification — none has a recorded "lessons challenge --verdict accept"\n')
       process.exit(0)
@@ -430,9 +526,9 @@ if (cmd === 'promote') {
   // The LISTING: OPEN candidates (not yet retired) that pass the floor, each with its challenge
   // status, so the skeptical evaluator can accept/reject by id BEFORE anything is codified. Already-
   // retired lessons are hidden (reported as a count only).
-  const retiredNote = retiredCount ? ` (${retiredCount} already retired — codified, out of the pool)` : ''
-  if (candidates.length === 0) { process.stdout.write(`lessons: no open recurring (>=${opt.minCount}×) verified candidates to promote${retiredNote}\n`); writeRegSection(); process.exit(0) }
-  process.stdout.write(`lessons: ${candidates.length} open candidate(s) passing the floor (verified + recurring, not yet retired)${retiredNote}. Challenge each before codifying:\n`)
+  const excludedNote = (retiredCount || invalidatedCount) ? ` (${retiredCount} already retired, ${invalidatedCount} invalidated — excluded)` : ''
+  if (candidates.length === 0) { process.stdout.write(`lessons: no open recurring (>=${opt.minCount}×) verified candidates to promote${excludedNote}\n`); writeRegSection(); process.exit(0) }
+  process.stdout.write(`lessons: ${candidates.length} open candidate(s) passing the floor (verified + recurring, not yet retired)${excludedNote}. Challenge each before codifying:\n`)
   for (const l of candidates) {
     const status = !l.challenge ? 'UNCHALLENGED — needs skeptical review'
       : l.challenge.verdict === 'accept' ? `ACCEPTED by ${l.challenge.by || 'skeptical-evaluator'}${l.challenge.reason ? `: ${l.challenge.reason}` : ''}`
@@ -446,6 +542,12 @@ if (cmd === 'promote') {
       for (const r of reg.regressions) {
         if (Object.hasOwn(l.gate_history, r.gate)) process.stdout.write(`      [REGRESSION: ${r.gate} PASS→FAIL last_pass=${r.last_pass_ts} first_fail=${r.first_fail_ts} — .loop/runs 결정론 집계]\n`)
       }
+    }
+    // Retirement-candidate annotation (issue #6) — purely informational, same spirit as the REGRESSION
+    // annotation above: a signal for a human/skeptic to act on via `lessons invalidate`, never an
+    // automatic delete/invalidate.
+    if (l.clean_pass_count >= CLEAN_RETIRE_THRESHOLD) {
+      process.stdout.write(`      [RETIREMENT CANDIDATE: clean_pass_count=${l.clean_pass_count} — gate가 이 교훈 없이도 ${l.clean_pass_count}회 깨끗하게 통과함. superseded/무관해졌다면 "lessons invalidate"로 표시할 것]\n`)
     }
   }
   writeRegSection()
@@ -466,17 +568,20 @@ if (cmd === 'stats') {
   const verified = all.filter(l => l.verified)
   const recurring = all.filter(l => l.count >= 2)
   const retired = all.filter(l => l.retired)
-  // open_candidates = the ACTIONABLE promotion backlog: verified + recurring, and in NEITHER terminal
-  // state — not already retired (codified, out of the pool) and not rejected (skeptic decided no). This is
-  // what loop-doctor reports as "승격 후보"; it falls to 0 once every recurring lesson is either
-  // codified+retired or rejected, instead of the raw recurring count that never falls (a permanent
+  const invalidated = all.filter(l => l.invalid_at)
+  // open_candidates = the ACTIONABLE promotion backlog: verified + recurring, and in NONE of the
+  // terminal/excluded states — not already retired (codified, out of the pool), not invalidated (WRONG,
+  // issue #6 — same exclusion as promote's `candidates`, so this count never claims more "승격 후보"
+  // than `promote` would actually list), and not rejected (skeptic decided no). This is what loop-doctor
+  // reports as "승격 후보"; it falls to 0 once every recurring lesson is either codified+retired,
+  // invalidated, or rejected, instead of the raw recurring count that never falls (a permanent
   // false-nag pre-retire). A rejected lesson re-opens automatically if it recurs with changed content
   // (record clears the stale verdict), so excluding it here loses nothing.
-  const openCandidates = all.filter(l => l.verified && l.count >= 2 && !l.retired && !(l.challenge && l.challenge.verdict === 'reject'))
+  const openCandidates = all.filter(l => l.verified && l.count >= 2 && !l.retired && !l.invalid_at && !(l.challenge && l.challenge.verdict === 'reject'))
   const iters = verified.flatMap(l => l.iterations)
   const a = avg(iters)
   process.stdout.write('=== lessons stats ===\n')
-  process.stdout.write(`total=${all.length} verified=${verified.length} recurring(>=2x)=${recurring.length} retired=${retired.length} open_candidates=${openCandidates.length} total_recurrences=${all.reduce((x, l) => x + l.count, 0)}\n`)
+  process.stdout.write(`total=${all.length} verified=${verified.length} recurring(>=2x)=${recurring.length} retired=${retired.length} invalidated=${invalidated.length} open_candidates=${openCandidates.length} total_recurrences=${all.reduce((x, l) => x + l.count, 0)}\n`)
   process.stdout.write(`by_category: engineering=${byCategory.engineering} domain=${byCategory.domain}\n`)
   process.stdout.write(`avg_iterations_to_green=${a == null ? 'n/a' : a.toFixed(2)} (over ${iters.length} verified convergence(s))\n`)
   const top = all.slice().sort((a, b) => b.count - a.count).slice(0, 5)

--- a/tools/loop-engine/test/lessons-hygiene.test.sh
+++ b/tools/loop-engine/test/lessons-hygiene.test.sh
@@ -1,0 +1,231 @@
+#!/usr/bin/env bash
+# Regression test for lessons.mjs corpus hygiene (issue #6, ported from glucofit-partners Linear
+# BAC-571): `invalid_at`/`superseded_by` invalidation vs the pre-existing `retired` (right-but-unused),
+# `clean_pass_count` (an exit-code-derived counter via the new `mark-clean` command), and promote's
+# informational retirement-candidate annotation.
+#
+# The core fail-closed invariant this locks down: an INVALIDATED lesson (marked WRONG, as opposed to
+# `retired` which means right-but-superseded) must never surface from recall (even if verified) nor from
+# promote (candidates listing / --codify) nor inflate stats' "open_candidates" (loop-doctor's "승격 후보"
+# count) beyond what promote would actually list.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$HERE/../../.."
+LESSONS="$ROOT/tools/loop-engine/bin/lessons.mjs"
+
+fail() { echo "FAIL: $1"; exit 1; }
+[ -f "$LESSONS" ] || fail "lessons.mjs not found at $LESSONS"
+
+DIR="$(mktemp -d "${TMPDIR:-/tmp}/tmp.XXXXXXXX")" || fail "mktemp -d failed"
+DIR2="$(mktemp -d "${TMPDIR:-/tmp}/tmp.XXXXXXXX")" || fail "mktemp -d failed"
+DIR3="$(mktemp -d "${TMPDIR:-/tmp}/tmp.XXXXXXXX")" || fail "mktemp -d failed"
+trap 'rm -rf "$DIR" "$DIR2" "$DIR3"' EXIT
+L() { node "$LESSONS" "$@" --lessons "$DIR"; }
+L2() { node "$LESSONS" "$@" --lessons "$DIR2"; }
+L3() { node "$LESSONS" "$@" --lessons "$DIR3"; }
+# extract the 16-hex id from a `promote` listing line naming a specific title (avoids brittle "seen ids"
+# bookkeeping — each lesson below gets a unique title instead).
+id_for() { # $1 = lessons dir  $2 = title substring
+  node "$LESSONS" promote --min-count 1 --lessons "$1" 2>/dev/null | grep -F "$2" | grep -oE '[0-9a-f]{16}' | head -1
+}
+
+# ==== 1) coerce-time hygiene: malformed invalid_at/invalid_reason/superseded_by/invalidated_by/
+#         clean_pass_count on a hand-edited/merge-corrupted file must all coerce to safe defaults
+#         (fail closed — a non-string invalid_at must NOT be treated as invalidated). ====
+cat > "$DIR/aaaa000000000001.json" <<'EOF'
+{ "id": "aaaa000000000001", "signature": ["coerce hygiene probe"], "title": "coerce hygiene probe",
+  "fix": "", "source": "manual", "category": "engineering", "verified": true, "count": 5,
+  "iterations": [], "gate_history": {},
+  "invalid_at": true, "invalid_reason": 123, "superseded_by": 456, "invalidated_by": ["x"],
+  "clean_pass_count": -3,
+  "first_seen": "2026-01-01T00:00:00.000Z", "last_seen": "2026-01-01T00:00:00.000Z" }
+EOF
+SOUT1="$(L stats 2>&1)"
+printf '%s' "$SOUT1" | grep -q "invalidated=0" || fail "malformed (non-string) invalid_at must coerce to NOT invalidated: $SOUT1"
+printf '%s' "$SOUT1" | grep -q "^total=1 " || fail "coerce probe must still count as a normal lesson: $SOUT1"
+POUT1="$(L promote --min-count 1 2>&1)"
+printf '%s' "$POUT1" | grep -q "coerce hygiene probe" || fail "coerced-clean lesson must still appear as an open candidate: $POUT1"
+printf '%s' "$POUT1" | grep -q "RETIREMENT CANDIDATE" && fail "negative clean_pass_count must coerce to 0, not trip the >=5 retirement annotation: $POUT1"
+
+# ==== 2) invalidate: usage errors (fail closed) ====
+rc=0; L invalidate >/dev/null 2>&1 || rc=$?
+[ "$rc" = "2" ] || fail "invalidate with no --id must exit 2; got rc=$rc"
+
+rc=0; ERR="$(L invalidate --id doesnotexist1234 2>&1 >/dev/null)" || rc=$?
+[ "$rc" = "2" ] || fail "invalidate on a nonexistent id must exit 2; got rc=$rc"
+printf '%s' "$ERR" | grep -q "no lesson with id doesnotexist1234" || fail "invalidate notfound must name the id: $ERR"
+
+# ==== 3) invalidate: success path sets invalid_at/invalid_reason/invalidated_by, leaves superseded_by
+#         empty when --superseded-by is omitted. ====
+L record --signature "FAIL: hygiene widget-inv" --verified --title "hygiene lesson widget-inv" >/dev/null || fail "record widget-inv failed"
+WID="$(id_for "$DIR" "hygiene lesson widget-inv")"
+[ -n "$WID" ] || fail "could not extract widget-inv id"
+OUT3="$(L invalidate --id "$WID" --reason "root cause was misattributed" --by "paul" 2>&1)"
+rc=$?
+[ "$rc" = "0" ] || fail "invalidate success path must exit 0; got rc=$rc: $OUT3"
+printf '%s' "$OUT3" | grep -q "invalidated $WID — root cause was misattributed" || fail "invalidate confirmation must name id+reason: $OUT3"
+grep -q '"invalid_reason": "root cause was misattributed"' "$DIR/$WID.json" || fail "invalid_reason not persisted: $(cat "$DIR/$WID.json")"
+grep -q '"invalidated_by": "paul"' "$DIR/$WID.json" || fail "invalidated_by not persisted: $(cat "$DIR/$WID.json")"
+grep -q '"superseded_by": ""' "$DIR/$WID.json" || fail "superseded_by must stay empty when omitted: $(cat "$DIR/$WID.json")"
+grep -qE '"invalid_at": "[^"]+"' "$DIR/$WID.json" || fail "invalid_at must be set to a non-empty timestamp: $(cat "$DIR/$WID.json")"
+grep -q '"invalid_at": ""' "$DIR/$WID.json" && fail "invalid_at must not be empty after invalidate: $(cat "$DIR/$WID.json")"
+
+# ==== 4) invalidate: --by defaults to "human" when omitted, --reason defaults to "" ====
+L record --signature "FAIL: hygiene gadget-inv2" --verified --title "hygiene lesson gadget-inv2" >/dev/null || fail "record gadget-inv2 failed"
+GID="$(id_for "$DIR" "hygiene lesson gadget-inv2")"
+[ -n "$GID" ] || fail "could not extract gadget-inv2 id"
+OUT4="$(L invalidate --id "$GID" 2>&1)"
+[ $? = 0 ] || fail "invalidate with no --reason/--by must still succeed: $OUT4"
+printf '%s' "$OUT4" | grep -q "invalidated $GID$" || fail "invalidate confirmation with no reason must not append ' — ': $OUT4"
+grep -q '"invalidated_by": "human"' "$DIR/$GID.json" || fail "invalidated_by must default to human: $(cat "$DIR/$GID.json")"
+grep -q '"invalid_reason": ""' "$DIR/$GID.json" || fail "invalid_reason must default to empty: $(cat "$DIR/$GID.json")"
+
+# ==== 5) invalidate --superseded-by: a dangling (nonexistent) target is refused, fail closed — the
+#         lesson being invalidated must NOT be mutated. ====
+L record --signature "FAIL: hygiene super-target-missing" --verified --title "hygiene lesson super-target-missing" >/dev/null || fail "record super-target-missing failed"
+SID="$(id_for "$DIR" "hygiene lesson super-target-missing")"
+[ -n "$SID" ] || fail "could not extract super-target-missing id"
+rc=0; ERR5="$(L invalidate --id "$SID" --superseded-by "nonexistentxxxxxx" 2>&1 >/dev/null)" || rc=$?
+[ "$rc" = "2" ] || fail "invalidate --superseded-by dangling target must exit 2; got rc=$rc"
+printf '%s' "$ERR5" | grep -q "superseded-by target nonexistentxxxxxx does not exist" || fail "must name the missing superseded-by target: $ERR5"
+# a fresh (never-invalidated) lesson file has no invalid_at key at all — coerce() only ADDS it as ''
+# on read, it isn't persisted until a write happens. A refused invalidate must not trigger that write.
+grep -q '"invalid_at"' "$DIR/$SID.json" && fail "a refused invalidate must NOT mutate the lesson (invalid_at key must not appear): $(cat "$DIR/$SID.json")"
+
+# ==== 6) invalidate --superseded-by: an existing target succeeds and is recorded. ====
+L record --signature "FAIL: hygiene super-source" --verified --title "hygiene lesson super-source" >/dev/null || fail "record super-source failed"
+SUP="$(id_for "$DIR" "hygiene lesson super-source")"
+[ -n "$SUP" ] || fail "could not extract super-source id"
+L record --signature "FAIL: hygiene super-old" --verified --title "hygiene lesson super-old" >/dev/null || fail "record super-old failed"
+OLD="$(id_for "$DIR" "hygiene lesson super-old")"
+[ -n "$OLD" ] || fail "could not extract super-old id"
+OUT6="$(L invalidate --id "$OLD" --superseded-by "$SUP" --reason "replaced by a newer lesson" 2>&1)"
+[ $? = 0 ] || fail "invalidate --superseded-by existing target must succeed: $OUT6"
+printf '%s' "$OUT6" | grep -q "superseded by $SUP" || fail "confirmation must name the superseder: $OUT6"
+grep -q "\"superseded_by\": \"$SUP\"" "$DIR/$OLD.json" || fail "superseded_by not persisted: $(cat "$DIR/$OLD.json")"
+
+# ==== 7) recall(): an invalidated lesson is NEVER recalled, even though it is verified — checked ahead
+#         of the verified check. stdout stays empty/exit 0 (unchanged miss contract); stderr names it
+#         INVALIDATED with the reason and the superseded-by pointer. ====
+L record --signature "FAIL: hygiene recall superseder" --verified --title "hygiene lesson recall superseder" >/dev/null || fail "record recall superseder failed"
+RSUP="$(id_for "$DIR" "hygiene lesson recall superseder")"
+[ -n "$RSUP" ] || fail "could not extract recall superseder id"
+L record --signature "FAIL: hygiene recall probe" --verified --title "hygiene lesson recall probe" >/dev/null || fail "record recall probe failed"
+L invalidate --id "$(id_for "$DIR" "hygiene lesson recall probe")" --reason "stale" --superseded-by "$RSUP" >/dev/null || fail "invalidate recall probe failed"
+OUT7="$(mktemp "${TMPDIR:-/tmp}/tmp.XXXXXXXX")"; ERR7="$(mktemp "${TMPDIR:-/tmp}/tmp.XXXXXXXX")"
+L recall --signature "FAIL: hygiene recall probe" >"$OUT7" 2>"$ERR7"
+rc=$?
+[ "$rc" = "0" ] || fail "recall of an invalidated lesson must still exit 0; got rc=$rc"
+[ -s "$OUT7" ] && fail "recall of an invalidated lesson must NOT write to stdout: $(cat "$OUT7")"
+grep -q "INVALIDATED" "$ERR7" || fail "recall miss on an invalidated lesson must say INVALIDATED: $(cat "$ERR7")"
+grep -q "stale" "$ERR7" || fail "recall INVALIDATED stderr must carry the reason: $(cat "$ERR7")"
+grep -q "superseded by $RSUP" "$ERR7" || fail "recall INVALIDATED stderr must name the superseder: $(cat "$ERR7")"
+rm -f "$OUT7" "$ERR7"
+
+# ==== 8) mark-clean: usage error when --gate is missing ====
+rc=0; L mark-clean >/dev/null 2>&1 || rc=$?
+[ "$rc" = "2" ] || fail "mark-clean with no --gate must exit 2; got rc=$rc"
+
+echo "PASS §1-8 (invalidate/recall/coerce hygiene)"
+
+# ================================================================================================
+# ==== 9) promote()/stats(): invalidated lessons are excluded from candidates + --codify, counted
+#         separately from retired in the excluded-note, and never inflate stats' open_candidates
+#         beyond what promote would list — even a PREVIOUSLY-ACCEPTED lesson disappears once
+#         invalidated (the safety-critical case: a challenge --verdict accept does NOT protect a
+#         lesson later discovered to be wrong). ====
+for i in 1 2 3; do L2 record --signature "FAIL: hygiene pool lesson A" --verified --title "hygiene pool lesson A" --gate "pnpm verify" >/dev/null || fail "record pool A #$i failed"; done
+LA="$(id_for "$DIR2" "hygiene pool lesson A")"
+[ -n "$LA" ] || fail "could not extract pool lesson A id"
+
+for i in 1 2 3; do L2 record --signature "FAIL: hygiene pool lesson B (accept then invalidate)" --verified --title "hygiene pool lesson B (accept then invalidate)" >/dev/null || fail "record pool B #$i failed"; done
+LB="$(id_for "$DIR2" "hygiene pool lesson B (accept then invalidate)")"
+[ -n "$LB" ] || fail "could not extract pool lesson B id"
+L2 challenge --id "$LB" --verdict accept --reason "looked solid at the time" >/dev/null || fail "challenge accept B failed"
+L2 invalidate --id "$LB" --reason "later found to be a red herring" >/dev/null || fail "invalidate accepted lesson B failed"
+
+for i in 1 2 3; do L2 record --signature "FAIL: hygiene pool lesson C (retired)" --verified --title "hygiene pool lesson C (retired)" >/dev/null || fail "record pool C #$i failed"; done
+LC="$(id_for "$DIR2" "hygiene pool lesson C (retired)")"
+[ -n "$LC" ] || fail "could not extract pool lesson C id"
+L2 challenge --id "$LC" --verdict accept --reason "real fix" >/dev/null || fail "challenge accept C failed"
+L2 retire --id "$LC" --ref "CLAUDE.md#hygiene-test" >/dev/null || fail "retire C failed"
+
+POUT9="$(L2 promote 2>&1)"
+printf '%s' "$POUT9" | grep -q "1 already retired, 1 invalidated — excluded" || fail "promote excluded-note must count retired and invalidated separately: $POUT9"
+printf '%s' "$POUT9" | grep -q "hygiene pool lesson A" || fail "non-excluded lesson A must still be listed: $POUT9"
+printf '%s' "$POUT9" | grep -q "hygiene pool lesson B" && fail "invalidated lesson B must NOT appear in the candidates listing: $POUT9"
+printf '%s' "$POUT9" | grep -q "hygiene pool lesson C" && fail "retired lesson C must NOT appear in the candidates listing: $POUT9"
+
+# --codify: B was ACCEPTED before being invalidated — this is the safety-critical assertion. It must
+# still be excluded (invalidate overrides a prior accept for codification purposes).
+COUT9="$(L2 promote --codify 2>&1)"
+printf '%s' "$COUT9" | grep -q "hygiene pool lesson B" && fail "an invalidated (even if previously accepted) lesson must NEVER reach --codify: $COUT9"
+printf '%s' "$COUT9" | grep -q "hygiene pool lesson A" && fail "lesson A (never challenged) must not be codified either: $COUT9"
+
+# stats: invalidated=1 (B), retired=1 (C), and open_candidates must NOT count the invalidated B —
+# only A is truly open (C is retired, terminal).
+SOUT9="$(L2 stats 2>&1)"
+printf '%s' "$SOUT9" | grep -q "retired=1 invalidated=1" || fail "stats summary must show retired=1 invalidated=1: $SOUT9"
+printf '%s' "$SOUT9" | grep -q "open_candidates=1" || fail "stats open_candidates must exclude the invalidated lesson (only A is open): $SOUT9"
+
+echo "PASS §9 (promote/stats invalidated exclusion, incl. previously-accepted lesson)"
+
+# ================================================================================================
+# ==== 10) mark-clean: bumps clean_pass_count only for lessons attributed (gate_history) to --gate,
+#          and only if they are NOT invalidated and NOT retired. record()'s fail-recurrence path
+#          resets the counter to 0. ====
+L3 record --signature "FAIL: hygiene mc lesson-match-1" --verified --title "hygiene mc lesson-match-1" --gate "pnpm verify" >/dev/null || fail "record mc match-1 failed"
+MC1="$(id_for "$DIR3" "hygiene mc lesson-match-1")"
+L3 record --signature "FAIL: hygiene mc lesson-match-2" --verified --title "hygiene mc lesson-match-2" --gate "pnpm verify" >/dev/null || fail "record mc match-2 failed"
+MC2="$(id_for "$DIR3" "hygiene mc lesson-match-2")"
+L3 record --signature "FAIL: hygiene mc lesson-other-gate" --verified --title "hygiene mc lesson-other-gate" --gate "pnpm typecheck" >/dev/null || fail "record mc other-gate failed"
+MC3="$(id_for "$DIR3" "hygiene mc lesson-other-gate")"
+L3 record --signature "FAIL: hygiene mc lesson-invalidated" --verified --title "hygiene mc lesson-invalidated" --gate "pnpm verify" >/dev/null || fail "record mc invalidated failed"
+MC4="$(id_for "$DIR3" "hygiene mc lesson-invalidated")"
+L3 invalidate --id "$MC4" --reason "not real" >/dev/null || fail "invalidate mc4 failed"
+for i in 1 2 3; do L3 record --signature "FAIL: hygiene mc lesson-retired" --verified --title "hygiene mc lesson-retired" --gate "pnpm verify" >/dev/null || fail "record mc retired #$i failed"; done
+MC5="$(id_for "$DIR3" "hygiene mc lesson-retired")"
+L3 challenge --id "$MC5" --verdict accept --reason "real fix" >/dev/null || fail "challenge mc5 failed"
+L3 retire --id "$MC5" --ref "CLAUDE.md#hygiene-mc" >/dev/null || fail "retire mc5 failed"
+
+OUT10="$(L3 mark-clean --gate "pnpm verify" 2>&1)"
+[ $? = 0 ] || fail "mark-clean must exit 0: $OUT10"
+printf '%s' "$OUT10" | grep -q "marked 2 lesson(s) clean for gate pnpm verify" || fail "mark-clean must mark exactly match-1 and match-2 (not other-gate/invalidated/retired): $OUT10"
+grep -q '"clean_pass_count": 1' "$DIR3/$MC1.json" || fail "match-1 clean_pass_count must be 1: $(cat "$DIR3/$MC1.json")"
+grep -q '"clean_pass_count": 1' "$DIR3/$MC2.json" || fail "match-2 clean_pass_count must be 1: $(cat "$DIR3/$MC2.json")"
+# MC3/MC4/MC5 must NOT be marked (still 0, or the key is simply absent — it's only persisted once a
+# lesson is written; a never-marked file may still lack the key entirely from `record` alone). Assert
+# the negative (no "1") rather than the positive default, since presence of the key isn't guaranteed.
+grep -q '"clean_pass_count": 1' "$DIR3/$MC3.json" && fail "other-gate lesson must NOT be marked: $(cat "$DIR3/$MC3.json")"
+grep -q '"clean_pass_count": 0' "$DIR3/$MC4.json" || fail "invalidated lesson must NOT be marked even though it matches the gate: $(cat "$DIR3/$MC4.json")"
+grep -q '"clean_pass_count": 0' "$DIR3/$MC5.json" || fail "retired lesson must NOT be marked even though it matches the gate: $(cat "$DIR3/$MC5.json")"
+
+# a SECOND clean gate pass accumulates (2), proving this is a genuine counter, not a flag.
+L3 mark-clean --gate "pnpm verify" >/dev/null || fail "second mark-clean failed"
+grep -q '"clean_pass_count": 2' "$DIR3/$MC1.json" || fail "match-1 clean_pass_count must accumulate to 2: $(cat "$DIR3/$MC1.json")"
+
+# fail-recurrence: match-1 recurs (record called again on the same signature) -> clean_pass_count
+# resets to 0, even though the gate history / count keeps growing (a recurrence is NOT stability).
+L3 record --signature "FAIL: hygiene mc lesson-match-1" --verified --title "hygiene mc lesson-match-1" --gate "pnpm verify" >/dev/null || fail "re-record match-1 (recurrence) failed"
+grep -q '"clean_pass_count": 0' "$DIR3/$MC1.json" || fail "a recurrence must reset clean_pass_count to 0: $(cat "$DIR3/$MC1.json")"
+grep -q '"count": 2' "$DIR3/$MC1.json" || fail "the recurrence must still increment count: $(cat "$DIR3/$MC1.json")"
+
+echo "PASS §10 (mark-clean selective marking + fail-recurrence reset)"
+
+# ================================================================================================
+# ==== 11) promote(): the informational RETIREMENT CANDIDATE annotation fires only at
+#          clean_pass_count >= CLEAN_RETIRE_THRESHOLD (5), and is purely informational — it does not
+#          remove the lesson from the listing or touch invalid_at/retired. ====
+for i in 1 2 3; do L3 record --signature "FAIL: hygiene mc lesson-clean5" --verified --title "hygiene mc lesson-clean5" --gate "pnpm build" >/dev/null || fail "record clean5 #$i failed"; done
+for i in 1 2 3 4; do L3 record --signature "FAIL: hygiene mc lesson-clean4" --verified --title "hygiene mc lesson-clean4" --gate "pnpm lint" >/dev/null || fail "record clean4 #$i failed"; done
+for i in 1 2 3 4 5; do L3 mark-clean --gate "pnpm build" >/dev/null || fail "mark-clean build #$i failed"; done
+for i in 1 2 3 4; do L3 mark-clean --gate "pnpm lint" >/dev/null || fail "mark-clean lint #$i failed"; done
+
+POUT11="$(L3 promote 2>&1)"
+printf '%s' "$POUT11" | grep -q "clean_pass_count=5" || fail "clean5 (>=threshold) must be annotated RETIREMENT CANDIDATE: $POUT11"
+printf '%s' "$POUT11" | grep -q "clean_pass_count=4" && fail "clean4 (below threshold) must NOT be annotated: $POUT11"
+printf '%s' "$POUT11" | grep -q "hygiene mc lesson-clean4" || fail "clean4 must still be listed as an ordinary open candidate: $POUT11"
+grep -q '"invalid_at": ""' "$DIR3/$(id_for "$DIR3" "hygiene mc lesson-clean5").json" || fail "the retirement-candidate annotation must be informational only — it must NOT invalidate the lesson"
+
+echo "PASS: lessons hygiene (issue #6) — invalidate/mark-clean commands, coerce-time defaults, recall/promote/codify fail-closed exclusion (incl. previously-accepted lessons), stats open_candidates consistency, retirement-candidate annotation"
+exit 0


### PR DESCRIPTION
## Summary

`.loop/lessons` had `verified`/`retired` but no way to say a lesson is
simply **wrong** (as opposed to `retired` = right-but-superseded), and no
exit-code-derived signal for "this gate has passed cleanly without this
lesson's fix in a while, maybe it's no longer needed." This closes both
gaps, matching the spec in the issue:

- **Schema**: `invalid_at` / `invalid_reason` / `superseded_by` /
  `invalidated_by` / `clean_pass_count`, all coerced to safe defaults on
  read (fail closed — malformed values never falsely mark a lesson
  invalidated).
- **`lessons invalidate --id <key> [--reason] [--superseded-by <id2>] [--by]`**:
  marks a lesson WRONG. Fail-closed usage errors for a missing/nonexistent
  `--id` and a dangling `--superseded-by` target (the target must already
  exist).
- **`lessons mark-clean --gate "<verify cmd>"`**: bumps `clean_pass_count`
  on every lesson attributed (via `gate_history`) to that gate that is
  neither invalidated nor retired. `record`'s fail-recurrence path resets
  the counter to 0 — a recurrence means the lesson isn't stable yet.
- **`recall`**: an invalidated lesson is never recalled, even if
  `verified` — checked ahead of the verified check.
- **`promote`**: invalidated lessons are excluded from the candidates
  listing and `--codify` (with a defense-in-depth re-check on the
  `--codify` filter itself, since this is the single most safety-critical
  path — a previously **accepted** lesson that later gets invalidated must
  still disappear from `--codify`, and is tested explicitly). The listing
  note now reports retired/invalidated counts separately, and a
  `clean_pass_count >= 5` (`CLEAN_RETIRE_THRESHOLD`) lesson gets an
  informational `[RETIREMENT CANDIDATE: ...]` annotation — never an
  auto-invalidate.
- **`stats`**: adds `invalidated=<n>` to the summary line, and
  `open_candidates` now also excludes invalidated lessons so it never
  reports more "승격 후보" than `promote` would actually list (this was a
  real gap: without it, stats and promote would disagree on an invalidated
  lesson).

Ported from glucofit-partners Linear BAC-571.

## Test plan

- [x] New hermetic test `tools/loop-engine/test/lessons-hygiene.test.sh`
      (pure bash+node, temp dirs, same idiom as `lessons-retire.test.sh`)
      covers: coerce-time hygiene for malformed new fields, `invalidate`
      usage errors + success + `--superseded-by` validation
      (dangling/valid target), `recall` exclusion of invalidated lessons
      (stderr message + reason + superseded-by), `promote`/`--codify`
      exclusion of invalidated lessons **including a previously-accepted
      one**, `stats` `invalidated=`/`open_candidates` consistency,
      `mark-clean` selective marking (gate match, excludes
      invalidated/retired) + `record`'s fail-recurrence reset, and the
      `RETIREMENT CANDIDATE` annotation threshold (5 fires, 4 doesn't).
- [x] Full regression suite green:

```
$ bash tools/loop-engine/test/run.sh
...
loop-engine selftest: 17/17 passed
```

- [x] `claude plugin validate --strict tools/loop-engine` → `✔ Validation passed`

Closes #6