### PR TITLE
feat(loop-fix): FAIL 채널 lesson 자동 수집 (#10)

### DIFF
--- a/tools/loop-engine/bin/lessons.mjs
+++ b/tools/loop-engine/bin/lessons.mjs
@@ -19,7 +19,7 @@
 //
 // Commands:
 //   lessons record  --signature-file <verdict.txt> | --signature "<text>"
-//                   [--fix "<what fixed it>"] [--title "<t>"] [--source loop-fix|eval-gate|diagnose|review|manual]
+//                   [--fix "<what fixed it>"] [--title "<t>"] [--source loop-fix|loop-fix-fail|eval-gate|diagnose|review|manual]
 //                   [--category engineering|domain] [--iterations N] [--verified] [--gate "<verify cmd>"] [--lessons <dir>]
 //                   --gate attributes this recurrence to a verify gate (BAC-631). Both this key and the
 //                   ledger's payload.cmd are normalized through lib/regression-signals normalizeGateKey

--- a/tools/loop-engine/bin/loop-fix.sh
+++ b/tools/loop-engine/bin/loop-fix.sh
@@ -282,6 +282,17 @@ start_watchdog() {
 
 log() { printf '%s\n' "$*" | tee -a "$HISTORY"; }
 
+# Phase 3 fail-channel (issue #10): record an UNVERIFIED lesson when the loop gives up without
+# ever reaching PASS — ground truth never confirmed a fix, so this is a signal, not a verified
+# lesson (record()'s existing merge logic upgrades it to verified=true if a later run with the
+# same signature DOES converge). No-op if --lessons wasn't given, or FIRST_VERDICT was never
+# captured (e.g. the very first verify hung before any verdict landed).
+record_fail_lesson() {
+  [ -n "$LESSONS" ] && [ -s "$FIRST_VERDICT" ] && [ -x "$LESSONS_BIN" ] || return 0
+  "$LESSONS_BIN" record --signature-file "$FIRST_VERDICT" --source loop-fix-fail --iterations "$iter" --lessons "$LESSONS" >/dev/null 2>&1 \
+    && log "recorded an unverified fail-channel lesson to memory ($LESSONS)"
+}
+
 log "=== loop-fix start $(date '+%Y-%m-%d %H:%M:%S') ==="
 log "verify: $VERIFY"
 log "fix:    ${FIX:-<none — verify-only mode>}"
@@ -350,6 +361,7 @@ while [ "$iter" -lt "$MAX_ITER" ]; do
   if [ -f "$WATCHDOG_FIRED" ]; then
     wreason="$(head -n1 "$WATCHDOG_FIRED" 2>/dev/null)"
     log "iter $iter: ${wreason:-TIMEOUT} — material-progress watchdog fired. Aborting."
+    record_fail_lesson
     log "=== loop-fix done: ${wreason:-TIMEOUT} ==="
     exit 1
   fi
@@ -425,6 +437,7 @@ while [ "$iter" -lt "$MAX_ITER" ]; do
   prev_fp="$fp"; prev_counts="$counts"
   if [ "$stall_count" -ge "$STALL" ]; then
     log "iter $iter: STALLED — identical failure fingerprint and no count progress ${stall_count}x running. Aborting."
+    record_fail_lesson
     log "=== loop-fix done: STALLED ==="
     exit 1
   fi
@@ -434,6 +447,7 @@ while [ "$iter" -lt "$MAX_ITER" ]; do
     elapsed=$(( $(date +%s) - start_epoch ))
     if [ "$elapsed" -ge "$BUDGET" ]; then
       log "iter $iter: budget ${BUDGET}s exhausted (${elapsed}s). Aborting."
+      record_fail_lesson
       log "=== loop-fix done: BUDGET ==="
       exit 1
     fi
@@ -442,6 +456,7 @@ while [ "$iter" -lt "$MAX_ITER" ]; do
   # ---- verify-only mode: no fixer, just report and stop ----
   if [ -z "$FIX" ]; then
     log "no --fix given; verify-only mode. Stopping at first FAIL."
+    record_fail_lesson
     log "=== loop-fix done: FAIL (verify-only) ==="
     exit 1
   fi
@@ -496,6 +511,7 @@ while [ "$iter" -lt "$MAX_ITER" ]; do
   if [ -f "$WATCHDOG_FIRED" ]; then
     wreason="$(head -n1 "$WATCHDOG_FIRED" 2>/dev/null)"
     log "iter $iter: ${wreason:-TIMEOUT} — material-progress watchdog fired during the fixer. Aborting."
+    record_fail_lesson
     log "=== loop-fix done: ${wreason:-TIMEOUT} ==="
     exit 1
   fi
@@ -511,5 +527,6 @@ while [ "$iter" -lt "$MAX_ITER" ]; do
 done
 
 log "reached max-iter=$MAX_ITER without PASS. Aborting."
+record_fail_lesson
 log "=== loop-fix done: MAX-ITER ==="
 exit 1

--- a/tools/loop-engine/test/loop-fix-fail-channel.test.sh
+++ b/tools/loop-engine/test/loop-fix-fail-channel.test.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# Regression test (issue #10): FAIL 채널 lesson 기록 — verdict FAIL로 수렴 못 하고 끝나는 경로
+# (STALLED/MAX-ITER/BUDGET/TIMEOUT-*/verify-only FAIL)도 --source=loop-fix-fail의 UNVERIFIED
+# lesson을 기록해야 한다(성공-only 기록의 학습 신호 유실 방지). 핵심 fail-closed 경계: INFRA와
+# PROTECTED-VIOLATION은 코드 실패 시그니처가 아니므로 절대 기록되면 안 된다 — 전부 기록하면
+# 인프라 노이즈로 lessons 코퍼스가 오염된다.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+LOOPFIX="$HERE/../bin/loop-fix.sh"
+
+fail() { echo "FAIL: $1"; exit 1; }
+[ -x "$LOOPFIX" ] || fail "loop-fix.sh not executable at $LOOPFIX"
+
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/tmp.XXXXXXXX")" || fail "mktemp -d failed"
+trap 'rm -rf "$WORK"' EXIT
+
+lessons_file_count() { ls "$1"/*.json 2>/dev/null | wc -l | tr -d ' '; }
+
+# ── case 1: MAX-ITER로 끝나는 실행 → unverified fail-channel lesson 기록 ────────────────────
+C="$WORK/c1"; mkdir -p "$C"; cd "$C" || fail "cd c1"
+cat > fake-verify.sh <<'EOF'
+#!/bin/sh
+echo "FAILED src/example.test.ts > max-iter fail-channel test"
+exit 1
+EOF
+# --stall을 --max-iter보다 크게 둬서 STALLED가 아니라 MAX-ITER로 끝나게 한다(고정 fingerprint여도).
+"$LOOPFIX" --verify 'sh fake-verify.sh' --fix ':' --max-iter 2 --stall 5 --lessons lessons >/dev/null 2>&1
+code=$?
+[ "$code" -eq 1 ] || fail "case1: expected exit 1 via max-iter, got $code"
+grep -q "MAX-ITER" .loop/history.log || fail "case1: expected the loop to reach MAX-ITER"
+[ "$(lessons_file_count lessons)" -eq 1 ] || fail "case1: expected exactly 1 lesson file recorded"
+f="$(ls lessons/*.json)"
+grep -q '"source": "loop-fix-fail"' "$f" || fail "case1: expected source=loop-fix-fail"
+grep -q '"verified": false' "$f" || fail "case1: expected verified=false (never converged)"
+
+# ── case 2: STALLED로 끝나는 실행 → unverified fail-channel lesson 기록 ─────────────────────
+C="$WORK/c2"; mkdir -p "$C"; cd "$C" || fail "cd c2"
+cat > fake-verify.sh <<'EOF'
+#!/bin/sh
+echo "Tests  3 failed | 7 passed (10)"
+echo "FAILED src/example.test.ts > stalled fail-channel test"
+exit 1
+EOF
+"$LOOPFIX" --verify 'sh fake-verify.sh' --fix ':' --stall 3 --max-iter 6 --lessons lessons >/dev/null 2>&1
+code=$?
+[ "$code" -eq 1 ] || fail "case2: expected exit 1 via STALLED, got $code"
+grep -q "STALLED" .loop/history.log || fail "case2: expected the loop to STALL"
+[ "$(lessons_file_count lessons)" -eq 1 ] || fail "case2: expected exactly 1 lesson file recorded"
+f="$(ls lessons/*.json)"
+grep -q '"source": "loop-fix-fail"' "$f" || fail "case2: expected source=loop-fix-fail"
+grep -q '"verified": false' "$f" || fail "case2: expected verified=false (never converged)"
+
+# ── case 3: INFRA로 끝나는 실행 → 기록되면 안 된다(fail-closed 핵심 경계) ───────────────────
+C="$WORK/c3"; mkdir -p "$C"; cd "$C" || fail "cd c3"
+cat > fake-verify.sh <<'EOF'
+#!/bin/sh
+echo "Error response from daemon: driver failed programming external connectivity: port is already allocated"
+exit 1
+EOF
+"$LOOPFIX" --verify 'sh fake-verify.sh' --fix 'touch fixer-ran' --infra-retries 2 --max-iter 10 --lessons lessons >/dev/null 2>&1
+code=$?
+[ "$code" -eq 1 ] || fail "case3: expected exit 1 via INFRA cap, got $code"
+grep -q "done: INFRA" .loop/history.log || fail "case3: expected INFRA abort marker"
+[ "$(lessons_file_count lessons)" -eq 0 ] || fail "case3: INFRA must NOT record a lesson (infra noise pollution)"
+
+# ── case 4: PROTECTED-VIOLATION으로 끝나는 실행 → 기록되면 안 된다 ─────────────────────────
+C="$WORK/c4"; mkdir -p "$C"; cd "$C" || fail "cd c4"
+cat > fake-verify.sh <<'EOF'
+#!/bin/sh
+echo "FAILED src/app.test.ts > protected violation fail-channel test"
+exit 1
+EOF
+echo "original" > guarded.txt
+"$LOOPFIX" --verify 'sh fake-verify.sh' --fix 'echo tampered >> guarded.txt' --protect 'guarded.txt' --max-iter 5 --stall 10 --lessons lessons >/dev/null 2>&1
+code=$?
+[ "$code" -eq 3 ] || fail "case4: expected exit 3 via PROTECTED-VIOLATION, got $code"
+grep -q "PROTECTED-VIOLATION" .loop/history.log || fail "case4: expected PROTECTED-VIOLATION abort marker"
+[ "$(lessons_file_count lessons)" -eq 0 ] || fail "case4: PROTECTED-VIOLATION must NOT record a lesson (fixer misbehavior, not a failure signature)"
+
+# ── case 5: 같은 실패가 나중에 PASS로 수렴하면 기존 fail-channel 레코드가 갱신된다 ──────────
+# (count 증가 + verified=false -> true 전환) — record()의 기존 병합 로직이 자연히 처리.
+C="$WORK/c5"; mkdir -p "$C"; cd "$C" || fail "cd c5"
+cat > fake-verify.sh <<'EOF'
+#!/bin/sh
+if [ -f fixed ]; then
+  echo ok
+  exit 0
+fi
+echo "FAILED src/example.test.ts > count-and-verify fail-channel test"
+exit 1
+EOF
+# 1회차: 절대 수렴 못 함(no-op fix) — MAX-ITER로 끝나며 unverified lesson count=1 기록.
+"$LOOPFIX" --verify 'sh fake-verify.sh' --fix ':' --max-iter 2 --stall 5 --lessons lessons >/dev/null 2>&1
+[ "$(lessons_file_count lessons)" -eq 1 ] || fail "case5: expected exactly 1 lesson after first (unconverged) run"
+f1="$(ls lessons/*.json)"
+grep -q '"count": 1' "$f1" || fail "case5: expected count=1 after first run"
+grep -q '"verified": false' "$f1" || fail "case5: expected verified=false after first run"
+
+# 2회차: 이번엔 fixer가 실제로 "fixed" 마커를 만들어 다음 verify가 PASS한다 — 같은 정규화
+# 시그니처(동일 FAIL 문구)라 같은 lesson id로 병합돼야 한다.
+"$LOOPFIX" --verify 'sh fake-verify.sh' --fix 'touch fixed' --max-iter 3 --stall 5 --lessons lessons >/dev/null 2>&1
+code=$?
+[ "$code" -eq 0 ] || fail "case5: expected PASS on second run, got exit $code"
+[ "$(lessons_file_count lessons)" -eq 1 ] || fail "case5: expected still exactly 1 lesson file (same signature, merged)"
+f2="$(ls lessons/*.json)"
+[ "$f1" = "$f2" ] || fail "case5: expected the SAME lesson id to be reused (same normalized signature)"
+grep -q '"count": 2' "$f2" || fail "case5: expected count to increase to 2 after later PASS convergence"
+grep -q '"verified": true' "$f2" || fail "case5: expected verified to flip true after later PASS convergence"
+
+echo "PASS: FAIL-channel lessons recorded on STALLED/MAX-ITER, withheld on INFRA/PROTECTED-VIOLATION, merged on later convergence"
+exit 0


### PR DESCRIPTION
## 요약

`loop-fix.sh`의 lesson 기록은 지금까지 최종 verify가 PASS로 수렴했을 때만 일어났다(`--verified` 경로). FAIL로 끝나는(수렴 못 하고 종료되는) 경로엔 기록 로직이 없어 성공-only 기록의 학습 신호가 유실되고 있었다.

이 PR은 verify가 PASS로 수렴하지 못하고 끝나는 다음 종료 지점에 `--source=loop-fix-fail`의 **UNVERIFIED** lesson 기록을 추가한다:

- STALLED
- MAX-ITER
- BUDGET (정규 경로 — infra-exempt 재시도 중의 BUDGET은 제외)
- TIMEOUT-IDLE / TIMEOUT-NO-PROGRESS (워치독, verify 구간과 fixer 구간 두 곳 모두)
- verify-only FAIL (`--fix` 없이 실행한 경우)

다음은 의도적으로 **기록하지 않는다**(코드 실패 시그니처가 아니거나 fixer 오작동이라 lessons 코퍼스를 오염시키므로):

- INFRA (전부 — 정규 경로든 infra-exempt 재시도 중 BUDGET이든)
- PROTECTED-VIOLATION (fixer의 reward-hacking 시도, 실패 시그니처 아님)
- VERDICT-RUN-ERROR (환경/사용법 오류)

같은 정규화 시그니처가 나중에 실제로 PASS로 수렴하면, `lessons.mjs`의 기존 `record()` 병합 로직이 자연히 처리해 count가 증가하고 `verified`가 `false → true`로 전환된다(별도 로직 불필요, 테스트로 증명).

## 변경 파일

- `tools/loop-engine/bin/loop-fix.sh`: `record_fail_lesson()` 헬퍼 추가 + 6개 종료 지점 직전에 호출 삽입
- `tools/loop-engine/bin/lessons.mjs`: 헤더 문서의 `--source` 값 목록에 `loop-fix-fail` 추가(문서만 — enum은 코드로 강제되지 않음)
- `tools/loop-engine/test/loop-fix-fail-channel.test.sh` (신규): MAX-ITER/STALLED 기록, INFRA/PROTECTED-VIOLATION 미기록(fail-closed 핵심 경계), 후속 PASS 수렴 시 병합(count 증가 + verified 전환)을 검증

## 검증 커맨드 실제 출력

```
$ bash tools/loop-engine/test/run.sh
...
PASS: FAIL-channel lessons recorded on STALLED/MAX-ITER, withheld on INFRA/PROTECTED-VIOLATION, merged on later convergence
...
loop-engine selftest: 18/18 passed

$ claude plugin validate --strict tools/loop-engine
Validating plugin manifest: /Users/paul/dev/paul-loop-10-fail-channel/tools/loop-engine/.claude-plugin/plugin.json

✔ Validation passed
```

Closes #10

---

**이 PR은 #6 PR(https://github.com/paulkim-lansik/paul-loop/pull/20) 위에 스택된 PR이다 — 그 PR이 먼저 머지된 뒤 이 PR의 base를 main으로 재타겟해야 한다.**