### PR TITLE
feat(loop-engine): AC-level success contract gate — ac-verify.sh (#23)

### DIFF
--- a/tools/loop-engine/bin/ac-verify.sh
+++ b/tools/loop-engine/bin/ac-verify.sh
@@ -5,7 +5,11 @@
 # through verdict-run.sh (the same Verdict Contract producer everything else in this repo
 # composes with), checks any `artifacts:`/`expect:` fields, and emits its own top-level VERDICT
 # block — so it plugs into whatever already consumes verdict-run.sh's shape (Stop-hook,
-# loop-fix.sh) unmodified.
+# loop-fix.sh) unmodified. This includes ${LOOP_DIR:-.loop}/verdict-state.json: each per-AC
+# verdict-run.sh sub-call writes that shared file with ITS OWN pass/fail (existing, unmodified
+# last-writer-wins contract), so after all ACs are processed this script makes one more sync call
+# whose only purpose is to be the last writer with the CORRECT overall aggregate — a Stop-hook-style
+# freshness gate reading that file sees ac-verify.sh's true result, not whichever AC ran last.
 #
 # Usage:
 #   ac-verify.sh <plan-file> [--log-dir <dir>]
@@ -78,6 +82,16 @@ join_semicolon() {
   printf '%s' "$out"
 }
 
+# Single-quote-escape $1 for safe embedding inside a single-quoted `sh -c` argument (used by the
+# verdict-state.json aggregate-sync call below — the plan path may contain spaces/quotes). Classic
+# close-quote/escaped-quote/reopen-quote trick. Note: BSD/macOS sed drops a lone backslash before a
+# non-special replacement char, so this needs FOUR backslashes in the double-quoted sed argument
+# (bash's own double-quote parsing folds 4 -> 2, then sed's `\\` -> one literal backslash escape
+# folds 2 -> 1) to land a single literal backslash in the output — verified empirically on macOS.
+shquote() {
+  printf '%s' "$1" | sed "s/'/'\\\\''/g"
+}
+
 # ---- parse args ----
 PLAN=""
 LOG_DIR="${LOOP_DIR:-.loop}"   # matches verdict-run.sh's own ${LOOP_DIR:-.loop} default convention
@@ -143,20 +157,68 @@ while IFS= read -r line || [ -n "$line" ]; do
         if [ "$first" -eq 1 ]; then
           desc="$(trim "$tok")"; first=0; continue
         fi
-        case "$tok" in
-          verify:*)
-            cur_field="verify"; verify_cmd="$(trim "${tok#verify:}")" ;;
-          artifacts:*)
-            cur_field="artifacts"; artifacts_field="$(trim "${tok#artifacts:}")" ;;
-          expect:*)
-            cur_field="expect"; expect_field="$(trim "${tok#expect:}")" ;;
+
+        # ---- normalize a COPY of the token for field-prefix matching only — lowercase (bash 3.2:
+        # tr, no ${var,,}) + strip up to one layer of leading markdown emphasis (**/__/*/_)
+        # immediately before the field name. Without this, an authoring variant like `Verify:` or
+        # `**verify:**` (both plausible things an LLM or human plan author writes) silently and
+        # invisibly folds into the description — a typo that quietly turns a real intended
+        # contract into "no contract", indistinguishable from a deliberately-uncontracted AC. The
+        # ORIGINAL (case-preserved, marker-preserved) text is used for the extracted VALUE below —
+        # only the prefix-match step itself needs to tolerate this.
+        tok_stripped="$tok"
+        case "$tok_stripped" in
+          '**'*) tok_stripped="${tok_stripped:2}" ;;
+          '__'*) tok_stripped="${tok_stripped:2}" ;;
+          '*'*)  tok_stripped="${tok_stripped:1}" ;;
+          '_'*)  tok_stripped="${tok_stripped:1}" ;;
+        esac
+        tok_norm="$(printf '%s' "$tok_stripped" | tr 'A-Z' 'a-z')"
+
+        field=""; label_len=0
+        case "$tok_norm" in
+          verify:*)    field="verify";    label_len=7  ;;
+          artifacts:*) field="artifacts"; label_len=10 ;;
+          expect:*)    field="expect";    label_len=7  ;;
+        esac
+
+        if [ -n "$field" ]; then
+          value="${tok_stripped:$label_len}"
+          # trailing emphasis markers immediately after the colon — the closing `**` of
+          # `**verify:**` lands here (same one-layer tolerance, other side of the label).
+          case "$value" in
+            '**'*) value="${value:2}" ;;
+            '__'*) value="${value:2}" ;;
+            '*'*)  value="${value:1}" ;;
+            '_'*)  value="${value:1}" ;;
+          esac
+          value="$(trim "$value")"
+          cur_field="$field"
+          case "$field" in
+            verify)    verify_cmd="$value" ;;
+            artifacts) artifacts_field="$value" ;;
+            expect)    expect_field="$value" ;;
+          esac
+          continue
+        fi
+
+        case "$cur_field" in
+          verify)    verify_cmd="$verify_cmd | $tok" ;;
+          artifacts) artifacts_field="$artifacts_field | $tok" ;;
+          expect)    expect_field="$expect_field | $tok" ;;
           *)
-            case "$cur_field" in
-              verify)    verify_cmd="$verify_cmd | $tok" ;;
-              artifacts) artifacts_field="$artifacts_field | $tok" ;;
-              expect)    expect_field="$expect_field | $tok" ;;
-              *)         desc="$desc | $tok" ;;
+            # This segment matched none of the three known fields (even after the normalization
+            # above) and is about to silently vanish into the description — exactly the
+            # invisible-typo failure mode. If it LOOKS like a mistyped field (a `:` within roughly
+            # its first 20 chars), warn on stderr so it's visible instead of silent. Stays a
+            # warning, not a hard error: an ordinary colon in free-text description content is
+            # legitimate and common — failing the build over it would be worse than the bug.
+            seg="$(trim "$tok")"
+            head20="$(printf '%s' "$seg" | cut -c1-20)"
+            case "$head20" in
+              *:*) echo "ac-verify.sh: warning — AC #$idx (\"$desc\"): unrecognized field-like segment (folded into description, not treated as a contract): \"$seg\"" >&2 ;;
             esac
+            desc="$desc | $tok"
             ;;
         esac
       done
@@ -279,6 +341,26 @@ else
 fi
 
 code=0; [ "$verdict" = "FAIL" ] && code=1
+
+# ---- correct the shared verdict-state.json: make OUR aggregate the last writer ----
+# Every per-AC `"$VERDICT_RUN" --log "$ac_log" -- sh -c "$verify_cmd"` call above already wrote
+# ${LOOP_DIR:-.loop}/verdict-state.json via verdict-run.sh's own write_state() (existing,
+# unmodified last-writer-wins contract — every layer writes it, that part of verdict-run.sh is
+# correct and untouched here). Left alone, whichever AC happened to be PROCESSED LAST leaves ITS
+# OWN pass/fail there — which can silently disagree with ac-verify.sh's own true aggregate
+# $verdict/$code above (e.g. an earlier AC failed but the last AC processed passed: the file would
+# read "PASS" even though our own VERDICT block below correctly says FAIL). A consumer reading
+# verdict-state.json directly (e.g. a Stop-hook-style freshness gate) would see a stale, wrong
+# "fresh PASS" for a run that genuinely failed.
+#
+# Fix: one final verdict-run.sh call whose only purpose is its write_state() side effect — make it
+# the last writer with the CORRECT aggregate result. Runs unconditionally (PASS or FAIL). Its own
+# stdout (a second, poorer VERDICT block) is thrown away (>/dev/null) — ac-verify.sh's own richer,
+# AC-specific block below (with the real passed=/failed=/skipped= SUMMARY) remains the only VERDICT
+# block that reaches the caller's stdout. Logged to a dedicated path, distinct from any per-AC log.
+SYNC_LOG="$LOGSUBDIR/aggregate-sync.log"
+sync_desc="ac-verify.sh aggregate result for '$(shquote "$PLAN")'"
+"$VERDICT_RUN" --log "$SYNC_LOG" -- sh -c ": $sync_desc; exit $code" >/dev/null 2>&1
 
 printf '=== VERDICT ===\n'
 printf 'VERDICT: %s\n' "$verdict"

--- a/tools/loop-engine/bin/ac-verify.sh
+++ b/tools/loop-engine/bin/ac-verify.sh
@@ -150,10 +150,31 @@ join_semicolon() {
 }
 
 # ---- parse args ----
+# --log-dir's dependents (LOGSUBDIR/SYNC_LOG/the LOOP_DIR export coupling verdict-run.sh's own
+# state-file location to ours, issue #23 round-2 finding) are applied INLINE, the instant --log-dir
+# itself is parsed — not deferred to after the loop finishes. Round-4 adversarial finding: a
+# post-loop "finalize" step left a window where a LATER usage error in the same invocation (e.g.
+# `plan.md --log-dir custom-dir --bogus-flag`) could exit before that finalize step ever ran, so
+# the trap's corrective sync silently fell back to the unrelated default `.loop/` instead of the
+# just-parsed --log-dir target — reproduced, the exact stale-state failure mode every prior round
+# exists to prevent, just relocated to a value that hadn't been "applied" yet. Applying it the
+# moment it's parsed removes the window entirely: there is no longer a separate "parsed but not
+# yet applied" state for --log-dir to be caught in when a later argument in the same command line
+# errors out.
 PLAN=""
 while [ $# -gt 0 ]; do
   case "$1" in
-    --log-dir) need2 $# "$1"; LOG_DIR="$2"; shift 2 ;;
+    --log-dir)
+      need2 $# "$1"
+      case "$2" in
+        -*) echo "ac-verify.sh: --log-dir requires a directory path, not another flag ('$2')" >&2; exit 2 ;;
+      esac
+      LOG_DIR="$2"
+      LOGSUBDIR="$LOG_DIR/ac-verify"
+      SYNC_LOG="$LOGSUBDIR/aggregate-sync.log"
+      export LOOP_DIR="$LOG_DIR"
+      shift 2
+      ;;
     --*)       echo "ac-verify.sh: unknown flag $1" >&2; exit 2 ;;
     *)
       if [ -z "$PLAN" ]; then PLAN="$1"; shift
@@ -161,22 +182,6 @@ while [ $# -gt 0 ]; do
       ;;
   esac
 done
-
-# ---- LOG_DIR is now finalized (flag parsed, default applied). Re-derive its dependents (the
-# trap above already covered every exit up to this point using the pre-parse default) ----
-LOGSUBDIR="$LOG_DIR/ac-verify"
-SYNC_LOG="$LOGSUBDIR/aggregate-sync.log"
-
-# Couple verdict-run.sh's own ${LOOP_DIR:-.loop} default to OUR --log-dir (issue #23 round-2
-# finding: they were previously decoupled — verdict-run.sh's write_state() derives
-# verdict-state.json's path purely from ITS OWN process's LOOP_DIR env var, which ac-verify.sh
-# never set, so a non-default --log-dir silently got its state file written to the unrelated
-# default ./.loop/ instead, and two parallel --log-dir runs with no manually-exported LOOP_DIR
-# would clobber the same shared default file). Exporting here makes every verdict-run.sh sub-call
-# below (per-AC calls and the corrective sync call) inherit a LOOP_DIR guaranteed to match
-# --log-dir. Both default to the literal ".loop", so this is a no-op for every caller that doesn't
-# pass --log-dir.
-export LOOP_DIR="$LOG_DIR"
 
 if [ -z "$PLAN" ]; then
   echo "ac-verify.sh: a plan file is required. Usage: ac-verify.sh <plan-file> [--log-dir <dir>]" >&2

--- a/tools/loop-engine/bin/ac-verify.sh
+++ b/tools/loop-engine/bin/ac-verify.sh
@@ -1,0 +1,296 @@
+#!/usr/bin/env bash
+# ac-verify.sh — AC-level success contract gate (ADR-0104, issue #23).
+#
+# Parses a plan file for one-line AC contracts, runs each contracted AC's `verify:` command
+# through verdict-run.sh (the same Verdict Contract producer everything else in this repo
+# composes with), checks any `artifacts:`/`expect:` fields, and emits its own top-level VERDICT
+# block — so it plugs into whatever already consumes verdict-run.sh's shape (Stop-hook,
+# loop-fix.sh) unmodified.
+#
+# Usage:
+#   ac-verify.sh <plan-file> [--log-dir <dir>]
+#
+# <plan-file> is a markdown (or plain text) file. It is scanned line-by-line for AC lines of the
+# form (an optional leading markdown list marker is tolerated):
+#
+#   AC: <description> | verify: <command> | artifacts: <paths> | expect: <substring>
+#   - AC: <description> | verify: <command>
+#
+# Only `AC: <description>` is required. `verify:`, `artifacts:`, and `expect:` are each optional,
+# may appear in any combination, and in any order after the description — each field is
+# separated from its neighbours by ` | ` (space-pipe-space). An AC line with none of the three
+# optional fields is a legitimate, human-readable-only acceptance criterion: it counts as
+# `skipped` in the aggregate, not as a failure in itself.
+#
+# artifacts: delimiter convention — COMMA-separated (`artifacts: path/one, path/two`). Chosen
+# over whitespace because paths may themselves contain spaces, and the field is already bounded
+# by ` | ` on both sides. Use this convention consistently anywhere plans are authored (see the
+# ship-feature SKILL.md step 1 guidance, which quotes this same syntax).
+#
+# Per contracted AC:
+#   - verify:    run via `verdict-run.sh --log <per-AC log> -- sh -c "<command>"` (same
+#                `-- sh -c` invocation loop-fix.sh uses). verdict-run.sh's own exit code decides
+#                this check: 0 = pass, nonzero = fail. A verdict-run.sh exit of 2 (its own
+#                usage-error / fail-closed refusal) is NOT a normal AC failure — it aborts
+#                ac-verify.sh itself with exit 2, same as loop-fix.sh's handling of the same case.
+#   - artifacts: each comma-separated path must exist (`-e`), resolved relative to the CWD
+#                ac-verify.sh itself runs from (NOT the plan file's directory — verify commands
+#                and artifacts are expected relative to the repo/worktree root, same as verify
+#                commands already are).
+#   - expect:    the per-AC log (verdict-run.sh's untruncated LOG output for that AC; empty if
+#                the AC has no verify: field) must contain this LITERAL substring (`grep -F`, not
+#                a regex).
+# An AC is fully PASSED only if every field it declares independently passes. A field that isn't
+# present on that AC line is simply not checked (neither pass nor fail).
+#
+# Fail-closed (modeled directly on require-tests.sh's "0 tests = RED"): if the plan has zero AC
+# lines at all, OR has AC lines but zero of them carry any contract field, the overall VERDICT is
+# FAIL — a gate that can PASS over zero contracts is exactly the dogfood trap ADR-0104 documents
+# (optional fields go unfilled unless something makes zero unacceptable). This does not require
+# every AC to have a contract — only that the plan as a whole has at least one.
+#
+# Exit code: 0 when VERDICT is PASS, 1 when FAIL, 2 on a genuine usage error (missing/unreadable
+# plan file, bad flag, or a verdict-run.sh exit-2 encountered mid-run — see above).
+#
+# bash 3.2 compatible (macOS default). No associative arrays, no ${var,,}, no mapfile/readarray.
+
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+VERDICT_RUN="$HERE/verdict-run.sh"
+SEP=$'\x1e'   # rare separator used only to split on literal " | " without touching pipes elsewhere in a token
+
+need2() { [ "$1" -ge 2 ] || { echo "ac-verify.sh: $2 requires a value" >&2; exit 2; }; }
+
+now_ms() {
+  perl -MTime::HiRes=time -e 'printf "%d", time()*1000' 2>/dev/null || echo $(( $(date +%s) * 1000 ))
+}
+
+trim() {
+  printf '%s' "$1" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//'
+}
+
+join_semicolon() {
+  out=""
+  for a in "$@"; do
+    if [ -z "$out" ]; then out="$a"; else out="$out; $a"; fi
+  done
+  printf '%s' "$out"
+}
+
+# ---- parse args ----
+PLAN=""
+LOG_DIR="${LOOP_DIR:-.loop}"   # matches verdict-run.sh's own ${LOOP_DIR:-.loop} default convention
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --log-dir) need2 $# "$1"; LOG_DIR="$2"; shift 2 ;;
+    --*)       echo "ac-verify.sh: unknown flag $1" >&2; exit 2 ;;
+    *)
+      if [ -z "$PLAN" ]; then PLAN="$1"; shift
+      else echo "ac-verify.sh: unexpected extra argument '$1'" >&2; exit 2; fi
+      ;;
+  esac
+done
+
+if [ -z "$PLAN" ]; then
+  echo "ac-verify.sh: a plan file is required. Usage: ac-verify.sh <plan-file> [--log-dir <dir>]" >&2
+  exit 2
+fi
+if [ ! -f "$PLAN" ] || [ ! -r "$PLAN" ]; then
+  echo "ac-verify.sh: cannot read plan file '$PLAN'" >&2
+  exit 2
+fi
+if [ ! -x "$VERDICT_RUN" ]; then
+  echo "ac-verify.sh: cannot find verdict-run.sh next to me ($VERDICT_RUN)" >&2
+  exit 2
+fi
+
+LOGSUBDIR="$LOG_DIR/ac-verify"
+mkdir -p "$LOGSUBDIR" 2>/dev/null || { echo "ac-verify.sh: cannot create log directory '$LOGSUBDIR'" >&2; exit 2; }
+AGG_LOG="$LOG_DIR/ac-verify.log"
+: > "$AGG_LOG" 2>/dev/null || { echo "ac-verify.sh: cannot write aggregate log file '$AGG_LOG'" >&2; exit 2; }
+case "$AGG_LOG" in
+  /*) AGG_LOG_ABS="$AGG_LOG" ;;
+  *)  AGG_LOG_ABS="$(pwd)/$AGG_LOG" ;;
+esac
+printf 'ac-verify.sh aggregate log for plan: %s\n\n' "$PLAN" >> "$AGG_LOG"
+
+start_ms="$(now_ms)"
+
+total=0; contracted=0; passed=0; failed=0
+FAILS=()
+idx=0
+
+# ---- scan the plan file for AC lines ----
+while IFS= read -r line || [ -n "$line" ]; do
+  if [[ "$line" =~ ^[[:space:]]*(-[[:space:]]+)?AC:[[:space:]]*(.*)$ ]]; then
+    content="${BASH_REMATCH[2]}"
+    idx=$((idx + 1))
+    total=$((total + 1))
+
+    # ---- split content on literal " | " (space-pipe-space), tolerating pipes embedded inside a
+    # field's own value — e.g. a verify: command with a shell pipe — by re-merging any segment
+    # that doesn't start with a known field prefix back onto the current field. ----
+    content_sub="${content// | /$SEP}"
+    IFS="$SEP" read -ra toks <<< "$content_sub"
+
+    desc=""; verify_cmd=""; artifacts_field=""; expect_field=""
+    cur_field="desc"; first=1
+    # bash 3.2 + `set -u`: expanding "${toks[@]}" on a zero-element array is an unbound-variable
+    # error, so guard with the count first (an AC line with nothing after "AC:" produces one).
+    if [ "${#toks[@]}" -gt 0 ]; then
+      for tok in "${toks[@]}"; do
+        if [ "$first" -eq 1 ]; then
+          desc="$(trim "$tok")"; first=0; continue
+        fi
+        case "$tok" in
+          verify:*)
+            cur_field="verify"; verify_cmd="$(trim "${tok#verify:}")" ;;
+          artifacts:*)
+            cur_field="artifacts"; artifacts_field="$(trim "${tok#artifacts:}")" ;;
+          expect:*)
+            cur_field="expect"; expect_field="$(trim "${tok#expect:}")" ;;
+          *)
+            case "$cur_field" in
+              verify)    verify_cmd="$verify_cmd | $tok" ;;
+              artifacts) artifacts_field="$artifacts_field | $tok" ;;
+              expect)    expect_field="$expect_field | $tok" ;;
+              *)         desc="$desc | $tok" ;;
+            esac
+            ;;
+        esac
+      done
+    fi
+
+    has_contract=0
+    [ -n "$verify_cmd" ] && has_contract=1
+    [ -n "$artifacts_field" ] && has_contract=1
+    [ -n "$expect_field" ] && has_contract=1
+    if [ "$has_contract" -eq 0 ]; then
+      continue   # description-only AC: legitimate, counted under skipped= below (not a failure)
+    fi
+    contracted=$((contracted + 1))
+
+    ac_log="$LOGSUBDIR/ac-$idx.log"
+    reasons=()
+
+    if [ -n "$verify_cmd" ]; then
+      # Capture verdict-run's own compact block via command substitution (NOT a `>` file
+      # redirect) — a file redirect that fails to open (e.g. an unwritable log dir) would exit 1
+      # itself WITHOUT verdict-run.sh ever running, masking what should be verdict-run's own
+      # exit-2 usage error as an ordinary AC FAIL. verdict-run.sh creates/truncates $ac_log itself
+      # (its own --log target), so we don't pre-touch it here — only in the else-branch below.
+      vr_out="$("$VERDICT_RUN" --log "$ac_log" -- sh -c "$verify_cmd" 2>&1)"
+      vcode=$?
+      if [ "$vcode" -eq 2 ]; then
+        # Mirrors loop-fix.sh's own handling: verdict-run's exit 2 is ITS usage error/fail-closed
+        # refusal, not a normal verify FAIL — don't silently swallow it into an AC failure.
+        echo "ac-verify.sh: verdict-run.sh refused to run for AC #$idx (\"$desc\") — usage error (exit 2):" >&2
+        printf '%s\n' "$vr_out" | sed 's/^/    /' >&2
+        exit 2
+      fi
+      if [ "$vcode" -ne 0 ]; then
+        # verdict-run.sh's own exit code just mirrors PASS/FAIL (0/1) — pull the underlying
+        # command's real exit code out of verdict-run's emitted block for a more useful reason.
+        real_exit="$(printf '%s\n' "$vr_out" | grep -m1 '^EXIT: ' | sed 's/^EXIT: //')"
+        if [ -n "$real_exit" ]; then
+          reasons+=("verify exited $real_exit")
+        else
+          reasons+=("verify failed (verdict-run.sh exit $vcode)")
+        fi
+      fi
+    else
+      # No verify: field — nothing else will create $ac_log, but expect: (if present) still needs
+      # a defined (empty) target to grep. A write failure here means the environment itself is
+      # broken (unwritable log dir) — fail closed with exit 2 rather than silently mis-reporting
+      # it as an ordinary AC FAIL.
+      if ! : > "$ac_log" 2>/dev/null; then
+        echo "ac-verify.sh: cannot write per-AC log '$ac_log' for AC #$idx (\"$desc\")" >&2
+        exit 2
+      fi
+    fi
+
+    if [ -n "$artifacts_field" ]; then
+      missing=""
+      IFS=',' read -ra apaths <<< "$artifacts_field"
+      if [ "${#apaths[@]}" -gt 0 ]; then
+        for p in "${apaths[@]}"; do
+          pt="$(trim "$p")"
+          [ -z "$pt" ] && continue
+          if [ ! -e "$pt" ]; then
+            if [ -z "$missing" ]; then missing="$pt"; else missing="$missing, $pt"; fi
+          fi
+        done
+      fi
+      [ -n "$missing" ] && reasons+=("missing artifact(s): $missing")
+    fi
+
+    if [ -n "$expect_field" ]; then
+      if ! grep -qF -- "$expect_field" "$ac_log" 2>/dev/null; then
+        reasons+=("expect substring not found: \"$expect_field\"")
+      fi
+    fi
+
+    ac_ok=1
+    [ "${#reasons[@]}" -gt 0 ] && ac_ok=0
+
+    {
+      printf '===== AC #%s: %s =====\n' "$idx" "$desc"
+      [ -n "$verify_cmd" ]      && printf 'verify: %s\n' "$verify_cmd"
+      [ -n "$artifacts_field" ] && printf 'artifacts: %s\n' "$artifacts_field"
+      [ -n "$expect_field" ]    && printf 'expect: %s\n' "$expect_field"
+      if [ "$ac_ok" -eq 1 ]; then
+        printf 'result: PASS\n'
+      else
+        printf 'result: FAIL (%s)\n' "$(join_semicolon "${reasons[@]}")"
+      fi
+      printf -- '--- output log: %s ---\n' "$ac_log"
+      cat "$ac_log" 2>/dev/null
+      printf '\n'
+    } >> "$AGG_LOG"
+
+    if [ "$ac_ok" -eq 1 ]; then
+      passed=$((passed + 1))
+    else
+      failed=$((failed + 1))
+      FAILS+=("AC \"$desc\": $(join_semicolon "${reasons[@]}")")
+    fi
+  fi
+done < "$PLAN"
+
+skipped=$((total - contracted))
+end_ms="$(now_ms)"
+dur=$(( end_ms - start_ms ))
+[ "$dur" -lt 0 ] && dur=0
+
+# ---- fail-closed: zero AC lines, or AC lines with zero contracts (require-tests.sh precedent) ----
+if [ "$total" -eq 0 ]; then
+  verdict="FAIL"
+  FAILS=("plan file '$PLAN' has ZERO AC lines ('AC: <description>') — a runtime-surface track requires at least one AC contract (verify:/artifacts:/expect:); same fail-closed shape as require-tests.sh's 0-tests=RED (refusing to certify PASS over nothing).")
+  printf 'ac-verify.sh: no "AC:" lines found in %s\n' "$PLAN" >> "$AGG_LOG"
+elif [ "$contracted" -eq 0 ]; then
+  verdict="FAIL"
+  FAILS=("plan file '$PLAN' has $total AC line(s) but ZERO carry a machine-checkable contract (verify:/artifacts:/expect:) — a runtime-surface track requires at least one AC contract; same fail-closed shape as require-tests.sh's 0-tests=RED (refusing to certify PASS over nothing).")
+  printf 'ac-verify.sh: %s AC line(s) found in %s but none carry a verify:/artifacts:/expect: contract\n' "$total" "$PLAN" >> "$AGG_LOG"
+elif [ "$failed" -gt 0 ]; then
+  verdict="FAIL"
+else
+  verdict="PASS"
+fi
+
+code=0; [ "$verdict" = "FAIL" ] && code=1
+
+printf '=== VERDICT ===\n'
+printf 'VERDICT: %s\n' "$verdict"
+printf 'EXIT: %s\n' "$code"
+printf 'SUMMARY: passed=%s failed=%s skipped=%s duration_ms=%s\n' "$passed" "$failed" "$skipped" "$dur"
+# bash 3.2 + `set -u`: guard the same zero-element-array expansion pitfall as above.
+if [ "${#FAILS[@]}" -gt 0 ]; then
+  for f in "${FAILS[@]}"; do
+    printf 'FAIL: %s\n' "$f"
+  done
+fi
+printf 'LOG: %s\n' "$AGG_LOG_ABS"
+printf '=== END VERDICT ===\n'
+
+exit "$code"

--- a/tools/loop-engine/bin/ac-verify.sh
+++ b/tools/loop-engine/bin/ac-verify.sh
@@ -8,10 +8,11 @@
 # loop-fix.sh) unmodified. This includes ${LOOP_DIR:-.loop}/verdict-state.json — coupled to OUR
 # --log-dir via an explicit `export LOOP_DIR="$LOG_DIR"` (see below) so a non-default --log-dir
 # isn't silently ignored: each per-AC verdict-run.sh sub-call writes that shared file with ITS OWN
-# pass/fail (existing, unmodified last-writer-wins contract). An EXIT trap (registered right after
-# LOG_DIR is finalized, see below) makes one corrective sync call on EVERY exit path this script
-# can take — normal completion AND any early exit (usage errors, a verdict-run.sh exit-2 hit
-# mid-run, or any exit path added later) — so it is always the last writer: the true aggregate on
+# pass/fail (existing, unmodified last-writer-wins contract). An EXIT trap (armed at the very top
+# of the script, before argument parsing even begins, see below) makes one corrective sync call on
+# EVERY exit path this script can take — normal completion AND any early exit (usage errors
+# including ones during argument parsing itself, a verdict-run.sh exit-2 hit mid-run, or any exit
+# path added later) — so it is always the last writer: the true aggregate on
 # normal completion, a fail-closed default on any early exit. A Stop-hook-style freshness gate
 # reading that file always sees ac-verify.sh's true result for THIS run, never a stale leftover
 # from an earlier AC or an earlier unrelated run.
@@ -67,6 +68,67 @@ set -uo pipefail
 
 HERE="$(cd "$(dirname "$0")" && pwd)"
 VERDICT_RUN="$HERE/verdict-run.sh"
+
+# ---- fail-closed corrective verdict-state.json sync via an EXIT trap — armed FIRST, before ANY
+# possible exit path (round-3 adversarial finding: the trap used to be registered AFTER the
+# argument-parsing while-loop below, so a usage error DURING parsing itself — an unknown flag,
+# `--log-dir` given with no value, a stray extra positional argument — called `exit 2` before the
+# trap was ever armed, leaving a stale earlier verdict-state.json completely untouched). Nothing
+# below this point may run any command that can exit before `trap ... EXIT` on the next line has
+# executed — so this block only ever does plain variable assignments and function *definitions*
+# (which cannot themselves fail/exit), never a command invocation.
+#
+# LOG_DIR gets its safe default here (matches verdict-run.sh's own ${LOOP_DIR:-.loop} convention)
+# so the trap has a real target even if a usage error strikes before the argument-parsing loop
+# below ever runs. That loop still overrides LOG_DIR via --log-dir when given (unchanged), and
+# re-derives LOGSUBDIR from the finalized value right after — since the trap's handler reads
+# SYNC_LOG (and SYNC_VERDICT_EXIT) at the moment it actually FIRES, not at registration time (bash
+# closures over the current value of a global variable), it continues to target wherever LOG_DIR
+# ends up being by the time of any given exit, exactly as it already did for the exit paths that
+# were already covered.
+#
+# ac-verify.sh has multiple exit paths — normal completion, usage errors (now including ones
+# during argument parsing itself), and a per-AC verdict-run.sh sub-call's own exit-2 refusal
+# encountered mid-run (see the header comment, and any exit path added later). A sync call placed
+# only at normal completion leaves every early-exit path with whatever an earlier AC's OWN
+# sub-call happened to leave in verdict-state.json (last-writer-wins) — a stale, unrelated
+# pass/fail for a run that never actually finished. Fixing this per call-site doesn't scale (the
+# next new early-exit path reopens the same gap) — so instead ONE trap fires on every exit, no
+# matter which code path reaches it, and makes one corrective verdict-run.sh sync call
+# (stdout+stderr discarded) whose only purpose is to be the last writer.
+#
+# SYNC_VERDICT_EXIT starts fail-closed (1 = FAIL) BEFORE the trap is registered — "treat this run
+# as failed/incomplete unless proven otherwise". Only the normal-completion path far below (once
+# the true aggregate $code has actually been computed) updates SYNC_VERDICT_EXIT to that real
+# value, right before the script's final `exit "$code"` — which is what fires the trap. Every
+# other exit reaches the trap with the untouched fail-closed default. The handler never calls
+# `exit` itself (that would clobber the real exit code this script is trying to return) — it only
+# runs its side effect and lets the original exit code propagate.
+LOG_DIR="${LOOP_DIR:-.loop}"   # matches verdict-run.sh's own ${LOOP_DIR:-.loop} default convention
+LOGSUBDIR="$LOG_DIR/ac-verify"
+SYNC_VERDICT_EXIT=1
+SYNC_LOG="$LOGSUBDIR/aggregate-sync.log"
+
+# Single-quote-escape $1 for safe embedding inside a single-quoted `sh -c` argument (used by the
+# verdict-state.json aggregate-sync call below — the plan path may contain spaces/quotes). Classic
+# close-quote/escaped-quote/reopen-quote trick. Note: BSD/macOS sed drops a lone backslash before a
+# non-special replacement char, so this needs FOUR backslashes in the double-quoted sed argument
+# (bash's own double-quote parsing folds 4 -> 2, then sed's `\\` -> one literal backslash escape
+# folds 2 -> 1) to land a single literal backslash in the output — verified empirically on macOS.
+# Defined here (not further below with the other small helpers) because sync_verdict_state_on_exit
+# calls it directly — a plain assignment/def block like this one can't itself exit, so defining it
+# ahead of the trap registration below is safe (PLAN is still unset at trap-registration time; the
+# handler reads its CURRENT value, empty string, when it actually fires).
+shquote() {
+  printf '%s' "$1" | sed "s/'/'\\\\''/g"
+}
+
+sync_verdict_state_on_exit() {
+  sync_desc="ac-verify.sh aggregate result for '$(shquote "${PLAN:-}")'"
+  "$VERDICT_RUN" --log "$SYNC_LOG" -- sh -c ": $sync_desc; exit $SYNC_VERDICT_EXIT" >/dev/null 2>&1
+}
+trap sync_verdict_state_on_exit EXIT
+
 SEP=$'\x1e'   # rare separator used only to split on literal " | " without touching pipes elsewhere in a token
 
 need2() { [ "$1" -ge 2 ] || { echo "ac-verify.sh: $2 requires a value" >&2; exit 2; }; }
@@ -87,19 +149,8 @@ join_semicolon() {
   printf '%s' "$out"
 }
 
-# Single-quote-escape $1 for safe embedding inside a single-quoted `sh -c` argument (used by the
-# verdict-state.json aggregate-sync call below — the plan path may contain spaces/quotes). Classic
-# close-quote/escaped-quote/reopen-quote trick. Note: BSD/macOS sed drops a lone backslash before a
-# non-special replacement char, so this needs FOUR backslashes in the double-quoted sed argument
-# (bash's own double-quote parsing folds 4 -> 2, then sed's `\\` -> one literal backslash escape
-# folds 2 -> 1) to land a single literal backslash in the output — verified empirically on macOS.
-shquote() {
-  printf '%s' "$1" | sed "s/'/'\\\\''/g"
-}
-
 # ---- parse args ----
 PLAN=""
-LOG_DIR="${LOOP_DIR:-.loop}"   # matches verdict-run.sh's own ${LOOP_DIR:-.loop} default convention
 while [ $# -gt 0 ]; do
   case "$1" in
     --log-dir) need2 $# "$1"; LOG_DIR="$2"; shift 2 ;;
@@ -111,7 +162,10 @@ while [ $# -gt 0 ]; do
   esac
 done
 
-# ---- LOG_DIR is now finalized (flag parsed, default applied) ----
+# ---- LOG_DIR is now finalized (flag parsed, default applied). Re-derive its dependents (the
+# trap above already covered every exit up to this point using the pre-parse default) ----
+LOGSUBDIR="$LOG_DIR/ac-verify"
+SYNC_LOG="$LOGSUBDIR/aggregate-sync.log"
 
 # Couple verdict-run.sh's own ${LOOP_DIR:-.loop} default to OUR --log-dir (issue #23 round-2
 # finding: they were previously decoupled — verdict-run.sh's write_state() derives
@@ -123,34 +177,6 @@ done
 # --log-dir. Both default to the literal ".loop", so this is a no-op for every caller that doesn't
 # pass --log-dir.
 export LOOP_DIR="$LOG_DIR"
-
-LOGSUBDIR="$LOG_DIR/ac-verify"
-
-# ---- fail-closed corrective verdict-state.json sync via an EXIT trap ----
-# ac-verify.sh has multiple exit paths — this normal-completion path, plus early exits on usage
-# errors and on a per-AC verdict-run.sh sub-call's own exit-2 refusal encountered mid-run (see the
-# header comment, and any exit path added later). A sync call placed only at normal completion
-# leaves every early-exit path with whatever an earlier AC's OWN sub-call happened to leave in
-# verdict-state.json (last-writer-wins) — a stale, unrelated pass/fail for a run that never
-# actually finished. Fixing this per call-site doesn't scale (the next new early-exit path
-# reopens the same gap) — so instead ONE trap fires on every exit, no matter which code path
-# reaches it, and makes one corrective verdict-run.sh sync call (stdout+stderr discarded) whose
-# only purpose is to be the last writer.
-#
-# SYNC_VERDICT_EXIT starts fail-closed (1 = FAIL) BEFORE the trap is registered — "treat this run
-# as failed/incomplete unless proven otherwise". Only the normal-completion path below (once the
-# true aggregate $code has actually been computed) updates SYNC_VERDICT_EXIT to that real value,
-# right before the script's final `exit "$code"` — which is what fires the trap. Every other exit
-# reaches the trap with the untouched fail-closed default. The handler never calls `exit` itself
-# (that would clobber the real exit code this script is trying to return) — it only runs its side
-# effect and lets the original exit code propagate.
-SYNC_VERDICT_EXIT=1
-SYNC_LOG="$LOGSUBDIR/aggregate-sync.log"
-sync_verdict_state_on_exit() {
-  sync_desc="ac-verify.sh aggregate result for '$(shquote "$PLAN")'"
-  "$VERDICT_RUN" --log "$SYNC_LOG" -- sh -c ": $sync_desc; exit $SYNC_VERDICT_EXIT" >/dev/null 2>&1
-}
-trap sync_verdict_state_on_exit EXIT
 
 if [ -z "$PLAN" ]; then
   echo "ac-verify.sh: a plan file is required. Usage: ac-verify.sh <plan-file> [--log-dir <dir>]" >&2

--- a/tools/loop-engine/bin/ac-verify.sh
+++ b/tools/loop-engine/bin/ac-verify.sh
@@ -5,11 +5,16 @@
 # through verdict-run.sh (the same Verdict Contract producer everything else in this repo
 # composes with), checks any `artifacts:`/`expect:` fields, and emits its own top-level VERDICT
 # block — so it plugs into whatever already consumes verdict-run.sh's shape (Stop-hook,
-# loop-fix.sh) unmodified. This includes ${LOOP_DIR:-.loop}/verdict-state.json: each per-AC
-# verdict-run.sh sub-call writes that shared file with ITS OWN pass/fail (existing, unmodified
-# last-writer-wins contract), so after all ACs are processed this script makes one more sync call
-# whose only purpose is to be the last writer with the CORRECT overall aggregate — a Stop-hook-style
-# freshness gate reading that file sees ac-verify.sh's true result, not whichever AC ran last.
+# loop-fix.sh) unmodified. This includes ${LOOP_DIR:-.loop}/verdict-state.json — coupled to OUR
+# --log-dir via an explicit `export LOOP_DIR="$LOG_DIR"` (see below) so a non-default --log-dir
+# isn't silently ignored: each per-AC verdict-run.sh sub-call writes that shared file with ITS OWN
+# pass/fail (existing, unmodified last-writer-wins contract). An EXIT trap (registered right after
+# LOG_DIR is finalized, see below) makes one corrective sync call on EVERY exit path this script
+# can take — normal completion AND any early exit (usage errors, a verdict-run.sh exit-2 hit
+# mid-run, or any exit path added later) — so it is always the last writer: the true aggregate on
+# normal completion, a fail-closed default on any early exit. A Stop-hook-style freshness gate
+# reading that file always sees ac-verify.sh's true result for THIS run, never a stale leftover
+# from an earlier AC or an earlier unrelated run.
 #
 # Usage:
 #   ac-verify.sh <plan-file> [--log-dir <dir>]
@@ -106,6 +111,47 @@ while [ $# -gt 0 ]; do
   esac
 done
 
+# ---- LOG_DIR is now finalized (flag parsed, default applied) ----
+
+# Couple verdict-run.sh's own ${LOOP_DIR:-.loop} default to OUR --log-dir (issue #23 round-2
+# finding: they were previously decoupled — verdict-run.sh's write_state() derives
+# verdict-state.json's path purely from ITS OWN process's LOOP_DIR env var, which ac-verify.sh
+# never set, so a non-default --log-dir silently got its state file written to the unrelated
+# default ./.loop/ instead, and two parallel --log-dir runs with no manually-exported LOOP_DIR
+# would clobber the same shared default file). Exporting here makes every verdict-run.sh sub-call
+# below (per-AC calls and the corrective sync call) inherit a LOOP_DIR guaranteed to match
+# --log-dir. Both default to the literal ".loop", so this is a no-op for every caller that doesn't
+# pass --log-dir.
+export LOOP_DIR="$LOG_DIR"
+
+LOGSUBDIR="$LOG_DIR/ac-verify"
+
+# ---- fail-closed corrective verdict-state.json sync via an EXIT trap ----
+# ac-verify.sh has multiple exit paths — this normal-completion path, plus early exits on usage
+# errors and on a per-AC verdict-run.sh sub-call's own exit-2 refusal encountered mid-run (see the
+# header comment, and any exit path added later). A sync call placed only at normal completion
+# leaves every early-exit path with whatever an earlier AC's OWN sub-call happened to leave in
+# verdict-state.json (last-writer-wins) — a stale, unrelated pass/fail for a run that never
+# actually finished. Fixing this per call-site doesn't scale (the next new early-exit path
+# reopens the same gap) — so instead ONE trap fires on every exit, no matter which code path
+# reaches it, and makes one corrective verdict-run.sh sync call (stdout+stderr discarded) whose
+# only purpose is to be the last writer.
+#
+# SYNC_VERDICT_EXIT starts fail-closed (1 = FAIL) BEFORE the trap is registered — "treat this run
+# as failed/incomplete unless proven otherwise". Only the normal-completion path below (once the
+# true aggregate $code has actually been computed) updates SYNC_VERDICT_EXIT to that real value,
+# right before the script's final `exit "$code"` — which is what fires the trap. Every other exit
+# reaches the trap with the untouched fail-closed default. The handler never calls `exit` itself
+# (that would clobber the real exit code this script is trying to return) — it only runs its side
+# effect and lets the original exit code propagate.
+SYNC_VERDICT_EXIT=1
+SYNC_LOG="$LOGSUBDIR/aggregate-sync.log"
+sync_verdict_state_on_exit() {
+  sync_desc="ac-verify.sh aggregate result for '$(shquote "$PLAN")'"
+  "$VERDICT_RUN" --log "$SYNC_LOG" -- sh -c ": $sync_desc; exit $SYNC_VERDICT_EXIT" >/dev/null 2>&1
+}
+trap sync_verdict_state_on_exit EXIT
+
 if [ -z "$PLAN" ]; then
   echo "ac-verify.sh: a plan file is required. Usage: ac-verify.sh <plan-file> [--log-dir <dir>]" >&2
   exit 2
@@ -119,7 +165,6 @@ if [ ! -x "$VERDICT_RUN" ]; then
   exit 2
 fi
 
-LOGSUBDIR="$LOG_DIR/ac-verify"
 mkdir -p "$LOGSUBDIR" 2>/dev/null || { echo "ac-verify.sh: cannot create log directory '$LOGSUBDIR'" >&2; exit 2; }
 AGG_LOG="$LOG_DIR/ac-verify.log"
 : > "$AGG_LOG" 2>/dev/null || { echo "ac-verify.sh: cannot write aggregate log file '$AGG_LOG'" >&2; exit 2; }
@@ -209,15 +254,38 @@ while IFS= read -r line || [ -n "$line" ]; do
           *)
             # This segment matched none of the three known fields (even after the normalization
             # above) and is about to silently vanish into the description — exactly the
-            # invisible-typo failure mode. If it LOOKS like a mistyped field (a `:` within roughly
-            # its first 20 chars), warn on stderr so it's visible instead of silent. Stays a
-            # warning, not a hard error: an ordinary colon in free-text description content is
-            # legitimate and common — failing the build over it would be worse than the bug.
+            # invisible-typo failure mode. Warn on stderr (not a hard error — an ordinary colon or
+            # leading word in free-text description content is legitimate and common; failing the
+            # build over it would be worse than the bug) when either heuristic fires:
+            #   1. it LOOKS like a mistyped field (a `:` within roughly its first 20 chars), or
+            #   2. its first whitespace-delimited word — after the SAME leading-emphasis-marker
+            #      stripping + lower-casing as the field-prefix matcher above, and with any single
+            #      trailing `:` stripped — case-insensitively equals one of the three reserved
+            #      field names. This catches a colon-OMITTED typo (e.g. "verify exit 9" instead of
+            #      "verify: exit 9") that heuristic 1 alone can't see (no colon anywhere), without
+            #      false-positiving on ordinary free text (which essentially never starts with
+            #      exactly one of these three words by coincidence). Additive to heuristic 1, which
+            #      still independently catches colon-typos further into a segment (e.g. the field
+            #      name itself misspelled, as in "verfy: exit 7").
             seg="$(trim "$tok")"
             head20="$(printf '%s' "$seg" | cut -c1-20)"
+            warn=0
             case "$head20" in
-              *:*) echo "ac-verify.sh: warning — AC #$idx (\"$desc\"): unrecognized field-like segment (folded into description, not treated as a contract): \"$seg\"" >&2 ;;
+              *:*) warn=1 ;;
             esac
+            word="$(printf '%s' "$seg" | awk '{print $1}')"
+            case "$word" in
+              '**'*) word="${word:2}" ;;
+              '__'*) word="${word:2}" ;;
+              '*'*)  word="${word:1}" ;;
+              '_'*)  word="${word:1}" ;;
+            esac
+            word="${word%:}"
+            word_norm="$(printf '%s' "$word" | tr 'A-Z' 'a-z')"
+            case "$word_norm" in
+              verify|artifacts|expect) warn=1 ;;
+            esac
+            [ "$warn" -eq 1 ] && echo "ac-verify.sh: warning — AC #$idx (\"$desc\"): unrecognized field-like segment (folded into description, not treated as a contract): \"$seg\"" >&2
             desc="$desc | $tok"
             ;;
         esac
@@ -342,25 +410,14 @@ fi
 
 code=0; [ "$verdict" = "FAIL" ] && code=1
 
-# ---- correct the shared verdict-state.json: make OUR aggregate the last writer ----
-# Every per-AC `"$VERDICT_RUN" --log "$ac_log" -- sh -c "$verify_cmd"` call above already wrote
-# ${LOOP_DIR:-.loop}/verdict-state.json via verdict-run.sh's own write_state() (existing,
-# unmodified last-writer-wins contract — every layer writes it, that part of verdict-run.sh is
-# correct and untouched here). Left alone, whichever AC happened to be PROCESSED LAST leaves ITS
-# OWN pass/fail there — which can silently disagree with ac-verify.sh's own true aggregate
-# $verdict/$code above (e.g. an earlier AC failed but the last AC processed passed: the file would
-# read "PASS" even though our own VERDICT block below correctly says FAIL). A consumer reading
-# verdict-state.json directly (e.g. a Stop-hook-style freshness gate) would see a stale, wrong
-# "fresh PASS" for a run that genuinely failed.
-#
-# Fix: one final verdict-run.sh call whose only purpose is its write_state() side effect — make it
-# the last writer with the CORRECT aggregate result. Runs unconditionally (PASS or FAIL). Its own
-# stdout (a second, poorer VERDICT block) is thrown away (>/dev/null) — ac-verify.sh's own richer,
-# AC-specific block below (with the real passed=/failed=/skipped= SUMMARY) remains the only VERDICT
-# block that reaches the caller's stdout. Logged to a dedicated path, distinct from any per-AC log.
-SYNC_LOG="$LOGSUBDIR/aggregate-sync.log"
-sync_desc="ac-verify.sh aggregate result for '$(shquote "$PLAN")'"
-"$VERDICT_RUN" --log "$SYNC_LOG" -- sh -c ": $sync_desc; exit $code" >/dev/null 2>&1
+# ---- the true aggregate is now known: arm the EXIT trap (registered earlier, right after
+# LOG_DIR was finalized) with the REAL result instead of its fail-closed default. This is the only
+# place SYNC_VERDICT_EXIT moves off of "1" — every other exit path in this script (including ones
+# added later) reaches the trap with the safe fail-closed default untouched, and the trap's own
+# corrective verdict-run.sh sync call (its stdout+stderr discarded — ac-verify.sh's own richer,
+# AC-specific block below, with the real passed=/failed=/skipped= SUMMARY, remains the only
+# VERDICT block that reaches the caller's stdout) fires automatically once this script exits.
+SYNC_VERDICT_EXIT="$code"
 
 printf '=== VERDICT ===\n'
 printf 'VERDICT: %s\n' "$verdict"

--- a/tools/loop-engine/test/ac-verify.test.sh
+++ b/tools/loop-engine/test/ac-verify.test.sh
@@ -271,5 +271,41 @@ printf '%s' "$STATE_CONTENT_R3" | grep -q '"verdict":"PASS"' && fail "(r3): the 
 printf '%s' "$STATE_CONTENT_R3" | grep -q '"verdict":"FAIL"' || fail "(r3): expected verdict-state.json to be corrected to FAIL by the trap, got: $STATE_CONTENT_R3"
 
 cd "$ORIG_PWD" || true
-echo "PASS: ac-verify.sh (issue #23) — zero-AC/zero-contract fail-closed, independent verify:/artifacts:/expect: checks, mixed pass+fail and contracted+uncontracted aggregation, Verdict Contract block shape, verdict-state.json aggregate-sync via an EXIT trap covering early-exit paths too (not last-writer-wins, not just the normal-completion path, and now armed BEFORE argument parsing itself), --log-dir/LOOP_DIR coupling (isolated verdict-state.json per --log-dir), case/markdown-emphasis-tolerant field parsing, unrecognized-field-like-segment warning (both colon-containing and colon-omitted typos)"
+
+# ==== (s) FIX round-5 regression: --log-dir's LOG_DIR/LOOP_DIR coupling must be applied INLINE the
+# instant --log-dir itself is parsed, not deferred to a step after the whole argument-parsing loop
+# finishes. Pre-fix, a LATER usage error in the same invocation (after a non-default --log-dir had
+# already been parsed) exited before that deferred coupling step ran, so the EXIT trap's corrective
+# sync silently targeted the unrelated default `.loop/` instead of the just-parsed --log-dir target
+# — the exact stale/wrong-target failure mode every prior round exists to prevent, just relocated
+# to a value that had been parsed but not yet "applied". (s1) proves the target directory a
+# non-default --log-dir names is the one that actually gets corrected, even when a later argument
+# in the same command line errors out — not the unrelated default. (s2) proves a flag-shaped
+# --log-dir value (a plausible operator slip: forgetting the directory and typing another flag
+# right after --log-dir) is now rejected up front with a clear error, instead of being silently
+# accepted and failing opaquely later inside mkdir/verdict-run.sh's own state write. ====
+SUB_S="$DIR/s"; mkdir -p "$SUB_S"; cd "$SUB_S" || fail "cd s"
+printf -- '- AC: seed pass | verify: true\n' > plan.md
+
+# ---- (s1) non-default --log-dir + a later bad flag must correct THAT target, not the default ----
+rm -rf custom-dir .loop
+run_ac_verify plan.md custom-dir >/dev/null 2>&1; SEED_CODE_S1=$?
+[ "$SEED_CODE_S1" -eq 0 ] || fail "(s1): seed run expected exit 0, got $SEED_CODE_S1"
+CUSTOM_STATE_S1="custom-dir/verdict-state.json"
+grep -q '"verdict":"PASS"' "$CUSTOM_STATE_S1" || fail "(s1): expected the seed run to leave custom-dir/verdict-state.json at PASS, got: $(cat "$CUSTOM_STATE_S1" 2>&1)"
+OUT_S1="$(env -u LOOP_DIR "$AC_VERIFY" plan.md --log-dir custom-dir --bogus-flag 2>&1)"; CODE_S1=$?
+[ "$CODE_S1" -eq 2 ] || fail "(s1): expected exit 2 (bogus flag after --log-dir), got $CODE_S1: $OUT_S1"
+[ -f "$CUSTOM_STATE_S1" ] || fail "(s1): expected custom-dir/verdict-state.json to still exist"
+STATE_CONTENT_S1="$(cat "$CUSTOM_STATE_S1")"
+printf '%s' "$STATE_CONTENT_S1" | grep -q '"verdict":"PASS"' && fail "(s1): the seeded PASS in custom-dir must NOT survive a later usage error in the same invocation (LOG_DIR/LOOP_DIR coupling must already be applied the instant --log-dir was parsed, before the later bad flag was even reached), got: $STATE_CONTENT_S1"
+printf '%s' "$STATE_CONTENT_S1" | grep -q '"verdict":"FAIL"' || fail "(s1): expected custom-dir/verdict-state.json to be corrected to FAIL, got: $STATE_CONTENT_S1"
+[ -f ".loop/verdict-state.json" ] && fail "(s1): the unrelated default .loop/verdict-state.json must not be created/touched by a run that named a different --log-dir target"
+
+# ---- (s2) a flag-shaped --log-dir value must be rejected up front, not silently accepted ----
+OUT_S2="$(env -u LOOP_DIR "$AC_VERIFY" plan.md --log-dir --weird 2>&1)"; CODE_S2=$?
+[ "$CODE_S2" -eq 2 ] || fail "(s2): expected exit 2 (flag-shaped --log-dir value), got $CODE_S2: $OUT_S2"
+printf '%s' "$OUT_S2" | grep -qi 'requires a directory path' || fail "(s2): expected a clear error naming --log-dir's value as flag-shaped, got: $OUT_S2"
+
+cd "$ORIG_PWD" || true
+echo "PASS: ac-verify.sh (issue #23) — zero-AC/zero-contract fail-closed, independent verify:/artifacts:/expect: checks, mixed pass+fail and contracted+uncontracted aggregation, Verdict Contract block shape, verdict-state.json aggregate-sync via an EXIT trap covering early-exit paths too (not last-writer-wins, not just the normal-completion path, and now armed BEFORE argument parsing itself), --log-dir/LOOP_DIR coupling applied inline the instant --log-dir is parsed (isolated verdict-state.json per --log-dir, correct even when a later argument errors), flag-shaped --log-dir values rejected up front, case/markdown-emphasis-tolerant field parsing, unrecognized-field-like-segment warning (both colon-containing and colon-omitted typos)"
 exit 0

--- a/tools/loop-engine/test/ac-verify.test.sh
+++ b/tools/loop-engine/test/ac-verify.test.sh
@@ -158,6 +158,69 @@ printf '%s' "$OUT_N" | grep -qE '^SUMMARY: passed=1 failed=0 skipped=1 ' || fail
 printf '%s' "$ERR_N" | grep -q 'unrecognized field-like segment' || fail "(n): expected a warning on stderr naming the unrecognized segment, got stderr: $ERR_N"
 printf '%s' "$ERR_N" | grep -q 'verfy: exit 7' || fail "(n): expected the warning to name the unrecognized segment verbatim ('verfy: exit 7'), got stderr: $ERR_N"
 
+# ==== (o) FIX 1 round-2 regression: an EARLY exit (verdict-run.sh's own exit-2 usage-error
+# refusal, hit for a LATER AC) must not leave an EARLIER AC's own stale PASS sitting in
+# verdict-state.json. Reproduces the round-2 adversarial finding directly: pre-create a directory
+# at the SECOND AC's expected per-AC log path so verdict-run.sh's own write-check for that AC
+# fails with exit 2 — after the FIRST AC already ran and its own sub-call already wrote
+# verdict-state.json with verdict:PASS. Before the EXIT-trap fix, this exit-2 path bypassed the
+# single manually-placed corrective sync call entirely, leaving that stale PASS in place with no
+# aggregate-sync.log ever created. ====
+SUB="$DIR/o"; mkdir -p "$SUB"; cd "$SUB" || fail "cd o"
+mkdir -p .loop/ac-verify
+mkdir -p .loop/ac-verify/ac-2.log   # a directory here forces verdict-run.sh's write-check to fail for AC #2
+printf -- '- AC: first passes | verify: true\n- AC: second explodes | verify: true\n' > plan.md
+OUT_O="$("$AC_VERIFY" plan.md --log-dir .loop 2>"$DIR/o-stderr.log")"; CODE_O=$?
+ERR_O="$(cat "$DIR/o-stderr.log")"
+[ "$CODE_O" -eq 2 ] || fail "(o): expected exit 2 (verdict-run.sh's own usage error propagated), got $CODE_O: $OUT_O / stderr: $ERR_O"
+printf '%s' "$ERR_O" | grep -q 'usage error (exit 2)' || fail "(o): expected the exit-2 stderr message, got: $ERR_O"
+STATE_FILE_O="$SUB/.loop/verdict-state.json"
+[ -f "$STATE_FILE_O" ] || fail "(o): expected verdict-state.json at $STATE_FILE_O (the EXIT trap should have synced it even on this early-abort path)"
+STATE_CONTENT_O="$(cat "$STATE_FILE_O")"
+printf '%s' "$STATE_CONTENT_O" | grep -q '"verdict":"PASS"' && fail "(o): verdict-state.json must NOT read PASS on this abort path (that would be AC #1's own stale leftover leaking through), got: $STATE_CONTENT_O"
+printf '%s' "$STATE_CONTENT_O" | grep -q '"verdict":"FAIL"' || fail "(o): expected verdict-state.json's own verdict field to be FAIL (the trap's fail-closed default), got: $STATE_CONTENT_O"
+[ -f "$SUB/.loop/ac-verify/aggregate-sync.log" ] || fail "(o): expected the trap's corrective sync call to have run (aggregate-sync.log missing)"
+
+# ==== (p) FIX 2 round-2 regression: --log-dir and verdict-run.sh's own ${LOOP_DIR:-.loop} default
+# must be coupled by construction (an explicit `export LOOP_DIR="$LOG_DIR"`), not by accidental
+# default-value coincidence. Two DIFFERENT --log-dir values, with NO LOOP_DIR exported beforehand
+# (exercises the previously-broken default-unset case — not the already-covered case where a
+# caller manually keeps them in sync): one plan that FAILs, one that PASSes. Each run's OWN
+# verdict-state.json (under ITS OWN --log-dir) must reflect THAT run's own result — not the other
+# run's, and not some unrelated shared default './.loop/verdict-state.json'. ====
+SUB="$DIR/p"; mkdir -p "$SUB"; cd "$SUB" || fail "cd p"
+unset LOOP_DIR
+printf -- '- AC: will fail | verify: false\n' > plan-fail.md
+printf -- '- AC: will pass | verify: true\n' > plan-pass.md
+"$AC_VERIFY" plan-fail.md --log-dir logdir-a >/dev/null 2>&1; CODE_P1=$?
+"$AC_VERIFY" plan-pass.md --log-dir logdir-b >/dev/null 2>&1; CODE_P2=$?
+[ "$CODE_P1" -eq 1 ] || fail "(p): expected the plan-fail.md run (logdir-a) to exit 1, got $CODE_P1"
+[ "$CODE_P2" -eq 0 ] || fail "(p): expected the plan-pass.md run (logdir-b) to exit 0, got $CODE_P2"
+STATE_A="$SUB/logdir-a/verdict-state.json"
+STATE_B="$SUB/logdir-b/verdict-state.json"
+[ -f "$STATE_A" ] || fail "(p): expected verdict-state.json under logdir-a (dir listing: $(ls -la "$SUB" 2>&1))"
+[ -f "$STATE_B" ] || fail "(p): expected verdict-state.json under logdir-b (dir listing: $(ls -la "$SUB" 2>&1))"
+[ -e "$SUB/.loop/verdict-state.json" ] && fail "(p): no verdict-state.json should land under the unrelated default .loop/ — both runs must use their own --log-dir exclusively, got: $(cat "$SUB/.loop/verdict-state.json" 2>&1)"
+grep -q '"verdict":"FAIL"' "$STATE_A" || fail "(p): logdir-a's verdict-state.json must reflect ITS OWN FAIL result, got: $(cat "$STATE_A")"
+grep -q '"verdict":"PASS"' "$STATE_B" || fail "(p): logdir-b's verdict-state.json must reflect ITS OWN PASS result (not clobbered by the other run's FAIL), got: $(cat "$STATE_B")"
+
+# ==== (q) FIX 3 round-2 regression: a colon-OMITTED typo of a reserved field name (`verify exit 9`
+# — no colon after "verify") must still fall into skipped= (NOT silently become a real contract
+# just because a warning now fires), but a warning must now fire on stderr naming the unrecognized
+# segment — matching the existing warning-format convention already used for the colon-containing
+# typo case (test (n) above). Before this fix, the colon-based heuristic alone (a `:` within the
+# segment's first ~20 chars) never fired here since there is no colon anywhere in the segment, so
+# this exact intended-but-broken contract vanished with zero trace. A second, correctly-contracted
+# passing AC isolates skipped=1 to the colon-less typo'd AC specifically. ====
+SUB="$DIR/q"; mkdir -p "$SUB"; cd "$SUB" || fail "cd q"
+printf -- '- AC: colonless typo | verify exit 9\n- AC: real contract | verify: true\n' > plan.md
+OUT_Q="$("$AC_VERIFY" plan.md --log-dir .loop 2>"$DIR/q-stderr.log")"; CODE_Q=$?
+ERR_Q="$(cat "$DIR/q-stderr.log")"
+[ "$CODE_Q" -eq 0 ] || fail "(q): expected exit 0 (the one real contract passes; the colon-less typo'd AC is skipped, not failed), got $CODE_Q: $OUT_Q"
+printf '%s' "$OUT_Q" | grep -qE '^SUMMARY: passed=1 failed=0 skipped=1 ' || fail "(q): expected passed=1 skipped=1 (colon-less typo'd field still unrecognized, folded into description as before): $OUT_Q"
+printf '%s' "$ERR_Q" | grep -q 'unrecognized field-like segment' || fail "(q): expected a warning on stderr naming the unrecognized segment even without a colon, got stderr: $ERR_Q"
+printf '%s' "$ERR_Q" | grep -q 'verify exit 9' || fail "(q): expected the warning to name the unrecognized segment verbatim ('verify exit 9'), got stderr: $ERR_Q"
+
 cd "$ORIG_PWD" || true
-echo "PASS: ac-verify.sh (issue #23) — zero-AC/zero-contract fail-closed, independent verify:/artifacts:/expect: checks, mixed pass+fail and contracted+uncontracted aggregation, Verdict Contract block shape, verdict-state.json aggregate-sync (not last-writer-wins), case/markdown-emphasis-tolerant field parsing, unrecognized-field-like-segment warning"
+echo "PASS: ac-verify.sh (issue #23) — zero-AC/zero-contract fail-closed, independent verify:/artifacts:/expect: checks, mixed pass+fail and contracted+uncontracted aggregation, Verdict Contract block shape, verdict-state.json aggregate-sync via an EXIT trap covering early-exit paths too (not last-writer-wins, not just the normal-completion path), --log-dir/LOOP_DIR coupling (isolated verdict-state.json per --log-dir), case/markdown-emphasis-tolerant field parsing, unrecognized-field-like-segment warning (both colon-containing and colon-omitted typos)"
 exit 0

--- a/tools/loop-engine/test/ac-verify.test.sh
+++ b/tools/loop-engine/test/ac-verify.test.sh
@@ -221,6 +221,55 @@ printf '%s' "$OUT_Q" | grep -qE '^SUMMARY: passed=1 failed=0 skipped=1 ' || fail
 printf '%s' "$ERR_Q" | grep -q 'unrecognized field-like segment' || fail "(q): expected a warning on stderr naming the unrecognized segment even without a colon, got stderr: $ERR_Q"
 printf '%s' "$ERR_Q" | grep -q 'verify exit 9' || fail "(q): expected the warning to name the unrecognized segment verbatim ('verify exit 9'), got stderr: $ERR_Q"
 
+# ==== (r) FIX round-3 regression: the EXIT trap must be armed BEFORE argument parsing itself, not
+# just after it. Pre-fix, the trap was registered AFTER the flag-parsing while-loop, so a usage
+# error DURING parsing (an unknown flag, `--log-dir` with no following value, an extra stray
+# positional argument) called `exit 2` before the trap was ever armed — leaving a stale earlier
+# verdict-state.json completely untouched (last-writer-wins from a PRIOR, unrelated normal run).
+# For each of the three shapes: seed a real PASS via a normal prior run in the same log-dir, then
+# re-run with the bad arguments and assert (a) exit 2, (b) the seeded PASS is corrected to FAIL by
+# the now-earlier-armed trap — proving there is no exit path, from the very first line onward,
+# that can occur before the trap has already been registered. ====
+SUB="$DIR/r"; mkdir -p "$SUB"; cd "$SUB" || fail "cd r"
+printf -- '- AC: seed pass | verify: true\n' > plan.md
+STATE_FILE_R="$SUB/.loop/verdict-state.json"
+
+# ---- (r1) unknown/bogus flag ----
+rm -rf .loop
+run_ac_verify plan.md .loop >/dev/null 2>&1; SEED_CODE_R1=$?
+[ "$SEED_CODE_R1" -eq 0 ] || fail "(r1): seed run expected exit 0, got $SEED_CODE_R1"
+grep -q '"verdict":"PASS"' "$STATE_FILE_R" || fail "(r1): expected the seed run to leave verdict-state.json at PASS, got: $(cat "$STATE_FILE_R" 2>&1)"
+OUT_R1="$("$AC_VERIFY" plan.md --log-dir .loop --bogus-flag 2>&1)"; CODE_R1=$?
+[ "$CODE_R1" -eq 2 ] || fail "(r1): expected exit 2 (unknown flag), got $CODE_R1: $OUT_R1"
+[ -f "$STATE_FILE_R" ] || fail "(r1): expected verdict-state.json to still exist at $STATE_FILE_R"
+STATE_CONTENT_R1="$(cat "$STATE_FILE_R")"
+printf '%s' "$STATE_CONTENT_R1" | grep -q '"verdict":"PASS"' && fail "(r1): the seeded PASS must NOT survive an unknown-flag usage error (the EXIT trap must already be armed during argument parsing), got: $STATE_CONTENT_R1"
+printf '%s' "$STATE_CONTENT_R1" | grep -q '"verdict":"FAIL"' || fail "(r1): expected verdict-state.json to be corrected to FAIL by the trap, got: $STATE_CONTENT_R1"
+
+# ---- (r2) --log-dir given with no following value ----
+rm -rf .loop
+run_ac_verify plan.md .loop >/dev/null 2>&1; SEED_CODE_R2=$?
+[ "$SEED_CODE_R2" -eq 0 ] || fail "(r2): seed run expected exit 0, got $SEED_CODE_R2"
+grep -q '"verdict":"PASS"' "$STATE_FILE_R" || fail "(r2): expected the seed run to leave verdict-state.json at PASS, got: $(cat "$STATE_FILE_R" 2>&1)"
+OUT_R2="$("$AC_VERIFY" plan.md --log-dir .loop --log-dir 2>&1)"; CODE_R2=$?
+[ "$CODE_R2" -eq 2 ] || fail "(r2): expected exit 2 (--log-dir with no value), got $CODE_R2: $OUT_R2"
+[ -f "$STATE_FILE_R" ] || fail "(r2): expected verdict-state.json to still exist at $STATE_FILE_R"
+STATE_CONTENT_R2="$(cat "$STATE_FILE_R")"
+printf '%s' "$STATE_CONTENT_R2" | grep -q '"verdict":"PASS"' && fail "(r2): the seeded PASS must NOT survive a missing-value --log-dir usage error (the EXIT trap must already be armed during argument parsing), got: $STATE_CONTENT_R2"
+printf '%s' "$STATE_CONTENT_R2" | grep -q '"verdict":"FAIL"' || fail "(r2): expected verdict-state.json to be corrected to FAIL by the trap, got: $STATE_CONTENT_R2"
+
+# ---- (r3) extra stray positional argument after the plan file ----
+rm -rf .loop
+run_ac_verify plan.md .loop >/dev/null 2>&1; SEED_CODE_R3=$?
+[ "$SEED_CODE_R3" -eq 0 ] || fail "(r3): seed run expected exit 0, got $SEED_CODE_R3"
+grep -q '"verdict":"PASS"' "$STATE_FILE_R" || fail "(r3): expected the seed run to leave verdict-state.json at PASS, got: $(cat "$STATE_FILE_R" 2>&1)"
+OUT_R3="$("$AC_VERIFY" plan.md extra-arg --log-dir .loop 2>&1)"; CODE_R3=$?
+[ "$CODE_R3" -eq 2 ] || fail "(r3): expected exit 2 (extra positional argument), got $CODE_R3: $OUT_R3"
+[ -f "$STATE_FILE_R" ] || fail "(r3): expected verdict-state.json to still exist at $STATE_FILE_R"
+STATE_CONTENT_R3="$(cat "$STATE_FILE_R")"
+printf '%s' "$STATE_CONTENT_R3" | grep -q '"verdict":"PASS"' && fail "(r3): the seeded PASS must NOT survive an extra-positional-argument usage error (the EXIT trap must already be armed during argument parsing), got: $STATE_CONTENT_R3"
+printf '%s' "$STATE_CONTENT_R3" | grep -q '"verdict":"FAIL"' || fail "(r3): expected verdict-state.json to be corrected to FAIL by the trap, got: $STATE_CONTENT_R3"
+
 cd "$ORIG_PWD" || true
-echo "PASS: ac-verify.sh (issue #23) — zero-AC/zero-contract fail-closed, independent verify:/artifacts:/expect: checks, mixed pass+fail and contracted+uncontracted aggregation, Verdict Contract block shape, verdict-state.json aggregate-sync via an EXIT trap covering early-exit paths too (not last-writer-wins, not just the normal-completion path), --log-dir/LOOP_DIR coupling (isolated verdict-state.json per --log-dir), case/markdown-emphasis-tolerant field parsing, unrecognized-field-like-segment warning (both colon-containing and colon-omitted typos)"
+echo "PASS: ac-verify.sh (issue #23) — zero-AC/zero-contract fail-closed, independent verify:/artifacts:/expect: checks, mixed pass+fail and contracted+uncontracted aggregation, Verdict Contract block shape, verdict-state.json aggregate-sync via an EXIT trap covering early-exit paths too (not last-writer-wins, not just the normal-completion path, and now armed BEFORE argument parsing itself), --log-dir/LOOP_DIR coupling (isolated verdict-state.json per --log-dir), case/markdown-emphasis-tolerant field parsing, unrecognized-field-like-segment warning (both colon-containing and colon-omitted typos)"
 exit 0

--- a/tools/loop-engine/test/ac-verify.test.sh
+++ b/tools/loop-engine/test/ac-verify.test.sh
@@ -108,6 +108,56 @@ else
   printf '%s' "$OUT_I" | grep -q '^VERDICT: FAIL$' || fail "(i): a nonzero exit must correspond to VERDICT: FAIL: $OUT_I"
 fi
 
+# ==== (j) FIX 1 regression: shared verdict-state.json must reflect ac-verify.sh's own aggregate,
+# not whichever per-AC verdict-run.sh sub-call happened to write it last. A failing AC listed
+# BEFORE a passing AC would, pre-fix, leave the LAST (passing) sub-call's own PASS/exit-0 write in
+# the state file — even though the true aggregate, and ac-verify.sh's own printed VERDICT block,
+# is FAIL. LOOP_DIR is exported explicitly (matching --log-dir) so the state file's location is
+# known, not assumed to be literally './.loop' by coincidence. ====
+SUB="$DIR/j"; mkdir -p "$SUB"; cd "$SUB" || fail "cd j"
+printf -- '- AC: fails first | verify: false\n- AC: passes second | verify: true\n' > plan.md
+export LOOP_DIR=".loop"
+OUT_J="$(run_ac_verify plan.md .loop 2>&1)"; CODE_J=$?
+unset LOOP_DIR
+[ "$CODE_J" -eq 1 ] || fail "(j): expected exit 1 (ac-verify.sh's own aggregate is FAIL — one AC failed), got $CODE_J: $OUT_J"
+printf '%s' "$OUT_J" | grep -q '^VERDICT: FAIL$' || fail "(j): expected ac-verify.sh's own printed VERDICT: FAIL: $OUT_J"
+STATE_FILE_J="$SUB/.loop/verdict-state.json"
+[ -f "$STATE_FILE_J" ] || fail "(j): expected verdict-state.json at $STATE_FILE_J (dir listing: $(ls -la "$SUB/.loop" 2>&1))"
+STATE_CONTENT_J="$(cat "$STATE_FILE_J")"
+printf '%s' "$STATE_CONTENT_J" | grep -q '"verdict":"FAIL"' || fail "(j): expected verdict-state.json's own verdict field to be FAIL (a last-writer-wins bug would show PASS, from the last-processed passing AC's own sub-call), got: $STATE_CONTENT_J"
+printf '%s' "$STATE_CONTENT_J" | grep -q '"exit":1' || fail "(j): expected verdict-state.json's own exit field to be 1, matching ac-verify.sh's own aggregate exit code, got: $STATE_CONTENT_J"
+
+# ==== (k) FIX 2(a) regression: a capitalized `Verify:` field must resolve as a real verify:
+# contract (not silently fold into the description) — a failing command must FAIL the gate. ====
+SUB="$DIR/k"; mkdir -p "$SUB"; cd "$SUB" || fail "cd k"
+printf -- '- AC: capitalized field | Verify: exit 7\n' > plan.md
+OUT_K="$(run_ac_verify plan.md .loop 2>&1)"; CODE_K=$?
+[ "$CODE_K" -eq 1 ] || fail "(k): expected exit 1 ('Verify:' must be treated as a real contract), got $CODE_K: $OUT_K"
+printf '%s' "$OUT_K" | grep -qE '^SUMMARY: passed=0 failed=1 skipped=0 ' || fail "(k): expected failed=1 (not silently folded into skipped=): $OUT_K"
+printf '%s' "$OUT_K" | grep -q '^FAIL: AC "capitalized field":.*verify exited 7' || fail "(k): expected a FAIL line naming the AC and its real exit code 7: $OUT_K"
+
+# ==== (l) FIX 2(a) regression: same as (k) but for markdown-bold `**verify:**`. ====
+SUB="$DIR/l"; mkdir -p "$SUB"; cd "$SUB" || fail "cd l"
+printf -- '- AC: bold field | **verify:** exit 7\n' > plan.md
+OUT_L="$(run_ac_verify plan.md .loop 2>&1)"; CODE_L=$?
+[ "$CODE_L" -eq 1 ] || fail "(l): expected exit 1 ('**verify:**' must be treated as a real contract), got $CODE_L: $OUT_L"
+printf '%s' "$OUT_L" | grep -qE '^SUMMARY: passed=0 failed=1 skipped=0 ' || fail "(l): expected failed=1 (not silently folded into skipped=): $OUT_L"
+printf '%s' "$OUT_L" | grep -q '^FAIL: AC "bold field":.*verify exited 7' || fail "(l): expected a FAIL line naming the AC and its real exit code 7: $OUT_L"
+
+# ==== (n) FIX 2(b) regression: a genuine typo (`verfy:`, not one of the normalized variants above)
+# must still fall into skipped= as before (it is NOT a recognized field), but must now print a
+# warning naming it, instead of vanishing with zero trace. A second, correctly-contracted passing
+# AC isolates skipped=1 to the typo'd AC specifically (avoids conflating with the separate
+# zero-contracts-in-the-whole-plan fail-closed path already covered by test (b) above). ====
+SUB="$DIR/n"; mkdir -p "$SUB"; cd "$SUB" || fail "cd n"
+printf -- '- AC: typo field | verfy: exit 7\n- AC: real contract | verify: true\n' > plan.md
+OUT_N="$("$AC_VERIFY" plan.md --log-dir .loop 2>"$DIR/n-stderr.log")"; CODE_N=$?
+ERR_N="$(cat "$DIR/n-stderr.log")"
+[ "$CODE_N" -eq 0 ] || fail "(n): expected exit 0 (the one real contract passes; the typo'd AC is skipped, not failed), got $CODE_N: $OUT_N"
+printf '%s' "$OUT_N" | grep -qE '^SUMMARY: passed=1 failed=0 skipped=1 ' || fail "(n): expected passed=1 skipped=1 (typo'd field unrecognized, folded into description as before): $OUT_N"
+printf '%s' "$ERR_N" | grep -q 'unrecognized field-like segment' || fail "(n): expected a warning on stderr naming the unrecognized segment, got stderr: $ERR_N"
+printf '%s' "$ERR_N" | grep -q 'verfy: exit 7' || fail "(n): expected the warning to name the unrecognized segment verbatim ('verfy: exit 7'), got stderr: $ERR_N"
+
 cd "$ORIG_PWD" || true
-echo "PASS: ac-verify.sh (issue #23) — zero-AC/zero-contract fail-closed, independent verify:/artifacts:/expect: checks, mixed pass+fail and contracted+uncontracted aggregation, Verdict Contract block shape"
+echo "PASS: ac-verify.sh (issue #23) — zero-AC/zero-contract fail-closed, independent verify:/artifacts:/expect: checks, mixed pass+fail and contracted+uncontracted aggregation, Verdict Contract block shape, verdict-state.json aggregate-sync (not last-writer-wins), case/markdown-emphasis-tolerant field parsing, unrecognized-field-like-segment warning"
 exit 0

--- a/tools/loop-engine/test/ac-verify.test.sh
+++ b/tools/loop-engine/test/ac-verify.test.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# Regression tests for ac-verify.sh (issue #23, ADR-0104) — the AC-level success contract gate.
+# Covers: zero-AC/zero-contract fail-closed (require-tests.sh precedent), independent
+# verify:/artifacts:/expect: checks, mixed contracted+uncontracted aggregation, mixed pass+fail
+# aggregation, and the emitted block's Verdict Contract shape.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+AC_VERIFY="$HERE/../bin/ac-verify.sh"
+
+fail() { echo "FAIL: $1"; exit 1; }
+[ -x "$AC_VERIFY" ] || fail "ac-verify.sh not found/executable at $AC_VERIFY"
+
+DIR="$(mktemp -d "${TMPDIR:-/tmp}/tmp.XXXXXXXX")" || fail "mktemp -d failed"
+trap 'rm -rf "$DIR"' EXIT
+ORIG_PWD="$(pwd)"
+
+run_ac_verify() { "$AC_VERIFY" "$1" --log-dir "$2"; }   # $1 = plan file (cwd-relative)  $2 = log-dir name
+
+# ==== (a) zero AC lines at all -> FAIL, contracted count 0 ====
+SUB="$DIR/a"; mkdir -p "$SUB"; cd "$SUB" || fail "cd a"
+printf '# plan\nno AC lines here at all\n' > plan.md
+OUT_A="$(run_ac_verify plan.md .loop 2>&1)"; CODE_A=$?
+[ "$CODE_A" -eq 1 ] || fail "(a): expected exit 1, got $CODE_A: $OUT_A"
+printf '%s' "$OUT_A" | grep -q '^VERDICT: FAIL$' || fail "(a): expected VERDICT: FAIL: $OUT_A"
+printf '%s' "$OUT_A" | grep -qE '^SUMMARY: passed=0 failed=0 skipped=0 ' || fail "(a): expected an all-zero summary: $OUT_A"
+printf '%s' "$OUT_A" | grep -q '^FAIL: .*ZERO AC lines' || fail "(a): expected a FAIL line naming ZERO AC lines: $OUT_A"
+printf '%s' "$OUT_A" | grep -q 'require-tests.sh' || fail "(a): expected the FAIL line to reference require-tests.sh's fail-closed precedent: $OUT_A"
+
+# ==== (b) AC lines present but none carry any contract field -> FAIL ====
+SUB="$DIR/b"; mkdir -p "$SUB"; cd "$SUB" || fail "cd b"
+printf -- '- AC: first thing, no contract\n- AC: second thing, no contract\n' > plan.md
+OUT_B="$(run_ac_verify plan.md .loop 2>&1)"; CODE_B=$?
+[ "$CODE_B" -eq 1 ] || fail "(b): expected exit 1, got $CODE_B: $OUT_B"
+printf '%s' "$OUT_B" | grep -q '^VERDICT: FAIL$' || fail "(b): expected VERDICT: FAIL: $OUT_B"
+printf '%s' "$OUT_B" | grep -qE '^SUMMARY: passed=0 failed=0 skipped=2 ' || fail "(b): expected skipped=2 (both uncontracted): $OUT_B"
+printf '%s' "$OUT_B" | grep -q '^FAIL: .*ZERO carry a machine-checkable contract' || fail "(b): expected a FAIL line naming zero contracts: $OUT_B"
+printf '%s' "$OUT_B" | grep -q 'require-tests.sh' || fail "(b): expected the FAIL line to reference require-tests.sh: $OUT_B"
+
+# ==== (c) one AC with a verify: command that exits 0 -> overall PASS ====
+SUB="$DIR/c"; mkdir -p "$SUB"; cd "$SUB" || fail "cd c"
+printf -- '- AC: server starts | verify: true\n' > plan.md
+OUT_C="$(run_ac_verify plan.md .loop 2>&1)"; CODE_C=$?
+[ "$CODE_C" -eq 0 ] || fail "(c): expected exit 0, got $CODE_C: $OUT_C"
+printf '%s' "$OUT_C" | grep -q '^VERDICT: PASS$' || fail "(c): expected VERDICT: PASS: $OUT_C"
+printf '%s' "$OUT_C" | grep -qE '^SUMMARY: passed=1 failed=0 skipped=0 ' || fail "(c): expected passed=1: $OUT_C"
+
+# ==== (d) one AC with a verify: command that exits nonzero -> overall FAIL, named FAIL: line ====
+SUB="$DIR/d"; mkdir -p "$SUB"; cd "$SUB" || fail "cd d"
+printf -- '- AC: broken build | verify: exit 7\n' > plan.md
+OUT_D="$(run_ac_verify plan.md .loop 2>&1)"; CODE_D=$?
+[ "$CODE_D" -eq 1 ] || fail "(d): expected exit 1, got $CODE_D: $OUT_D"
+printf '%s' "$OUT_D" | grep -q '^VERDICT: FAIL$' || fail "(d): expected VERDICT: FAIL: $OUT_D"
+printf '%s' "$OUT_D" | grep -qE '^SUMMARY: passed=0 failed=1 skipped=0 ' || fail "(d): expected failed=1: $OUT_D"
+printf '%s' "$OUT_D" | grep -q '^FAIL: AC "broken build":.*verify exited 7' || fail "(d): expected a FAIL line naming the AC and its real exit code 7: $OUT_D"
+
+# ==== (e) artifacts: — an existing path passes; a missing path FAILs even if verify: exits 0 ====
+SUB="$DIR/e"; mkdir -p "$SUB"; cd "$SUB" || fail "cd e"
+: > exists.txt
+printf -- '- AC: artifact present | verify: true | artifacts: exists.txt\n' > plan-ok.md
+OUT_E1="$(run_ac_verify plan-ok.md .loop 2>&1)"; CODE_E1=$?
+[ "$CODE_E1" -eq 0 ] || fail "(e-present): expected exit 0, got $CODE_E1: $OUT_E1"
+printf '%s' "$OUT_E1" | grep -qE '^SUMMARY: passed=1 failed=0 skipped=0 ' || fail "(e-present): expected passed=1: $OUT_E1"
+
+printf -- '- AC: artifact missing | verify: true | artifacts: does-not-exist.txt\n' > plan-missing.md
+OUT_E2="$(run_ac_verify plan-missing.md .loop2 2>&1)"; CODE_E2=$?
+[ "$CODE_E2" -eq 1 ] || fail "(e-missing): expected exit 1 even though verify: exits 0, got $CODE_E2: $OUT_E2"
+printf '%s' "$OUT_E2" | grep -q '^FAIL: AC "artifact missing":.*missing artifact(s): does-not-exist.txt' || fail "(e-missing): expected a FAIL line naming the missing artifact: $OUT_E2"
+
+# ==== (f) expect: — substring present passes; substring absent FAILs ====
+SUB="$DIR/f"; mkdir -p "$SUB"; cd "$SUB" || fail "cd f"
+printf -- '- AC: greets correctly | verify: echo hello-world | expect: hello-world\n' > plan-present.md
+OUT_F1="$(run_ac_verify plan-present.md .loop 2>&1)"; CODE_F1=$?
+[ "$CODE_F1" -eq 0 ] || fail "(f-present): expected exit 0, got $CODE_F1: $OUT_F1"
+
+printf -- '- AC: greets correctly | verify: echo hello-world | expect: goodbye\n' > plan-absent.md
+OUT_F2="$(run_ac_verify plan-absent.md .loop2 2>&1)"; CODE_F2=$?
+[ "$CODE_F2" -eq 1 ] || fail "(f-absent): expected exit 1, got $CODE_F2: $OUT_F2"
+printf '%s' "$OUT_F2" | grep -q '^FAIL: AC "greets correctly":.*expect substring not found' || fail "(f-absent): expected a FAIL line naming the missing expect substring: $OUT_F2"
+
+# ==== (g) one contracted AC (passes) + one uncontracted AC -> overall PASS, uncontracted counted under skipped= ====
+SUB="$DIR/g"; mkdir -p "$SUB"; cd "$SUB" || fail "cd g"
+printf -- '- AC: contracted one | verify: true\n- AC: uncontracted human check\n' > plan.md
+OUT_G="$(run_ac_verify plan.md .loop 2>&1)"; CODE_G=$?
+[ "$CODE_G" -eq 0 ] || fail "(g): expected exit 0, got $CODE_G: $OUT_G"
+printf '%s' "$OUT_G" | grep -q '^VERDICT: PASS$' || fail "(g): expected VERDICT: PASS: $OUT_G"
+printf '%s' "$OUT_G" | grep -qE '^SUMMARY: passed=1 failed=0 skipped=1 ' || fail "(g): expected passed=1 skipped=1: $OUT_G"
+
+# ==== (h) one passing + one failing contracted AC -> overall FAIL, exactly one FAIL: line ====
+SUB="$DIR/h"; mkdir -p "$SUB"; cd "$SUB" || fail "cd h"
+printf -- '- AC: good one | verify: true\n- AC: bad one | verify: false\n' > plan.md
+OUT_H="$(run_ac_verify plan.md .loop 2>&1)"; CODE_H=$?
+[ "$CODE_H" -eq 1 ] || fail "(h): expected exit 1, got $CODE_H: $OUT_H"
+printf '%s' "$OUT_H" | grep -qE '^SUMMARY: passed=1 failed=1 skipped=0 ' || fail "(h): expected passed=1 failed=1: $OUT_H"
+FAIL_LINES_H="$(printf '%s\n' "$OUT_H" | grep -c '^FAIL: ')"
+[ "$FAIL_LINES_H" -eq 1 ] || fail "(h): expected exactly 1 FAIL: line, got $FAIL_LINES_H: $OUT_H"
+printf '%s' "$OUT_H" | grep -q '^FAIL: AC "bad one":' || fail "(h): expected the FAIL line to name 'bad one': $OUT_H"
+printf '%s' "$OUT_H" | grep -q '^FAIL: AC "good one":' && fail "(h): the passing AC must NOT produce a FAIL line: $OUT_H"
+
+# ==== (i) sanity-check the emitted block's delimiters + the VERDICT line matches the actual exit code ====
+SUB="$DIR/i"; mkdir -p "$SUB"; cd "$SUB" || fail "cd i"
+printf -- '- AC: sanity check | verify: true\n' > plan.md
+OUT_I="$(run_ac_verify plan.md .loop 2>&1)"; CODE_I=$?
+[ "$(printf '%s\n' "$OUT_I" | head -n1)" = "=== VERDICT ===" ] || fail "(i): block must start with '=== VERDICT ===': $OUT_I"
+[ "$(printf '%s\n' "$OUT_I" | tail -n1)" = "=== END VERDICT ===" ] || fail "(i): block must end with '=== END VERDICT ===': $OUT_I"
+if [ "$CODE_I" -eq 0 ]; then
+  printf '%s' "$OUT_I" | grep -q '^VERDICT: PASS$' || fail "(i): exit 0 must correspond to VERDICT: PASS: $OUT_I"
+else
+  printf '%s' "$OUT_I" | grep -q '^VERDICT: FAIL$' || fail "(i): a nonzero exit must correspond to VERDICT: FAIL: $OUT_I"
+fi
+
+cd "$ORIG_PWD" || true
+echo "PASS: ac-verify.sh (issue #23) — zero-AC/zero-contract fail-closed, independent verify:/artifacts:/expect: checks, mixed pass+fail and contracted+uncontracted aggregation, Verdict Contract block shape"
+exit 0

--- a/tools/ship-flow/agents/planner.md
+++ b/tools/ship-flow/agents/planner.md
@@ -23,6 +23,12 @@ whether a plan is concrete enough to safely hand to TDD, and to say exactly why 
 4. **No speculative scope.** Flag anything in the plan that isn't required by the stated acceptance
    criteria — configurability, abstractions, or error handling for scenarios the plan itself doesn't
    claim can happen. This isn't your call to delete, just to flag for the implementer.
+5. **AC contract coverage.** For a plan targeting a `standard` or `risky` track (`docs-only` is
+   exempt — no runtime surface to contract against), the plan as a whole must declare at least one
+   acceptance criterion using the one-line contract syntax (`verify:`/`artifacts:`/`expect:`). Not
+   every AC needs one, but zero across the whole plan is a BLOCK — this is the same fail-closed shape
+   `ac-verify.sh`/`require-tests.sh` already enforce elsewhere in this plugin, and catching it here
+   means the plan never reaches TDD before failing, instead of failing much later at step 3.
 
 ## What you don't do
 

--- a/tools/ship-flow/skills/ship-feature/SKILL.md
+++ b/tools/ship-flow/skills/ship-feature/SKILL.md
@@ -155,6 +155,27 @@ planned paths directly: `<loop-engine classify-risk.sh> --no-gate --path <planne
 resulting `TRACK:`/`DEEP_GATES:` scope the remaining steps.
 → **Gate:** success criteria (what "done" verifiably means) has to be written down before moving on.
 
+**Express acceptance criteria as one-line AC contracts** — this is what makes step 3's gate below
+machine-checkable instead of self-reported (ADR-0104). Syntax (quoted verbatim — matches
+`ac-verify.sh`'s parser exactly, an optional leading markdown list marker like `- ` is tolerated):
+
+```
+AC: <description> | verify: <command> | artifacts: <path1>,<path2> | expect: <substring>
+```
+
+Only `AC: <description>` is required — `verify:`, `artifacts:`, and `expect:` are each optional, may
+appear in any combination or order, and are separated by ` | `. `artifacts:` paths are
+**comma-separated** (not space-separated — a path may itself contain spaces). Example:
+
+```
+AC: login rejects a wrong password | verify: pnpm --filter api test -- auth.spec.ts | expect: 401
+```
+
+For a `standard` or `risky` track (anything with a runtime surface — `docs-only` is exempt, since
+step 3 is already skipped for it per the TRACK table above), **the plan as a whole must express at
+least one AC with a machine-checkable contract** (a `verify:` and/or `artifacts:`/`expect:` field) —
+not every AC needs one, but zero across the whole plan means step 3 (Runtime verify) will fail closed.
+
 **If the plan itself exceeds one session's budget** (the scope is too large to pin down a single
 verifiable "done"), don't jump straight to implementation — split the issue into a map of decision
 tickets first: one separate tracked issue per still-open question (blocked-by links pointing at
@@ -177,7 +198,10 @@ actual diff with `--from-git`). Red loops back autonomously.
 ### 3. Runtime verify
 Build and run the app, drive the changed surface (CLI/API/GUI — whatever applies) through it, and
 confirm **what was intended actually works**. This produces runtime evidence, not a re-run of the test
-suite.
+suite. When step 1's plan has any AC contracts, this is now formalized via `<however this repo invokes
+its installed loop-engine plugin's bin scripts> ac-verify.sh <plan-file>` (ADR-0104) — deterministic
+subprocess judgment (verify exit code, artifact existence, output substring) per contracted AC,
+composing with — not replacing — the observe-the-running-app check above.
 → **Gate:** PASS. FAIL → **loop back to step 2**. SKIP (no runtime surface exists) passes with a
 one-line reason.
 


### PR DESCRIPTION
## What

Implements #23 — the AC-level success contract gate, ported from glucofit-partners' ADR-0104
(`docs/adr/0104-ac-level-success-contract-plan-file-is-source-paul-loop-owns-implementation.md`,
BAC-625 grill session, glucofit-partners PR #740). ADR-0104's decision 5 assigns implementation
ownership of this primitive to paul-loop itself (this repo), not the consuming repo's `tools/`.

**Design (from ADR-0104, already settled — this PR is implementation only):**
1. The plan file (this skill's step 1 output) is the source of truth for AC contracts — a
   tracker's AC prose is a human-readable copy, never the parse target (reproducibility: a verify
   loop that depends on tracker API access can't run in CI or a fresh clone).
2. This is an *additional* gate on top of the existing repo-wide verify command, formalizing
   ship-feature step 3 (Runtime verify) — it doesn't replace `pnpm verify`-equivalent.
3. Execution lives in a dedicated `ac-verify.sh` that reuses `verdict-run.sh` per AC (command
   execution + VERDICT capture), adding artifact-existence and output-substring checks plus
   overall aggregation and its own VERDICT block. `verdict-run.sh` itself stays a single-command
   contract, unmodified.
4. Zero AC contracts in a plan = fail-closed FAIL, modeled directly on `require-tests.sh`'s
   "0 tests = RED" — this is the fix for the dogfood trap ADR-0104 documents (ouroboros' real seed
   AC set had 9/9 contract-free, because nothing made zero unacceptable).

## What changed

- **`tools/loop-engine/bin/ac-verify.sh`** (new) — parses a plan file for one-line AC contracts
  (`AC: <desc> | verify: <cmd> | artifacts: <paths> | expect: <substring>`, tolerant of a leading
  `- ` list marker), runs each contracted AC's `verify:` command through `verdict-run.sh` using
  the exact `-- sh -c "<cmd>"` invocation `loop-fix.sh` already uses, independently checks
  `artifacts:` (comma-separated paths, existence relative to CWD) and `expect:` (literal substring
  via `grep -F` against the per-AC log), and emits its own top-level Verdict Contract block
  (`=== VERDICT === ... === END VERDICT ===`) so it composes unmodified with whatever already
  consumes `verdict-run.sh`'s shape (Stop-hook, `loop-fix.sh`). Fail-closed exactly like
  `require-tests.sh`: zero AC lines, or AC lines with zero contracted fields, is FAIL with a
  `FAIL:` line that explicitly names the same fail-closed precedent. `verdict-run.sh`'s own
  exit-2 usage errors are propagated as `ac-verify.sh`'s own hard exit 2 (mirroring
  `loop-fix.sh`'s handling of the same case), not silently folded into an AC failure. bash 3.2
  compatible (no associative arrays, `${var,,}`, or mapfile/readarray).

- **`tools/ship-flow/skills/ship-feature/SKILL.md`** — step 1 now quotes the AC contract syntax
  verbatim (with the comma-separated `artifacts:` delimiter convention and a worked example), and
  states that a `standard`/`risky` track plan must express at least one contracted AC (`docs-only`
  stays exempt, per the existing TRACK table). Step 3 gets one added sentence: when the plan has AC
  contracts, the gate is now formalized via `ac-verify.sh`, composing with (not replacing) the
  existing observe-the-running-app guidance.

- **`tools/ship-flow/agents/planner.md`** — adds a 5th fail-any-criterion check, "AC contract
  coverage": a `standard`/`risky` plan with zero contracted ACs is a BLOCK, catching the same
  fail-closed condition before TDD starts rather than only failing later at step 3.

- **`tools/loop-engine/test/ac-verify.test.sh`** (new) — regression coverage: (a) zero AC lines →
  FAIL; (b) AC lines with zero contracts → FAIL; (c) passing `verify:` → PASS; (d) failing
  `verify:` → FAIL naming the AC + its real exit code; (e) `artifacts:` present/missing
  (missing FAILs even when `verify:` exits 0); (f) `expect:` substring present/absent; (g) mixed
  contracted+uncontracted AC → PASS, uncontracted counted under `skipped=`; (h) mixed pass+fail
  contracted ACs → FAIL with exactly one `FAIL:` line; (i) block-delimiter/exit-code sanity.

## Follow-up fixes (adversarial review, same PR)

An independent adversarial review reproduced two real gaps in the first version of
`ac-verify.sh`, both fixed in a follow-up commit on this branch:

1. **`verdict-state.json` last-writer-wins.** Each per-AC `verdict-run.sh` sub-call writes
   `${LOOP_DIR:-.loop}/verdict-state.json` with *its own* pass/fail (`verdict-run.sh`'s existing,
   unmodified contract — every layer writes it, last writer wins). Left uncorrected, if a failing
   AC was processed before a passing one, the file ended up showing the **last-processed** AC's
   own PASS/exit-0 even though `ac-verify.sh`'s own printed `VERDICT: FAIL` block was correct — a
   Stop-hook-style freshness gate reading that file directly would see a stale, wrong "fresh
   PASS" for a run that genuinely failed. This directly undermines the "composes unmodified with
   whatever already consumes `verdict-run.sh`'s shape" claim above for any consumer of
   `verdict-state.json` specifically (the top-level stdout `VERDICT` block itself was always
   correct). Fixed: after computing its own true aggregate, `ac-verify.sh` now makes one
   unconditional final `verdict-run.sh` call whose only purpose is to be the last writer to
   `verdict-state.json` with the *correct* aggregate result (its own poorer VERDICT block is
   discarded). **The "composes unmodified" claim above is now accurate for `verdict-state.json`
   too**, not just for the printed block.
2. **Field-prefix parsing was exact-match case-sensitive with zero tolerance for plausible
   authoring variants.** `Verify: exit 7` and `**verify:** exit 7` (capitalized, and
   markdown-bold-wrapped — both plausible things an LLM or human plan author writes) silently
   vanished with zero diagnostic, folded into the description and counted as `skipped=`,
   indistinguishable from a deliberately-uncontracted AC. Fixed: (a) prefix-matching now
   normalizes a copy of each token (lowercase + strip up to one layer of leading/trailing
   markdown emphasis — `**`/`__`/`*`/`_`) before matching, while the extracted *value* keeps the
   original case/text; (b) any segment that still doesn't match a known field but looks
   field-like (a `:` within roughly its first 20 chars) now prints a warning to stderr naming the
   AC and the segment verbatim, instead of vanishing with zero trace — stays a warning, not a
   hard error, since an ordinary colon in free-text description content is legitimate.

New regression coverage in the same `ac-verify.test.sh`: (j) a failing-AC-before-passing-AC plan,
asserted against `verdict-state.json`'s actual on-disk content (not just `ac-verify.sh`'s own
stdout/exit code); (k)/(l) `Verify:` and `**verify:**` correctly FAIL the gate on a failing
command instead of being silently skipped; (n) a genuine typo (`verfy:`, not one of the
normalized variants) still falls into `skipped=` as before, but now emits a named warning on
stderr.

## Verification

`bash tools/loop-engine/test/run.sh` (full suite, ~60s — unrelated existing tests create real git
worktrees):

```
PASS: ac-verify.sh (issue #23) — zero-AC/zero-contract fail-closed, independent verify:/artifacts:/expect:
checks, mixed pass+fail and contracted+uncontracted aggregation, Verdict Contract block shape,
verdict-state.json aggregate-sync (not last-writer-wins), case/markdown-emphasis-tolerant field
parsing, unrecognized-field-like-segment warning
...
loop-engine selftest: 22/22 passed
```
(22/22 — still one `.test.sh` file for `ac-verify.sh` (the follow-up fixes above added more cases
to the same file, not a new file); 21/21 → 22/22 remains the delta introduced by this PR overall,
zero regressions.)

Manual sanity runs of `ac-verify.sh` against throwaway `mktemp -d` fixtures beyond the automated
test file confirmed: normal PASS/FAIL aggregation, the zero-AC and zero-contract fail-closed
messages (both explicitly cite `require-tests.sh`), a real underlying exit code surfaced in the
`FAIL:` reason (`exit 3` reported correctly, not verdict-run's own wrapper exit), a shell-pipe
embedded inside a `verify:` command parsing correctly, and a genuinely broken log directory
correctly hard-aborting with exit 2 (propagating `verdict-run.sh`'s own usage-error message)
instead of being misreported as an ordinary AC failure.

**Manual reproduction of the two adversarial-review fixtures, before/after the follow-up fix:**

Fixture 1 — `- AC: fails first | verify: false` listed before `- AC: passes second | verify: true`:
- Before: `verdict-state.json` → `{"verdict":"PASS","exit":0,...}` (the last sub-call's own state)
  while `ac-verify.sh`'s own stdout correctly said `VERDICT: FAIL` / `EXIT: 1` — a direct
  contradiction between the file and the printed block.
- After: `verdict-state.json` → `{"verdict":"FAIL","exit":1,...,"cmd":"sh -c : ac-verify.sh
  aggregate result for 'plan.md'; exit 1",...}`, now agreeing with `ac-verify.sh`'s own
  `VERDICT: FAIL` / `EXIT: 1`.

Fixture 2/3 — `- AC: capitalized field | Verify: exit 7` and `- AC: bold field | **verify:** exit 7`:
- Before: both exited 1, but for the *wrong* reason — `SUMMARY: passed=0 failed=0 skipped=1` with
  `FAIL: plan file 'plan.md' has 1 AC line(s) but ZERO carry a machine-checkable contract` (the
  zero-contract fail-closed path — `exit 7` never actually ran).
  After: both now exit 1 for the *right* reason — `SUMMARY: passed=0 failed=1 skipped=0` with
  `FAIL: AC "...": verify exited 7` — the command is recognized as a real contract and actually
  runs.
- Typo control (`verfy: exit 7`, deliberately NOT one of the normalized variants): still correctly
  falls into `skipped=` (unchanged behavior), but now prints
  `ac-verify.sh: warning — AC #1 ("typo field"): unrecognized field-like segment (folded into
  description, not treated as a contract): "verfy: exit 7"` on stderr instead of vanishing
  silently.

---

Merge is on hold pending human review.

