### PR TITLE
fix(lessons): fail-closed --verified record without --signature-file (#9)

### DIFF
--- a/tools/loop-engine/bin/lessons.mjs
+++ b/tools/loop-engine/bin/lessons.mjs
@@ -25,6 +25,8 @@
 //                   ledger's payload.cmd are normalized through lib/regression-signals normalizeGateKey
 //                   (leading `sh -c ` wrapper stripped + ledger truncation rule), so "pnpm verify" and the
 //                   loop-fix path's "sh -c pnpm verify" cross-reference as ONE gate in promote --runs.
+//                   --verified requires --signature-file (issue #9, fail-closed): a hand-typed --signature
+//                   string is not acceptable evidence for a verified record — usage error, exit 2.
 //   lessons recall  (--signature-file|--signature) [--include-unverified]
 //                   [--category engineering|domain] [--lessons <dir>]
 //                   A miss (no lesson, or --category mismatch) is silent on stdout (exit 0 unchanged —
@@ -257,6 +259,12 @@ const avg = a => a.length ? (a.reduce((x, y) => x + y, 0) / a.length) : null
 if (cmd === 'record') {
   const s = signatureOf()
   if (!s) usage('record needs --signature-file or --signature with at least one FAIL line')
+  // Evidence integrity (issue #9): a --verified record is a claim that ground truth (the verifier)
+  // confirmed a fix. A hand-typed --signature string carries no evidence trail — anyone can type
+  // any text. Fail closed: --verified requires --signature-file (a real file path, i.e. an actual
+  // verdict/log artifact on disk). Unverified records (no --verified) are unaffected — this is a
+  // constraint on the VERIFIED claim only, not on record() in general.
+  if (opt.verified && !opt.sigFile) usage('refusing --verified record without --signature-file — hand-typed --signature text is not acceptable evidence for a verified lesson (fail-closed, evidence must be a file). Use --signature-file <path> instead, or drop --verified.')
   const msg = withLock(() => {
     const existing = readLesson(s.key)
     if (existing) {

--- a/tools/loop-engine/bin/loop-fix.sh
+++ b/tools/loop-engine/bin/loop-fix.sh
@@ -380,10 +380,18 @@ while [ "$iter" -lt "$MAX_ITER" ]; do
 
   if [ "$vcode" -eq 0 ]; then
     log "iter $iter: PASS — stopping (success)."
+    # mark-clean wiring (issue #9): bump clean_pass_count on every lesson tied to this gate BEFORE
+    # record — record's existing-lesson merge path resets clean_pass_count to 0 for the lesson that
+    # just recurred THIS run (if FIRST_VERDICT was captured), so that lesson is never miscounted as
+    # a clean pass. Runs whenever --lessons is set, independent of FIRST_VERDICT — a fully clean pass
+    # (no failure this run) has no FIRST_VERDICT but must still bump every lesson on this gate.
+    if [ -n "$LESSONS" ] && [ -x "$LESSONS_BIN" ]; then
+      "$LESSONS_BIN" mark-clean --gate "$VERIFY" --lessons "$LESSONS" >/dev/null 2>&1
+    fi
     # Phase 3: record a VERIFIED lesson — ground truth (the verifier) confirmed this fix worked.
     if [ -n "$LESSONS" ] && [ -s "$FIRST_VERDICT" ] && [ -x "$LESSONS_BIN" ]; then
       "$LESSONS_BIN" record --signature-file "$FIRST_VERDICT" --source loop-fix \
-        --iterations "$iter" --verified --lessons "$LESSONS" >/dev/null 2>&1 \
+        --iterations "$iter" --verified --gate "$VERIFY" --lessons "$LESSONS" >/dev/null 2>&1 \
         && log "recorded a verified lesson to memory ($LESSONS)"
     fi
     log "=== loop-fix done: SUCCESS in $iter iteration(s) ==="

--- a/tools/loop-engine/docs/lessons.md
+++ b/tools/loop-engine/docs/lessons.md
@@ -36,6 +36,9 @@ same lesson. File-per-lesson is git-diffable and merge-friendly.
 { "id": "<sig>", "title": "...", "fix": "...", "source": "loop-fix", "category": "engineering",
   "verified": true, "count": 3, "iterations": [2,1,3],
   "gate_history": { "pnpm verify": { "count": 2, "first_seen": "...", "last_seen": "..." } },
+  "clean_pass_count": 0,
+  "challenge": null, "retired": null,
+  "invalid_at": "", "invalid_reason": "", "superseded_by": "", "invalidated_by": "",
   "first_seen": "...", "last_seen": "..." }
 ```
 
@@ -47,6 +50,23 @@ normalized gate command (same rule as the runs ledger's `payload.cmd`). Missing/
 coerce to `{}` on read — same read-time-default precedent as `category`, no migration. PASS history
 is NOT copied here; the `.loop/runs` ledger stays the SSOT.
 
+`clean_pass_count` (issue #9) is an exit-code-derived counter: `mark-clean --gate <cmd>` bumps it on
+every lesson attributed to that gate (via `gate_history`) that is neither invalidated nor retired —
+"how many times this gate has passed CLEANLY since this lesson's fix was last needed." `record`'s
+fail-recurrence path (an existing lesson matched again) resets it to 0 — a recurrence is evidence the
+lesson is NOT yet stable. `loop-fix.sh` calls `mark-clean` on every PASS (before `record`, so a lesson
+that just recurred THIS run is not miscounted as clean), whether or not this run ever failed. Missing/
+corrupt coerces to `0` on read — same read-time-default precedent as `category`/`gate_history`.
+`promote`'s listing annotates candidates crossing an informational `CLEAN_RETIRE_THRESHOLD` (5) as
+retirement candidates — a signal only, never an auto-invalidate/retire.
+
+`invalid_at`/`invalid_reason`/`superseded_by`/`invalidated_by` (issue #6) record an `invalidate` call
+— the lesson itself was WRONG, distinct from `retired` (the lesson was right but is now
+superseded/codified). `invalid_at` is authoritative only as a non-empty string (empty = not
+invalidated, the read-time default). An invalidated lesson is excluded, fail-closed, from every
+downstream surface: `recall` (checked ahead of the verified check, so even a `verified: true` lesson
+that was later invalidated is never recalled) and `promote` (listing / `--codify`).
+
 ## Commands
 
 ```bash
@@ -55,6 +75,12 @@ lessons record  --signature-file <verdict.txt> [--fix "..."] [--source loop-fix|
 lessons recall  --signature-file <verdict.txt> [--include-unverified] [--category engineering|domain] [--lessons <dir>]
 lessons promote [--min-count N] [--codify] [--runs <runs-dir>] [--lessons <dir>]   # recurring verified → codify candidates
 lessons retire  --id <key> --ref "<where codified>" [--lessons <dir>]   # TERMINAL: retire a codified lesson from the pool
+lessons invalidate --id <key> [--reason "..."] [--superseded-by <id2>] [--by "<who>"] [--lessons <dir>]
+                # mark a lesson WRONG (distinct from retire — right but superseded). Fail-closed
+                # excluded from recall and promote (listing/--codify) from then on.
+lessons mark-clean --gate "<verify cmd>" [--lessons <dir>]
+                # bump clean_pass_count on every non-invalidated, non-retired lesson attributed to
+                # --gate — "this gate passed cleanly, without this lesson's fix being needed again."
 lessons stats   [--category engineering|domain] [--lessons <dir>]   # observability: convergence + avg iterations + retired/open/by-category counts
 ```
 
@@ -83,7 +109,12 @@ loop-fix.sh --verify "npm test" --fix '<agent>' --protect "**/*.test.*" --lesson
 
 - On each failing iteration, `loop-fix` **recalls** verified lessons for that exact failure and
   injects them into the fix prompt ("a past verified run hit this same failure — here's what worked").
-- On **SUCCESS**, it **records** a verified lesson (the original failure → converged in N iterations).
+- On **SUCCESS**, it first calls **`mark-clean --gate "$VERIFY"`** (bumping `clean_pass_count` on every
+  lesson tied to this gate — runs even on a fully clean pass with no failure at all this run), THEN
+  **records** a verified lesson tagged `--gate "$VERIFY"` when a failure was captured this run (the
+  original failure → converged in N iterations). This order matters: if the run's own failure just
+  recurred, `record`'s merge resets that lesson's `clean_pass_count` back to 0 right after `mark-clean`
+  bumped it, so a lesson that just needed its fix again is never miscounted as a clean pass.
 
 So the 5th time the loop meets a familiar failure, it starts with the answer instead of rediscovering
 it — and `lessons stats` shows whether the loop is getting faster (avg iterations-to-green).

--- a/tools/loop-engine/test/lessons-category.test.sh
+++ b/tools/loop-engine/test/lessons-category.test.sh
@@ -19,14 +19,14 @@ trap 'rm -rf "$DIR"' EXIT
 L() { node "$LESSONS" "$@" --lessons "$DIR"; }
 
 # 1) record with no --category defaults to engineering.
-L record --signature "FAIL: flaky ci runner timed out" --verified --title "ci timeout" >/dev/null \
+L record --signature-file <(printf '%s\n' "FAIL: flaky ci runner timed out") --verified --title "ci timeout" >/dev/null \
   || fail "record (no category) failed"
 ID1="$(L promote --min-count 1 2>/dev/null | grep -oE '[0-9a-f]{16}' | head -1)"
 [ -n "$ID1" ] || fail "could not extract lesson id (no-category record)"
 grep -q '"category": "engineering"' "$DIR/$ID1.json" || fail "default category must be 'engineering': $(cat "$DIR/$ID1.json")"
 
 # 2) record with --category domain sets it on creation.
-L record --signature "FAIL: dose calculation off by one unit" --verified --title "dose calc" --category domain >/dev/null \
+L record --signature-file <(printf '%s\n' "FAIL: dose calculation off by one unit") --verified --title "dose calc" --category domain >/dev/null \
   || fail "record --category domain failed"
 ID2="$(L promote --min-count 1 2>/dev/null | grep -oE '[0-9a-f]{16}' | grep -v "^$ID1$" | head -1)"
 [ -n "$ID2" ] || fail "could not extract lesson id (domain record)"

--- a/tools/loop-engine/test/lessons-evidence-integrity.test.sh
+++ b/tools/loop-engine/test/lessons-evidence-integrity.test.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Regression test for lessons.mjs `record` evidence integrity (issue #9, ported from glucofit-partners
+# Linear BAC-627).
+#
+# verdict-run.sh already implements the full-output → LOG(untruncated) evidence contract. The remaining
+# gap was `record`: it accepted --verified with a hand-typed --signature string and NO --signature-file
+# — i.e. a "verified" lesson backed by no evidence file at all, just whatever text was typed on the
+# command line. This locks the fail-closed fix: --verified without --signature-file is a usage error
+# (exit 2), while unverified records (no --verified) are unaffected — the constraint applies only to the
+# VERIFIED claim, not to record() in general.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$HERE/../../.."
+LESSONS="$ROOT/tools/loop-engine/bin/lessons.mjs"
+
+fail() { echo "FAIL: $1"; exit 1; }
+[ -f "$LESSONS" ] || fail "lessons.mjs not found at $LESSONS"
+
+DIR="$(mktemp -d "${TMPDIR:-/tmp}/tmp.XXXXXXXX")" || fail "mktemp -d failed"
+trap 'rm -rf "$DIR"' EXIT
+L() { node "$LESSONS" "$@" --lessons "$DIR"; }
+
+# 1) --signature (hand-typed text, no --signature-file) + --verified must be REFUSED — fail closed,
+#    exit 2, and the error must name --signature-file so the fix is discoverable.
+rc=0; ERR1="$(L record --signature "FAIL: evidence integrity probe" --verified --title "should be refused" 2>&1 >/dev/null)" || rc=$?
+[ "$rc" = "2" ] || fail "--signature + --verified (no --signature-file) must exit 2 (fail closed); got rc=$rc"
+printf '%s' "$ERR1" | grep -q -- "--signature-file" || fail "refusal must name --signature-file so the fix is discoverable: $ERR1"
+# and it must not have written a lesson file at all.
+[ -z "$(find "$DIR" -maxdepth 1 -name '*.json' 2>/dev/null)" ] || fail "a refused --verified record must not write a lesson file: $(ls "$DIR")"
+
+# 2) --signature-file + --verified succeeds (real evidence file on disk) — exit 0.
+SIGF="$DIR/verdict.txt"
+printf 'FAIL: evidence integrity probe\n' > "$SIGF"
+OUT2="$(L record --signature-file "$SIGF" --verified --title "backed by a real file" 2>&1)"
+rc=$?
+[ "$rc" = "0" ] || fail "--signature-file + --verified must succeed; got rc=$rc: $OUT2"
+printf '%s' "$OUT2" | grep -q "verified=true" || fail "the successful record must be marked verified: $OUT2"
+
+# 3) --signature (hand-typed) WITHOUT --verified must still be allowed — this constraint is on the
+#    VERIFIED claim only, not on record() in general (unverified/self-reported records are unchanged).
+OUT3="$(L record --signature "FAIL: unverified hand-typed probe" --title "unverified is fine" 2>&1)"
+rc=$?
+[ "$rc" = "0" ] || fail "--signature without --verified must still succeed (unverified records unaffected); got rc=$rc: $OUT3"
+printf '%s' "$OUT3" | grep -q "verified=false" || fail "an unverified record must report verified=false: $OUT3"
+
+echo "PASS: lessons record evidence integrity (issue #9) — --verified without --signature-file is refused fail-closed, --signature-file + --verified succeeds, unverified hand-typed records are unaffected"
+exit 0

--- a/tools/loop-engine/test/lessons-hygiene.test.sh
+++ b/tools/loop-engine/test/lessons-hygiene.test.sh
@@ -57,7 +57,7 @@ printf '%s' "$ERR" | grep -q "no lesson with id doesnotexist1234" || fail "inval
 
 # ==== 3) invalidate: success path sets invalid_at/invalid_reason/invalidated_by, leaves superseded_by
 #         empty when --superseded-by is omitted. ====
-L record --signature "FAIL: hygiene widget-inv" --verified --title "hygiene lesson widget-inv" >/dev/null || fail "record widget-inv failed"
+L record --signature-file <(printf '%s\n' "FAIL: hygiene widget-inv") --verified --title "hygiene lesson widget-inv" >/dev/null || fail "record widget-inv failed"
 WID="$(id_for "$DIR" "hygiene lesson widget-inv")"
 [ -n "$WID" ] || fail "could not extract widget-inv id"
 OUT3="$(L invalidate --id "$WID" --reason "root cause was misattributed" --by "paul" 2>&1)"
@@ -71,7 +71,7 @@ grep -qE '"invalid_at": "[^"]+"' "$DIR/$WID.json" || fail "invalid_at must be se
 grep -q '"invalid_at": ""' "$DIR/$WID.json" && fail "invalid_at must not be empty after invalidate: $(cat "$DIR/$WID.json")"
 
 # ==== 4) invalidate: --by defaults to "human" when omitted, --reason defaults to "" ====
-L record --signature "FAIL: hygiene gadget-inv2" --verified --title "hygiene lesson gadget-inv2" >/dev/null || fail "record gadget-inv2 failed"
+L record --signature-file <(printf '%s\n' "FAIL: hygiene gadget-inv2") --verified --title "hygiene lesson gadget-inv2" >/dev/null || fail "record gadget-inv2 failed"
 GID="$(id_for "$DIR" "hygiene lesson gadget-inv2")"
 [ -n "$GID" ] || fail "could not extract gadget-inv2 id"
 OUT4="$(L invalidate --id "$GID" 2>&1)"
@@ -82,7 +82,7 @@ grep -q '"invalid_reason": ""' "$DIR/$GID.json" || fail "invalid_reason must def
 
 # ==== 5) invalidate --superseded-by: a dangling (nonexistent) target is refused, fail closed — the
 #         lesson being invalidated must NOT be mutated. ====
-L record --signature "FAIL: hygiene super-target-missing" --verified --title "hygiene lesson super-target-missing" >/dev/null || fail "record super-target-missing failed"
+L record --signature-file <(printf '%s\n' "FAIL: hygiene super-target-missing") --verified --title "hygiene lesson super-target-missing" >/dev/null || fail "record super-target-missing failed"
 SID="$(id_for "$DIR" "hygiene lesson super-target-missing")"
 [ -n "$SID" ] || fail "could not extract super-target-missing id"
 rc=0; ERR5="$(L invalidate --id "$SID" --superseded-by "nonexistentxxxxxx" 2>&1 >/dev/null)" || rc=$?
@@ -93,10 +93,10 @@ printf '%s' "$ERR5" | grep -q "superseded-by target nonexistentxxxxxx does not e
 grep -q '"invalid_at"' "$DIR/$SID.json" && fail "a refused invalidate must NOT mutate the lesson (invalid_at key must not appear): $(cat "$DIR/$SID.json")"
 
 # ==== 6) invalidate --superseded-by: an existing target succeeds and is recorded. ====
-L record --signature "FAIL: hygiene super-source" --verified --title "hygiene lesson super-source" >/dev/null || fail "record super-source failed"
+L record --signature-file <(printf '%s\n' "FAIL: hygiene super-source") --verified --title "hygiene lesson super-source" >/dev/null || fail "record super-source failed"
 SUP="$(id_for "$DIR" "hygiene lesson super-source")"
 [ -n "$SUP" ] || fail "could not extract super-source id"
-L record --signature "FAIL: hygiene super-old" --verified --title "hygiene lesson super-old" >/dev/null || fail "record super-old failed"
+L record --signature-file <(printf '%s\n' "FAIL: hygiene super-old") --verified --title "hygiene lesson super-old" >/dev/null || fail "record super-old failed"
 OLD="$(id_for "$DIR" "hygiene lesson super-old")"
 [ -n "$OLD" ] || fail "could not extract super-old id"
 OUT6="$(L invalidate --id "$OLD" --superseded-by "$SUP" --reason "replaced by a newer lesson" 2>&1)"
@@ -107,10 +107,10 @@ grep -q "\"superseded_by\": \"$SUP\"" "$DIR/$OLD.json" || fail "superseded_by no
 # ==== 7) recall(): an invalidated lesson is NEVER recalled, even though it is verified — checked ahead
 #         of the verified check. stdout stays empty/exit 0 (unchanged miss contract); stderr names it
 #         INVALIDATED with the reason and the superseded-by pointer. ====
-L record --signature "FAIL: hygiene recall superseder" --verified --title "hygiene lesson recall superseder" >/dev/null || fail "record recall superseder failed"
+L record --signature-file <(printf '%s\n' "FAIL: hygiene recall superseder") --verified --title "hygiene lesson recall superseder" >/dev/null || fail "record recall superseder failed"
 RSUP="$(id_for "$DIR" "hygiene lesson recall superseder")"
 [ -n "$RSUP" ] || fail "could not extract recall superseder id"
-L record --signature "FAIL: hygiene recall probe" --verified --title "hygiene lesson recall probe" >/dev/null || fail "record recall probe failed"
+L record --signature-file <(printf '%s\n' "FAIL: hygiene recall probe") --verified --title "hygiene lesson recall probe" >/dev/null || fail "record recall probe failed"
 L invalidate --id "$(id_for "$DIR" "hygiene lesson recall probe")" --reason "stale" --superseded-by "$RSUP" >/dev/null || fail "invalidate recall probe failed"
 OUT7="$(mktemp "${TMPDIR:-/tmp}/tmp.XXXXXXXX")"; ERR7="$(mktemp "${TMPDIR:-/tmp}/tmp.XXXXXXXX")"
 L recall --signature "FAIL: hygiene recall probe" >"$OUT7" 2>"$ERR7"
@@ -134,17 +134,17 @@ echo "PASS §1-8 (invalidate/recall/coerce hygiene)"
 #         beyond what promote would list — even a PREVIOUSLY-ACCEPTED lesson disappears once
 #         invalidated (the safety-critical case: a challenge --verdict accept does NOT protect a
 #         lesson later discovered to be wrong). ====
-for i in 1 2 3; do L2 record --signature "FAIL: hygiene pool lesson A" --verified --title "hygiene pool lesson A" --gate "pnpm verify" >/dev/null || fail "record pool A #$i failed"; done
+for i in 1 2 3; do L2 record --signature-file <(printf '%s\n' "FAIL: hygiene pool lesson A") --verified --title "hygiene pool lesson A" --gate "pnpm verify" >/dev/null || fail "record pool A #$i failed"; done
 LA="$(id_for "$DIR2" "hygiene pool lesson A")"
 [ -n "$LA" ] || fail "could not extract pool lesson A id"
 
-for i in 1 2 3; do L2 record --signature "FAIL: hygiene pool lesson B (accept then invalidate)" --verified --title "hygiene pool lesson B (accept then invalidate)" >/dev/null || fail "record pool B #$i failed"; done
+for i in 1 2 3; do L2 record --signature-file <(printf '%s\n' "FAIL: hygiene pool lesson B (accept then invalidate)") --verified --title "hygiene pool lesson B (accept then invalidate)" >/dev/null || fail "record pool B #$i failed"; done
 LB="$(id_for "$DIR2" "hygiene pool lesson B (accept then invalidate)")"
 [ -n "$LB" ] || fail "could not extract pool lesson B id"
 L2 challenge --id "$LB" --verdict accept --reason "looked solid at the time" >/dev/null || fail "challenge accept B failed"
 L2 invalidate --id "$LB" --reason "later found to be a red herring" >/dev/null || fail "invalidate accepted lesson B failed"
 
-for i in 1 2 3; do L2 record --signature "FAIL: hygiene pool lesson C (retired)" --verified --title "hygiene pool lesson C (retired)" >/dev/null || fail "record pool C #$i failed"; done
+for i in 1 2 3; do L2 record --signature-file <(printf '%s\n' "FAIL: hygiene pool lesson C (retired)") --verified --title "hygiene pool lesson C (retired)" >/dev/null || fail "record pool C #$i failed"; done
 LC="$(id_for "$DIR2" "hygiene pool lesson C (retired)")"
 [ -n "$LC" ] || fail "could not extract pool lesson C id"
 L2 challenge --id "$LC" --verdict accept --reason "real fix" >/dev/null || fail "challenge accept C failed"
@@ -174,16 +174,16 @@ echo "PASS §9 (promote/stats invalidated exclusion, incl. previously-accepted l
 # ==== 10) mark-clean: bumps clean_pass_count only for lessons attributed (gate_history) to --gate,
 #          and only if they are NOT invalidated and NOT retired. record()'s fail-recurrence path
 #          resets the counter to 0. ====
-L3 record --signature "FAIL: hygiene mc lesson-match-1" --verified --title "hygiene mc lesson-match-1" --gate "pnpm verify" >/dev/null || fail "record mc match-1 failed"
+L3 record --signature-file <(printf '%s\n' "FAIL: hygiene mc lesson-match-1") --verified --title "hygiene mc lesson-match-1" --gate "pnpm verify" >/dev/null || fail "record mc match-1 failed"
 MC1="$(id_for "$DIR3" "hygiene mc lesson-match-1")"
-L3 record --signature "FAIL: hygiene mc lesson-match-2" --verified --title "hygiene mc lesson-match-2" --gate "pnpm verify" >/dev/null || fail "record mc match-2 failed"
+L3 record --signature-file <(printf '%s\n' "FAIL: hygiene mc lesson-match-2") --verified --title "hygiene mc lesson-match-2" --gate "pnpm verify" >/dev/null || fail "record mc match-2 failed"
 MC2="$(id_for "$DIR3" "hygiene mc lesson-match-2")"
-L3 record --signature "FAIL: hygiene mc lesson-other-gate" --verified --title "hygiene mc lesson-other-gate" --gate "pnpm typecheck" >/dev/null || fail "record mc other-gate failed"
+L3 record --signature-file <(printf '%s\n' "FAIL: hygiene mc lesson-other-gate") --verified --title "hygiene mc lesson-other-gate" --gate "pnpm typecheck" >/dev/null || fail "record mc other-gate failed"
 MC3="$(id_for "$DIR3" "hygiene mc lesson-other-gate")"
-L3 record --signature "FAIL: hygiene mc lesson-invalidated" --verified --title "hygiene mc lesson-invalidated" --gate "pnpm verify" >/dev/null || fail "record mc invalidated failed"
+L3 record --signature-file <(printf '%s\n' "FAIL: hygiene mc lesson-invalidated") --verified --title "hygiene mc lesson-invalidated" --gate "pnpm verify" >/dev/null || fail "record mc invalidated failed"
 MC4="$(id_for "$DIR3" "hygiene mc lesson-invalidated")"
 L3 invalidate --id "$MC4" --reason "not real" >/dev/null || fail "invalidate mc4 failed"
-for i in 1 2 3; do L3 record --signature "FAIL: hygiene mc lesson-retired" --verified --title "hygiene mc lesson-retired" --gate "pnpm verify" >/dev/null || fail "record mc retired #$i failed"; done
+for i in 1 2 3; do L3 record --signature-file <(printf '%s\n' "FAIL: hygiene mc lesson-retired") --verified --title "hygiene mc lesson-retired" --gate "pnpm verify" >/dev/null || fail "record mc retired #$i failed"; done
 MC5="$(id_for "$DIR3" "hygiene mc lesson-retired")"
 L3 challenge --id "$MC5" --verdict accept --reason "real fix" >/dev/null || fail "challenge mc5 failed"
 L3 retire --id "$MC5" --ref "CLAUDE.md#hygiene-mc" >/dev/null || fail "retire mc5 failed"
@@ -206,7 +206,7 @@ grep -q '"clean_pass_count": 2' "$DIR3/$MC1.json" || fail "match-1 clean_pass_co
 
 # fail-recurrence: match-1 recurs (record called again on the same signature) -> clean_pass_count
 # resets to 0, even though the gate history / count keeps growing (a recurrence is NOT stability).
-L3 record --signature "FAIL: hygiene mc lesson-match-1" --verified --title "hygiene mc lesson-match-1" --gate "pnpm verify" >/dev/null || fail "re-record match-1 (recurrence) failed"
+L3 record --signature-file <(printf '%s\n' "FAIL: hygiene mc lesson-match-1") --verified --title "hygiene mc lesson-match-1" --gate "pnpm verify" >/dev/null || fail "re-record match-1 (recurrence) failed"
 grep -q '"clean_pass_count": 0' "$DIR3/$MC1.json" || fail "a recurrence must reset clean_pass_count to 0: $(cat "$DIR3/$MC1.json")"
 grep -q '"count": 2' "$DIR3/$MC1.json" || fail "the recurrence must still increment count: $(cat "$DIR3/$MC1.json")"
 
@@ -216,8 +216,8 @@ echo "PASS §10 (mark-clean selective marking + fail-recurrence reset)"
 # ==== 11) promote(): the informational RETIREMENT CANDIDATE annotation fires only at
 #          clean_pass_count >= CLEAN_RETIRE_THRESHOLD (5), and is purely informational — it does not
 #          remove the lesson from the listing or touch invalid_at/retired. ====
-for i in 1 2 3; do L3 record --signature "FAIL: hygiene mc lesson-clean5" --verified --title "hygiene mc lesson-clean5" --gate "pnpm build" >/dev/null || fail "record clean5 #$i failed"; done
-for i in 1 2 3 4; do L3 record --signature "FAIL: hygiene mc lesson-clean4" --verified --title "hygiene mc lesson-clean4" --gate "pnpm lint" >/dev/null || fail "record clean4 #$i failed"; done
+for i in 1 2 3; do L3 record --signature-file <(printf '%s\n' "FAIL: hygiene mc lesson-clean5") --verified --title "hygiene mc lesson-clean5" --gate "pnpm build" >/dev/null || fail "record clean5 #$i failed"; done
+for i in 1 2 3 4; do L3 record --signature-file <(printf '%s\n' "FAIL: hygiene mc lesson-clean4") --verified --title "hygiene mc lesson-clean4" --gate "pnpm lint" >/dev/null || fail "record clean4 #$i failed"; done
 for i in 1 2 3 4 5; do L3 mark-clean --gate "pnpm build" >/dev/null || fail "mark-clean build #$i failed"; done
 for i in 1 2 3 4; do L3 mark-clean --gate "pnpm lint" >/dev/null || fail "mark-clean lint #$i failed"; done
 

--- a/tools/loop-engine/test/lessons-recall.test.sh
+++ b/tools/loop-engine/test/lessons-recall.test.sh
@@ -23,7 +23,7 @@ fail() { echo "FAIL: $1"; exit 1; }
 DIR="$(mktemp -d "${TMPDIR:-/tmp}/tmp.XXXXXXXX")" || fail "mktemp -d failed"
 trap 'rm -rf "$DIR"' EXIT
 
-node "$LESSONS" record --signature "FAIL: widget exploded at boot" --verified --fix "reboot the widget" --title "widget boot fix" --lessons "$DIR" >/dev/null \
+node "$LESSONS" record --signature-file <(printf '%s\n' "FAIL: widget exploded at boot") --verified --fix "reboot the widget" --title "widget boot fix" --lessons "$DIR" >/dev/null \
   || fail "record failed"
 
 # 1) HIT: stdout has the lesson, stderr is silent (no noise on the success path).

--- a/tools/loop-engine/test/lessons-retire.test.sh
+++ b/tools/loop-engine/test/lessons-retire.test.sh
@@ -21,7 +21,7 @@ L() { node "$LESSONS" "$@" --lessons "$DIR"; }
 
 # record the same verified lesson 3× → recurring (count=3), clears the promote floor (min-count 3)
 for i in 1 2 3; do
-  L record --signature "FAIL: widget exploded at boot" --verified --fix "reboot the widget" --title "widget boot fix" >/dev/null \
+  L record --signature-file <(printf '%s\n' "FAIL: widget exploded at boot") --verified --fix "reboot the widget" --title "widget boot fix" >/dev/null \
     || fail "record #$i failed"
 done
 ID="$(L promote 2>/dev/null | grep -oE '[0-9a-f]{16}' | head -1)"
@@ -52,7 +52,7 @@ printf '%s' "$SOUT" | grep -q "open_candidates=0" || fail "stats must show open_
 
 # 6) a CONTENT change (new fix/title on a verified re-record) clears retirement → the lesson re-enters the
 #    pool for fresh review (the codified guideline is now stale). Fail closed.
-L record --signature "FAIL: widget exploded at boot" --verified --fix "DIFFERENT fix now" --title "widget boot fix v2" >/dev/null \
+L record --signature-file <(printf '%s\n' "FAIL: widget exploded at boot") --verified --fix "DIFFERENT fix now" --title "widget boot fix v2" >/dev/null \
   || fail "re-record with new content failed"
 SOUT2="$(L stats 2>&1)"
 printf '%s' "$SOUT2" | grep -q "retired=0" || fail "content change must clear retirement (retired=0): $SOUT2"
@@ -61,7 +61,7 @@ printf '%s' "$SOUT2" | grep -q "open_candidates=1" || fail "cleared lesson must 
 # 7) a REJECTED recurring lesson is NOT counted as an open candidate — the skeptic decided no, so it is
 #    terminal (not actionable), same as retired. loop-doctor's "승격 후보" must not nag about it.
 for i in 1 2 3; do
-  L record --signature "FAIL: gadget fizzled at shutdown" --verified --title "gadget fix" >/dev/null || fail "record gadget #$i failed"
+  L record --signature-file <(printf '%s\n' "FAIL: gadget fizzled at shutdown") --verified --title "gadget fix" >/dev/null || fail "record gadget #$i failed"
 done
 GID="$(L promote 2>/dev/null | grep -oE '^  [0-9a-f]{16}' | tr -d ' ' | grep -v "^$ID$" | head -1)"
 [ -n "$GID" ] || fail "could not extract second (gadget) lesson id"

--- a/tools/loop-engine/test/loop-fix-fail-channel.test.sh
+++ b/tools/loop-engine/test/loop-fix-fail-channel.test.sh
@@ -107,5 +107,40 @@ f2="$(ls lessons/*.json)"
 grep -q '"count": 2' "$f2" || fail "case5: expected count to increase to 2 after later PASS convergence"
 grep -q '"verified": true' "$f2" || fail "case5: expected verified to flip true after later PASS convergence"
 
-echo "PASS: FAIL-channel lessons recorded on STALLED/MAX-ITER, withheld on INFRA/PROTECTED-VIOLATION, merged on later convergence"
+# ── case 6: BUDGET로 끝나는 실행 → unverified fail-channel lesson 기록 ─────────────────────
+C="$WORK/c6"; mkdir -p "$C"; cd "$C" || fail "cd c6"
+cat > fake-verify.sh <<'EOF'
+#!/bin/sh
+sleep 1
+echo "FAILED src/example.test.ts > budget fail-channel test"
+exit 1
+EOF
+# sleep 1 이 iter1에서 이미 --budget-sec 1을 넘겨 STALLED보다 먼저 BUDGET으로 끊긴다
+# (infra-exempt.test.sh case 7과 같은 패턴).
+"$LOOPFIX" --verify 'sh fake-verify.sh' --fix ':' --budget-sec 1 --max-iter 10 --lessons lessons >/dev/null 2>&1
+code=$?
+[ "$code" -eq 1 ] || fail "case6: expected exit 1 via BUDGET, got $code"
+grep -q "done: BUDGET" .loop/history.log || fail "case6: expected the loop to hit BUDGET"
+[ "$(lessons_file_count lessons)" -eq 1 ] || fail "case6: expected exactly 1 lesson file recorded"
+f="$(ls lessons/*.json)"
+grep -q '"source": "loop-fix-fail"' "$f" || fail "case6: expected source=loop-fix-fail"
+grep -q '"verified": false' "$f" || fail "case6: expected verified=false (never converged)"
+
+# ── case 7: --fix 없는 verify-only 모드 — 첫 FAIL에서 즉시 중단 → unverified lesson 기록 ────
+C="$WORK/c7"; mkdir -p "$C"; cd "$C" || fail "cd c7"
+cat > fake-verify.sh <<'EOF'
+#!/bin/sh
+echo "FAILED src/example.test.ts > verify-only fail-channel test"
+exit 1
+EOF
+"$LOOPFIX" --verify 'sh fake-verify.sh' --lessons lessons >/dev/null 2>&1
+code=$?
+[ "$code" -eq 1 ] || fail "case7: expected exit 1 via verify-only FAIL, got $code"
+grep -q "done: FAIL (verify-only)" .loop/history.log || fail "case7: expected verify-only FAIL marker"
+[ "$(lessons_file_count lessons)" -eq 1 ] || fail "case7: expected exactly 1 lesson file recorded"
+f="$(ls lessons/*.json)"
+grep -q '"source": "loop-fix-fail"' "$f" || fail "case7: expected source=loop-fix-fail"
+grep -q '"verified": false' "$f" || fail "case7: expected verified=false (never converged)"
+
+echo "PASS: FAIL-channel lessons recorded on STALLED/MAX-ITER/BUDGET/verify-only-FAIL, withheld on INFRA/PROTECTED-VIOLATION, merged on later convergence"
 exit 0

--- a/tools/loop-engine/test/loop-fix-mark-clean.test.sh
+++ b/tools/loop-engine/test/loop-fix-mark-clean.test.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Regression test (issue #9 mark-clean wiring): loop-fix.sh's PASS branch must actually call
+# `lessons mark-clean --gate "$VERIFY"` — before BAC-9's fix there was no call site anywhere in the
+# codebase, so clean_pass_count could never move off 0. This proves the wiring end-to-end by reading
+# the lesson JSON directly:
+#   (a) a fail-then-converge run records a verified lesson (count=1, clean_pass_count=0 — new lesson).
+#   (b) a later, fully-clean run (no failure at all) bumps that SAME lesson's clean_pass_count 0 -> 1
+#       via mark-clean alone (record is never called — no FIRST_VERDICT was captured this run).
+#   (c) a THIRD run where the same failure recurs and converges again bumps clean_pass_count to 2 via
+#       mark-clean, but record's existing-lesson merge (fail-recurrence reset) then resets it back to
+#       0 for the SAME iteration — mark-clean must fire BEFORE record, or the just-recurred lesson
+#       would be miscounted as a clean pass.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+LOOPFIX="$HERE/../bin/loop-fix.sh"
+
+fail() { echo "FAIL: $1"; exit 1; }
+[ -x "$LOOPFIX" ] || fail "loop-fix.sh not executable at $LOOPFIX"
+
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/tmp.XXXXXXXX")" || fail "mktemp -d failed"
+trap 'rm -rf "$WORK"' EXIT
+
+# clean_pass_count is only written to the JSON file once something has actually bumped/reset it
+# (a brand-new lesson's literal never sets the key at all — it defaults to 0 at READ time via
+# lessons.mjs's coerce()). Read it back the same way rather than grepping for a literal key/value,
+# so this test doesn't depend on that write-time implementation detail.
+read_clean_pass_count() {
+  node -e '
+    const fs = require("fs")
+    const l = JSON.parse(fs.readFileSync(process.argv[1], "utf8"))
+    const v = Number.isInteger(l.clean_pass_count) && l.clean_pass_count >= 0 ? l.clean_pass_count : 0
+    process.stdout.write(String(v))
+  ' "$1"
+}
+
+C="$WORK/c1"; mkdir -p "$C"; cd "$C" || fail "cd c1"
+cat > fake-verify.sh <<'EOF'
+#!/bin/sh
+if [ -f converged ]; then
+  echo ok
+  exit 0
+fi
+echo "FAILED src/example.test.ts > mark-clean wiring test"
+exit 1
+EOF
+
+# ── (a) fail then converge: records a NEW verified lesson, count=1, clean_pass_count=0 ─────────
+"$LOOPFIX" --verify 'sh fake-verify.sh' --fix 'touch converged' --max-iter 3 --stall 5 --lessons lessons >/dev/null 2>&1
+code=$?
+[ "$code" -eq 0 ] || fail "(a): expected PASS on first (fail-then-converge) run, got exit $code"
+[ "$(ls lessons/*.json 2>/dev/null | wc -l | tr -d ' ')" -eq 1 ] || fail "(a): expected exactly 1 lesson file"
+f="$(ls lessons/*.json)"
+grep -q '"count": 1' "$f" || fail "(a): expected count=1 after first convergence"
+grep -q '"verified": true' "$f" || fail "(a): expected verified=true after first convergence"
+[ "$(read_clean_pass_count "$f")" -eq 0 ] || fail "(a): expected clean_pass_count=0 on a brand-new lesson"
+
+# ── (b) a later fully-clean run (no failure this run) bumps clean_pass_count via mark-clean alone ──
+"$LOOPFIX" --verify 'sh fake-verify.sh' --max-iter 1 --lessons lessons >/dev/null 2>&1
+code=$?
+[ "$code" -eq 0 ] || fail "(b): expected PASS on the clean run, got exit $code"
+[ "$(ls lessons/*.json 2>/dev/null | wc -l | tr -d ' ')" -eq 1 ] || fail "(b): expected still exactly 1 lesson file (no new lesson created)"
+f2="$(ls lessons/*.json)"
+[ "$f" = "$f2" ] || fail "(b): expected the same lesson id to be reused"
+grep -q '"count": 1' "$f2" || fail "(b): a clean pass must NOT bump count (record is not called)"
+[ "$(read_clean_pass_count "$f2")" -eq 1 ] || fail "(b): expected clean_pass_count to bump 0 -> 1 via mark-clean"
+
+# ── (c) the same failure recurs and converges again: clean_pass_count resets to 0 ───────────────
+rm -f converged
+"$LOOPFIX" --verify 'sh fake-verify.sh' --fix 'touch converged' --max-iter 3 --stall 5 --lessons lessons >/dev/null 2>&1
+code=$?
+[ "$code" -eq 0 ] || fail "(c): expected PASS on the recur-then-converge run, got exit $code"
+[ "$(ls lessons/*.json 2>/dev/null | wc -l | tr -d ' ')" -eq 1 ] || fail "(c): expected still exactly 1 lesson file"
+f3="$(ls lessons/*.json)"
+[ "$f" = "$f3" ] || fail "(c): expected the same lesson id to be reused"
+grep -q '"count": 2' "$f3" || fail "(c): expected count to increase to 2 after the recurrence"
+[ "$(read_clean_pass_count "$f3")" -eq 0 ] || fail "(c): expected clean_pass_count reset to 0 — the recurrence must not be counted clean, even though mark-clean fired first this run"
+
+echo "PASS: mark-clean is wired into loop-fix.sh's PASS branch — clean_pass_count bumps on clean passes and resets on recurrence"
+exit 0

--- a/tools/loop-engine/test/regression-signals.test.sh
+++ b/tools/loop-engine/test/regression-signals.test.sh
@@ -66,9 +66,9 @@ node -e '
 ' "$JSON" || fail "T1b gate-key normalization wrong"
 # record --gate도 같은 정규화를 거쳐 교차 참조 키가 일치해야 한다(lessons 쪽 표면).
 LDIRN="$DIR/lessons-norm"
-node "$LESSONS" record --signature "FAIL: norm cross-ref" --verified --gate "sh -c pnpm verify" --lessons "$LDIRN" >/dev/null || fail "T1b record --gate failed"
-node "$LESSONS" record --signature "FAIL: norm cross-ref" --verified --lessons "$LDIRN" >/dev/null
-node "$LESSONS" record --signature "FAIL: norm cross-ref" --verified --lessons "$LDIRN" >/dev/null
+node "$LESSONS" record --signature-file <(printf '%s\n' "FAIL: norm cross-ref") --verified --gate "sh -c pnpm verify" --lessons "$LDIRN" >/dev/null || fail "T1b record --gate failed"
+node "$LESSONS" record --signature-file <(printf '%s\n' "FAIL: norm cross-ref") --verified --lessons "$LDIRN" >/dev/null
+node "$LESSONS" record --signature-file <(printf '%s\n' "FAIL: norm cross-ref") --verified --lessons "$LDIRN" >/dev/null
 PNORM="$(node "$LESSONS" promote --runs "$N" --lessons "$LDIRN" 2>/dev/null)" || fail "T1b promote --runs must exit 0"
 printf '%s' "$PNORM" | grep -q "\[REGRESSION: pnpm verify PASS→FAIL" || fail "T1b record --gate 'sh -c pnpm verify' must cross-reference the normalized gate, got: $PNORM"
 echo "PASS: T1b gate identity converges across call paths (sh -c wrapper normalized, both surfaces)"
@@ -225,7 +225,7 @@ echo "PASS: T6 missing/empty runs dir is handled without crash, exit 0"
 # ── T7) lessons record --gate ×3 → promote --runs: [3×] 카운트와 [REGRESSION:] 줄이 구분 병기 ─
 LDIR="$DIR/lessons7"
 for i in 1 2 3; do
-  node "$LESSONS" record --signature "FAIL: rls policy missing on tenant table" --verified \
+  node "$LESSONS" record --signature-file <(printf '%s\n' "FAIL: rls policy missing on tenant table") --verified \
     --fix "add pgPolicy + FORCE" --title "rls policy fix" --gate "pnpm verify" --lessons "$LDIR" >/dev/null \
     || fail "T7 record #$i failed"
 done
@@ -259,7 +259,7 @@ cat > "$LDIR8/0123456789abcdef.json" <<'EOF'
 EOF
 SOUT="$(node "$LESSONS" stats --lessons "$LDIR8")" || fail "T8 stats on legacy lesson must exit 0"
 printf '%s' "$SOUT" | grep -q "total=1 verified=1" || fail "T8 stats must read the legacy lesson, got: $SOUT"
-node "$LESSONS" record --signature "FAIL: fresh failure" --verified --lessons "$LDIR8" >/dev/null || fail "T8 record without --gate must work"
+node "$LESSONS" record --signature-file <(printf '%s\n' "FAIL: fresh failure") --verified --lessons "$LDIR8" >/dev/null || fail "T8 record without --gate must work"
 ROUT="$(node "$LESSONS" recall --signature "FAIL: fresh failure" --lessons "$LDIR8" 2>/dev/null)" || fail "T8 recall must exit 0"
 printf '%s' "$ROUT" | grep -q "Past lesson" || fail "T8 recall must behave as before, got: $ROUT"
 POUT8="$(node "$LESSONS" promote --runs "$A" --lessons "$LDIR8" 2>/dev/null)" || fail "T8 promote --runs must exit 0"
@@ -293,14 +293,14 @@ cat > "$P/runP.jsonl" <<'EOF'
 EOF
 LDIRP="$DIR/lessons-proto"
 for i in 1 2 3; do
-  node "$LESSONS" record --signature "FAIL: no gate attribution here" --verified --lessons "$LDIRP" >/dev/null || fail "T11 record #$i failed"
+  node "$LESSONS" record --signature-file <(printf '%s\n' "FAIL: no gate attribution here") --verified --lessons "$LDIRP" >/dev/null || fail "T11 record #$i failed"
 done
 POUTP="$(node "$LESSONS" promote --runs "$P" --lessons "$LDIRP" 2>/dev/null)" || fail "T11 promote --runs must exit 0"
 printf '%s' "$POUTP" | grep -q "\[REGRESSION: constructor" && fail "T11 candidate WITHOUT gate_history must never get a per-candidate line via the prototype chain, got: $POUTP"
 printf '%s' "$POUTP" | grep -q "REGRESSION: constructor" || fail "T11 the independent section must still surface the forged-name regression, got: $POUTP"
 # record --gate "__proto__"의 일반 대입은 프로토타입 세터를 타 무음 유실된다 — own property로 남아야 한다.
-node "$LESSONS" record --signature "FAIL: proto gate lesson" --verified --gate "__proto__" --lessons "$LDIRP" >/dev/null || fail "T11 record --gate proto #1 failed"
-node "$LESSONS" record --signature "FAIL: proto gate lesson" --verified --gate "__proto__" --lessons "$LDIRP" >/dev/null || fail "T11 record --gate proto #2 failed"
+node "$LESSONS" record --signature-file <(printf '%s\n' "FAIL: proto gate lesson") --verified --gate "__proto__" --lessons "$LDIRP" >/dev/null || fail "T11 record --gate proto #1 failed"
+node "$LESSONS" record --signature-file <(printf '%s\n' "FAIL: proto gate lesson") --verified --gate "__proto__" --lessons "$LDIRP" >/dev/null || fail "T11 record --gate proto #2 failed"
 node -e '
   const { readdirSync, readFileSync } = require("node:fs");
   const dir = process.argv[1];

--- a/tools/loop-engine/test/sanitize.test.sh
+++ b/tools/loop-engine/test/sanitize.test.sh
@@ -82,10 +82,10 @@ grep -q hunter2 "$DIR/t8.log" || fail "T8: LOOP_SANITIZE_OFF=1 must leave the lo
 
 # T9: lessons 대칭 배선 — 저장 JSON에 시크릿 부재 AND 같은 원문 서명 재-record가 같은 키에 적중(count=2).
 LDIR="$DIR/ls"
-node "$LESSONS" record --signature "FAIL: boom token=abc123xyz" --fix "export PASSWORD=hunterX99 후 재시도" --verified --lessons "$LDIR" >/dev/null || fail "T9: record #1 failed"
+node "$LESSONS" record --signature-file <(printf '%s\n' "FAIL: boom token=abc123xyz") --fix "export PASSWORD=hunterX99 후 재시도" --verified --lessons "$LDIR" >/dev/null || fail "T9: record #1 failed"
 grep -rq abc123xyz "$LDIR" && fail "T9: signature secret persisted in the lessons store"
 grep -rq hunterX99 "$LDIR" && fail "T9: fix secret persisted in the lessons store"
-ROUT="$(node "$LESSONS" record --signature "FAIL: boom token=abc123xyz" --verified --lessons "$LDIR")" || fail "T9: record #2 failed"
+ROUT="$(node "$LESSONS" record --signature-file <(printf '%s\n' "FAIL: boom token=abc123xyz") --verified --lessons "$LDIR")" || fail "T9: record #2 failed"
 printf '%s' "$ROUT" | grep -q 'count=2' || fail "T9: same raw signature must hit the same key (record/recall symmetry): $ROUT"
 
 # T10: 리뷰 회귀 — assertion operand·진단 어휘 보존 (lessons 서명 불변식·loop-fix stall 오탐 방지).

--- a/tools/ship-flow/skills/ship-feature/SKILL.md
+++ b/tools/ship-flow/skills/ship-feature/SKILL.md
@@ -79,6 +79,11 @@ a human.
   stops there.
 - **Issues live in this repo's tracker.** Use whatever this repo's `trackerName` config says (Linear is
   the worked example below); don't fall back to ad-hoc GitHub issues if a real tracker is configured.
+- **Verification results are quoted, not paraphrased.** Test runs, gate verdicts, review findings —
+  report these by pasting the actual output (or LOG file) verbatim, the same way step 5 pastes the
+  risk-verdict markdown block into the PR body rather than transcribing it. A hand-summarized paraphrase
+  can silently launder a partial/failing result into an apparent pass; the raw output is the evidence,
+  not a description of it.
 
 ## Risk gate — the rules classify, not the agent
 


### PR DESCRIPTION
## Summary

- `lessons.mjs record` accepted `--verified` on a hand-typed `--signature "<text>"` string with no `--signature-file` — a "verified" lesson backed by no evidence file at all, just whatever text was typed on the command line. Now `record` refuses this fail-closed (usage error, exit 2) unless backed by `--signature-file` (a real file path). Unverified records (no `--verified`) are unaffected — this is a constraint on the VERIFIED claim only.
- Header doc comment for `record` updated with the new rule.
- New test `tools/loop-engine/test/lessons-evidence-integrity.test.sh` locks: (1) hand-typed `--signature` + `--verified` → exit 2, error names `--signature-file`, no lesson file written; (2) `--signature-file` + `--verified` → succeeds; (3) hand-typed `--signature` without `--verified` → still succeeds (unverified path unaffected).
- Existing tests that hand-typed `--signature "<text>" --verified` (which the new fail-closed check would now reject) are updated to route the same literal text through `--signature-file <(printf '%s\n' "<text>")` — a real evidence file via process substitution, same signature hash, same test semantics, now honest evidence per the new rule. Touched: `lessons-category.test.sh`, `lessons-recall.test.sh`, `lessons-hygiene.test.sh`, `lessons-retire.test.sh`, `regression-signals.test.sh`, `sanitize.test.sh`. Production callers (`loop-fix.sh`'s verified/fail-channel record paths) already used `--signature-file` and needed no change.
- `ship-feature/SKILL.md`: added an explicit invariant — verification results (test runs, gate verdicts, review findings) are reported by quoting the actual output/LOG verbatim, never paraphrased. Generalizes step 5's existing "paste the risk-verdict markdown block verbatim into the PR body" rule to verification reporting throughout the flow.

## Verification

`bash tools/loop-engine/test/run.sh` (LOG, untruncated tail — full 19/19):

```
PASS: lessons category — read-time default, record create/update, invalid rejected, stats/recall filter+breakdown
PASS: lessons record evidence integrity (issue #9) — --verified without --signature-file is refused fail-closed, --signature-file + --verified succeeds, unverified hand-typed records are unaffected
PASS §1-8 (invalidate/recall/coerce hygiene)
PASS §9 (promote/stats invalidated exclusion, incl. previously-accepted lesson)
PASS §10 (mark-clean selective marking + fail-recurrence reset)
PASS: lessons hygiene (issue #6) — invalidate/mark-clean commands, coerce-time defaults, recall/promote/codify fail-closed exclusion (incl. previously-accepted lessons), stats open_candidates consistency, retirement-candidate annotation
PASS: lessons recall — miss hints on stderr only (key + semantic-recall routing), hit stays silent, --top removed
SKIP: BAC-580 probe needs tsx+lessons.ts (packages/loop-memory) — run 'pnpm install' first
PASS: lessons retire — fail-closed before accept, retires from listing/--codify/stats, content-change re-opens, rejected not counted, and (BAC-580) retired/reject lessons are excluded from loop-memory graduation + already-graduated notes are reaped
PASS: FAIL-channel lessons recorded on STALLED/MAX-ITER, withheld on INFRA/PROTECTED-VIOLATION, merged on later convergence
PASS: infra failures are budget-exempt with their own retry cap, no fixer spawn, no lessons pollution
...
PASS: regression-signals — deterministic PASS→FAIL detection + promote signal wiring (BAC-631)
...
PASS: sanitize.mjs — blocklist drop, truncation, pass-through, text masking, in-place atomic rewrite, fail-closed switch, verdict-run + lessons wiring, operand preservation, JSON/URL shapes, metric pass-through, fail-open path
PASS: --guard-mutation flips the verdict on git-visible mutation, stays opt-in, no gitignored false positives, fail-closed outside git
loop-engine selftest: 19/19 passed
```
(exit code 0; `...` above elides unrelated PASS lines already covered by base #6/#10 stacks — full log is 90+ lines, all PASS/SKIP, `run.sh` itself asserts `[ fails -eq 0 ]`)

`claude plugin validate --strict tools/loop-engine`:
```
Validating plugin manifest: /Users/paul/dev/paul-loop-9-evidence-integrity/tools/loop-engine/.claude-plugin/plugin.json

✔ Validation passed
```

`claude plugin validate --strict tools/ship-flow`:
```
Validating plugin manifest: /Users/paul/dev/paul-loop-9-evidence-integrity/tools/ship-flow/.claude-plugin/plugin.json

✔ Validation passed
```

Base-branch sanity check (before any change, on top of #6+#10): `bash tools/loop-engine/test/run.sh` was already green (`loop-engine selftest: 18/18 passed`, exit 0) — confirmed before starting implementation.

Closes #9

---

This PR is stacked on the #10 PR (https://github.com/paulkim-lansik/paul-loop/pull/24) — merge order: #20 → #24 → this PR.
