### PR TITLE
fix(loop-fix): --protect 가드 7라운드 적대적 하드닝 (탐지→원복→무결성→메모리이관→PASS경로→grace period→watchdog경합)

### DIFF
--- a/tools/loop-engine/bin/loop-fix.sh
+++ b/tools/loop-engine/bin/loop-fix.sh
@@ -379,20 +379,44 @@ check_protected() {
   [ "$_now" = "$PROTECT_SNAP_DATA" ]
 }
 
-# check_protected_with_grace() (issue #34 round-5, Part 1): runs check_protected() first — zero
-# added latency when nothing is protected, or when the mutation already happened synchronously (the
-# overwhelming common case) — and ONLY if that came back clean AND something is actually protected,
-# sleeps PROTECT_GRACE_SEC and checks a SECOND time. Exists because `sh -c "$FIX"` does not wait on a
-# job the fixer detaches with `&`: a fixer can return immediately while a backgrounded subshell
-# mutates a protected file after loop-fix.sh has already moved on to its own check. A single
-# check_protected() call, no matter WHERE it runs, can only ever prove "clean as of the instant it
-# ran" — it cannot see a mutation that has not happened yet. This recheck converts "any delay beats
-# detection" into "the delay must be under PROTECT_GRACE_SEC to be undetected" — see the round-5
-# Guard-scope block above for what this does and does NOT guarantee.
+# check_protected_with_grace() (issue #34 round-5, Part 1): runs check_protected() first (zero added
+# latency when nothing is protected) and, ONLY if something is actually protected, ALSO sleeps
+# PROTECT_GRACE_SEC and checks a SECOND time — regardless of whether the first check was clean or
+# violated (a violation already returns 1 without paying the sleep; every CLEAN check, which is the
+# common case, does pay it — do not read this as "the common case is free"). Exists because
+# `sh -c "$FIX"` does not wait on a job the fixer detaches with `&`: a fixer can return immediately
+# while a backgrounded subshell mutates a protected file after loop-fix.sh has already moved on to
+# its own check. A single check_protected() call, no matter WHERE it runs, can only ever prove
+# "clean as of the instant it ran" — it cannot see a mutation that has not happened yet. This
+# recheck converts "any delay beats detection" into "the delay must be under PROTECT_GRACE_SEC to be
+# undetected" — see the round-5 Guard-scope block above for what this does and does NOT guarantee.
+#
+# Round-6 adversarial finding: a plain single `sleep "$PROTECT_GRACE_SEC"` is itself a child process
+# of loop-fix.sh, and start_watchdog()'s descendant-killer (BAC-626 ③) sends SIGTERM/SIGKILL to
+# EVERY child process when an idle/progress timeout fires — including this sleep, if the configured
+# watchdog timeout happens to be shorter than PROTECT_GRACE_SEC (an unusual combination, but a real,
+# demonstrated one: --idle-timeout-sec below the default recommended 600s). That would silently
+# truncate the grace period without ever completing the recheck below. Fix: background the sleep,
+# `wait` on it, and check ITS OWN exit status — a `sleep` killed by a signal exits at 128+signum (143
+# for SIGTERM, 137 for SIGKILL), a normal uninterrupted sleep exits 0 — and retry the SAME full
+# PROTECT_GRACE_SEC duration (not a computed remainder, which would need sub-second wall-clock
+# arithmetic `date +%s` cannot provide portably — BSD date has no %N) if it was killed. Bounded to 3
+# attempts; the watchdog fires at most once per run and its subshell exits right after its one kill
+# sweep (see start_watchdog()), so at most one retry is ever needed in practice.
 check_protected_with_grace() {
   check_protected || return 1
   [ -n "$PROTECT_SNAP_DATA" ] || return 0
-  sleep "$PROTECT_GRACE_SEC"
+  case "$PROTECT_GRACE_SEC" in
+    0|0.0|0.00|.0|.00) return 0 ;;   # explicit "no grace" test-speed override — skip the sleep entirely
+  esac
+  _grace_tries=0
+  while [ "$_grace_tries" -lt 3 ]; do
+    sleep "$PROTECT_GRACE_SEC" 2>/dev/null &
+    _grace_pid=$!
+    wait "$_grace_pid" 2>/dev/null
+    [ $? -lt 128 ] && break
+    _grace_tries=$(( _grace_tries + 1 ))
+  done
   check_protected
 }
 
@@ -738,6 +762,13 @@ while [ "$iter" -lt "$MAX_ITER" ]; do
   if [ "$vcode" -eq 2 ]; then
     log "iter $iter: verdict-run refused to run (exit 2 — usage error / fail-closed guard). Aborting."
     sed 's/^/    /' "$LOOP_DIR/verdict-run.err" 2>/dev/null | tee -a "$HISTORY"
+    # Round-6 adversarial finding: this abort path exits without ever rechecking protected files —
+    # an earlier iteration's still-pending delayed background mutation (see
+    # check_protected_with_grace()) could land after every other check in the run and leave the
+    # workspace silently corrupted on this otherwise-unrelated exit. Same treatment as the other six
+    # abort points: check_protected_on_abort() restores + warns but never changes this path's own
+    # exit code.
+    check_protected_on_abort
     log "=== loop-fix done: VERDICT-RUN-ERROR ==="
     exit 2
   fi

--- a/tools/loop-engine/bin/loop-fix.sh
+++ b/tools/loop-engine/bin/loop-fix.sh
@@ -62,7 +62,11 @@
 #                       never self-match a broad glob like '**/*.test.*'); otherwise it is a
 #                       single-level glob or a literal path. If a --protect pattern matches ZERO
 #                       files, the loop refuses to run (exit 2) rather than silently leaving the
-#                       guard off.
+#                       guard off. Every check_protected() call that comes back clean is followed by
+#                       a bounded grace-period recheck (PROTECT_GRACE_SEC, default 1.5s, override via
+#                       env var LOOP_PROTECT_GRACE_SEC — mainly a test-speed knob) before being
+#                       trusted — see round-5 in Guard scope below for why, and what this does and
+#                       does NOT guarantee.
 #   --loop-dir <dir>    State/handoff dir (default .loop).
 #   --lessons <dir>     Verified-lessons memory (Phase 3): recall past fixes for this same failure
 #                       into the fix prompt, and record a VERIFIED lesson on success. See bin/lessons.mjs.
@@ -111,12 +115,52 @@
 # symlink to an external path, the restored bytes land at the symlink's target and the file is
 # left as a symlink (content is correct, file type/identity is not) — this does not defeat
 # detection or let a rerun report false success, it is a restoration-fidelity gap, not a bypass.
-# Round-4 fix, narrow residual: check_protected() now also runs on the PASS path (right before
-# declaring success), not just the FAIL path — closing a bypass where a fixer backgrounded a
-# detached mutation timed to land after the FAIL-path check but before the next verify call; a
-# narrower window still remains (a background job timed to land in the handful of shell statements
-# between the new PASS-path check and the actual exit 0 — likely low milliseconds, not the whole
-# verify runtime) and is knowingly not chased further, same as the other narrow gaps in this section.
+# Round-4 fix: check_protected() now also runs on the PASS path (right before declaring success),
+# not just the FAIL path — closing a bypass where a fixer backgrounded a detached mutation timed to
+# land after the FAIL-path check but before the next verify call.
+#
+# Round-5 fix (this revision) — two parts closing the SAME underlying limitation from two angles:
+# the fixer runs as `sh -c "$FIX"`, and if $FIX ends with something like "(sleep D;
+# corrupt-the-file) & true", that backgrounded subshell is NOT waited on — `sh -c "$FIX"` exits once
+# "true" returns, the background job gets reparented away from anything loop-fix.sh can see or wait
+# for, and ANY delay D longer than roughly "however long this process takes to finish its own check
+# and exit" lands the corruption strictly AFTER that check already ran and reported clean. This is
+# NOT a logic bug in check_protected() itself (confirmed correct in isolation) — it is a structural
+# property of any short-lived supervisor process: you cannot detect, at the moment you check,
+# something that has not happened yet. Adding another check_protected() call at some OTHER point
+# does not close this either — the same argument applies to whatever the new "last point" becomes;
+# an attacker just increases D further.
+#
+#   Part 1 — bounded grace-period recheck (check_protected_with_grace(), used on BOTH the PASS path
+#   and the FAIL path, replacing the bare check_protected() calls round 4 added): once a
+#   check_protected() call comes back clean, sleep a short, bounded grace period (PROTECT_GRACE_SEC,
+#   default 1.5s, override via env var LOOP_PROTECT_GRACE_SEC — a test-speed knob) and check ONE
+#   more time; a failing recheck is handled exactly like any other violation. This converts "any D
+#   beats it" into "D must be under PROTECT_GRACE_SEC to be undetected" — a meaningfully higher bar
+#   against realistic reward-hacking, NOT a claim that the gap is closed (see "Honest limit" below).
+#
+#   Part 2 — the STALLED / BUDGET / watchdog-during-fixer / infra-cap-exhausted abort paths check
+#   their OWN abort condition and exit BEFORE that iteration's fixer invocation or the FAIL-path
+#   check_protected() call ever runs. A corruption from an EARLIER iteration's still-pending delayed
+#   background job can therefore land after every check_protected() call in the run has already
+#   completed, and the run exits non-zero — its own real failure code (STALLED stays STALLED, BUDGET
+#   stays BUDGET; this is NOT the false-SUCCESS class of bug) — with the protected file left
+#   corrupted, unrestored, and unflagged. Each of these paths now also calls
+#   check_protected_with_grace() (via check_protected_on_abort()) right before it exits: on a
+#   violation it logs a warning, restores from backup, and cleans up any rogue new protect-matching
+#   file — the same recovery as a normal violation — but keeps its OWN exit code. This is workspace
+#   hygiene on exit, not a re-diagnosis of why the run failed.
+#
+# Honest limit (read this, it is the actual guarantee): the grace period raises the bar, it does not
+# close the gap. A background job whose delay exceeds PROTECT_GRACE_SEC lands strictly after this
+# process has finished checking and exited — a structural limit of any short-lived supervisor
+# process, not a bug in this specific check, and NOT something a larger grace period alone can ever
+# fully close (an attacker can always pick a D larger than whatever finite grace period is set). If
+# a caller needs a stronger guarantee against a fixer that deliberately backgrounds long-delayed
+# mutations, the fixer's execution environment itself would need to be sandboxed (e.g. no ability to
+# survive past the fixer subprocess's own lifetime, via a process-group kill or similar OS-level
+# containment) — that is a materially different, larger architectural change and is explicitly out
+# of scope for this fix.
 # Stall caveat: stall detection is reliable when the verifier emits recognizable failure markers
 # or changing pass/fail counts; the hard guarantee against runaway is --max-iter.
 #
@@ -133,6 +177,11 @@ LESSONS=""        # optional verified-lessons memory dir (Phase 3)
 INFRA_RETRIES=2   # BAC-626 ②: transient 인프라 실패 면제 상한(초과 시 INFRA 중단)
 IDLE_T=0; PROG_T=0  # BAC-626 ③: material-progress 워치독(0=off, 완전 opt-in)
 GUARD_MUT=""      # BAC-626 ④: verdict-run passthrough 플래그(빈 값=off)
+# issue #34 round-5: bounded grace period a check_protected() pass is held to before being trusted —
+# raises the bar against a fixer that backgrounds a delayed mutation (see check_protected_with_grace()
+# and the round-5 Guard-scope block above) but does NOT guarantee catching every delay, only ones
+# shorter than this. Override via LOOP_PROTECT_GRACE_SEC (test-speed knob).
+PROTECT_GRACE_SEC="${LOOP_PROTECT_GRACE_SEC:-1.5}"
 
 need2() { [ "$1" -ge 2 ] || { echo "loop-fix.sh: $2 requires a value" >&2; exit 2; }; }
 
@@ -330,6 +379,23 @@ check_protected() {
   [ "$_now" = "$PROTECT_SNAP_DATA" ]
 }
 
+# check_protected_with_grace() (issue #34 round-5, Part 1): runs check_protected() first — zero
+# added latency when nothing is protected, or when the mutation already happened synchronously (the
+# overwhelming common case) — and ONLY if that came back clean AND something is actually protected,
+# sleeps PROTECT_GRACE_SEC and checks a SECOND time. Exists because `sh -c "$FIX"` does not wait on a
+# job the fixer detaches with `&`: a fixer can return immediately while a backgrounded subshell
+# mutates a protected file after loop-fix.sh has already moved on to its own check. A single
+# check_protected() call, no matter WHERE it runs, can only ever prove "clean as of the instant it
+# ran" — it cannot see a mutation that has not happened yet. This recheck converts "any delay beats
+# detection" into "the delay must be under PROTECT_GRACE_SEC to be undetected" — see the round-5
+# Guard-scope block above for what this does and does NOT guarantee.
+check_protected_with_grace() {
+  check_protected || return 1
+  [ -n "$PROTECT_SNAP_DATA" ] || return 0
+  sleep "$PROTECT_GRACE_SEC"
+  check_protected
+}
+
 # Restores every protected file to the bytes captured by snapshot_protected() at run start —
 # called right before the PROTECTED-VIOLATION abort so "detect" becomes "detect and undo" (issue
 # #34). Deliberately restores from $PROTECT_BACKUP, NOT `git checkout`: a protected file may
@@ -442,6 +508,26 @@ handle_protect_violation() {
   cleanup_rogue_protected
   log "=== loop-fix done: PROTECTED-VIOLATION ==="
   exit 3
+}
+
+# check_protected_on_abort() (issue #34 round-5, Part 2): STALLED / BUDGET / watchdog-during-fixer /
+# infra-cap-exhausted aborts check their OWN abort condition and exit BEFORE that iteration's fixer
+# invocation or the FAIL-path check_protected() call ever runs — so a corruption from an EARLIER
+# iteration's still-pending delayed background job (see check_protected_with_grace() above) can land
+# after every check_protected() call in the run has already completed, leaving the protected file
+# corrupted, unrestored, and unflagged even though the run correctly exits non-zero. Called right
+# before each of those paths' own exit: on a violation it logs a warning, restores from backup, and
+# cleans up any rogue new protect-matching file — same recovery as handle_protect_violation() — but
+# deliberately does NOT exit 3 and does NOT change the caller's verdict. Callers ignore this
+# function's return value and keep their own exit code and their own "done: X" reason; this is
+# workspace hygiene on exit, not a re-diagnosis of why the run failed.
+check_protected_on_abort() {
+  check_protected_with_grace && return 0
+  log "iter $iter: PROTECTED FILE MODIFIED by the fixer, discovered while aborting for an unrelated reason. This is reward hacking — restoring before this run exits (the exit code below is this abort's OWN reason, not a protect violation)."
+  log "Changed vs snapshot:"
+  diff <(printf '%s' "$PROTECT_SNAP_DATA") <(printf '%s' "$PROTECT_NOW_DATA") 2>/dev/null | sed 's/^/    /' | tee -a "$HISTORY"
+  restore_protected
+  cleanup_rogue_protected
 }
 
 # ── BAC-626 ①: 전체 LOG의 러너 요약줄 합산 카운트 ──────────────────────────────────────────
@@ -640,6 +726,7 @@ while [ "$iter" -lt "$MAX_ITER" ]; do
   if [ -f "$WATCHDOG_FIRED" ]; then
     wreason="$(head -n1 "$WATCHDOG_FIRED" 2>/dev/null)"
     log "iter $iter: ${wreason:-TIMEOUT} — material-progress watchdog fired. Aborting."
+    check_protected_on_abort
     record_fail_lesson
     log "=== loop-fix done: ${wreason:-TIMEOUT} ==="
     exit 1
@@ -666,7 +753,9 @@ while [ "$iter" -lt "$MAX_ITER" ]; do
     # PROTECTED-VIOLATION log line, no restore, no compromise marker — the same silent-false-SUCCESS
     # signature as every other bug this file exists to close. Must run before ANY success signal
     # (including the "PASS — stopping" log line just below), not just before the exit 0.
-    if ! check_protected; then
+    # Round-5: uses check_protected_with_grace() (a bounded sleep-then-recheck), not the bare
+    # check_protected() round 4 added — see the round-5 Guard-scope block near the top of this file.
+    if ! check_protected_with_grace; then
       handle_protect_violation
     fi
     log "iter $iter: PASS — stopping (success)."
@@ -701,6 +790,7 @@ while [ "$iter" -lt "$MAX_ITER" ]; do
     infra_count=$(( infra_count + 1 ))
     if [ "$infra_count" -gt "$INFRA_RETRIES" ]; then
       log "iter $iter: INFRA failure ${infra_count}x — retry cap exhausted. Aborting (infra, not code)."
+      check_protected_on_abort
       log "=== loop-fix done: INFRA ==="
       exit 1
     fi
@@ -708,6 +798,7 @@ while [ "$iter" -lt "$MAX_ITER" ]; do
     # (아래 정규 경로의 budget 블록과 동일 판정, 3축 리뷰 ②).
     if [ "$BUDGET" -gt 0 ] && [ $(( $(date +%s) - start_epoch )) -ge "$BUDGET" ]; then
       log "iter $iter: budget ${BUDGET}s exhausted during an infra-exempt retry. Aborting."
+      check_protected_on_abort
       log "=== loop-fix done: BUDGET ==="
       exit 1
     fi
@@ -735,6 +826,7 @@ while [ "$iter" -lt "$MAX_ITER" ]; do
   prev_fp="$fp"; prev_counts="$counts"
   if [ "$stall_count" -ge "$STALL" ]; then
     log "iter $iter: STALLED — identical failure fingerprint and no count progress ${stall_count}x running. Aborting."
+    check_protected_on_abort
     record_fail_lesson
     log "=== loop-fix done: STALLED ==="
     exit 1
@@ -745,6 +837,7 @@ while [ "$iter" -lt "$MAX_ITER" ]; do
     elapsed=$(( $(date +%s) - start_epoch ))
     if [ "$elapsed" -ge "$BUDGET" ]; then
       log "iter $iter: budget ${BUDGET}s exhausted (${elapsed}s). Aborting."
+      check_protected_on_abort
       record_fail_lesson
       log "=== loop-fix done: BUDGET ==="
       exit 1
@@ -809,13 +902,17 @@ while [ "$iter" -lt "$MAX_ITER" ]; do
   if [ -f "$WATCHDOG_FIRED" ]; then
     wreason="$(head -n1 "$WATCHDOG_FIRED" 2>/dev/null)"
     log "iter $iter: ${wreason:-TIMEOUT} — material-progress watchdog fired during the fixer. Aborting."
+    check_protected_on_abort
     record_fail_lesson
     log "=== loop-fix done: ${wreason:-TIMEOUT} ==="
     exit 1
   fi
 
   # ---- reward-hacking guard: protected files must be untouched ----
-  if ! check_protected; then
+  # Round-5: check_protected_with_grace() (bounded sleep-then-recheck) — same reasoning as the
+  # PASS-path call above, applied here for consistency (a fixer can background a delayed mutation
+  # timed to evade an immediate-only check here just as easily as on the PASS path).
+  if ! check_protected_with_grace; then
     handle_protect_violation
   fi
 done

--- a/tools/loop-engine/bin/loop-fix.sh
+++ b/tools/loop-engine/bin/loop-fix.sh
@@ -111,6 +111,12 @@
 # symlink to an external path, the restored bytes land at the symlink's target and the file is
 # left as a symlink (content is correct, file type/identity is not) — this does not defeat
 # detection or let a rerun report false success, it is a restoration-fidelity gap, not a bypass.
+# Round-4 fix, narrow residual: check_protected() now also runs on the PASS path (right before
+# declaring success), not just the FAIL path — closing a bypass where a fixer backgrounded a
+# detached mutation timed to land after the FAIL-path check but before the next verify call; a
+# narrower window still remains (a background job timed to land in the handful of shell statements
+# between the new PASS-path check and the actual exit 0 — likely low milliseconds, not the whole
+# verify runtime) and is knowingly not chased further, same as the other narrow gaps in this section.
 # Stall caveat: stall detection is reliable when the verifier emits recognizable failure markers
 # or changing pass/fail counts; the hard guarantee against runaway is --max-iter.
 #
@@ -423,6 +429,21 @@ cleanup_rogue_protected() {
   done
 }
 
+# Shared PROTECTED-VIOLATION response — invoked from BOTH call sites: the FAIL-path check (after the
+# fixer runs, before looping back to the next verify) and the PASS-path check (round-4, right before
+# declaring success). Same reaction either way: log loudly, show the diff, restore + clean up, and
+# exit 3. Factored out so the PASS-path addition below cannot drift from the FAIL-path behaviour it
+# is mirroring. Never returns.
+handle_protect_violation() {
+  log "iter $iter: PROTECTED FILE MODIFIED by the fixer. This is reward hacking — aborting."
+  log "Changed vs snapshot:"
+  diff <(printf '%s' "$PROTECT_SNAP_DATA") <(printf '%s' "$PROTECT_NOW_DATA") 2>/dev/null | sed 's/^/    /' | tee -a "$HISTORY"
+  restore_protected
+  cleanup_rogue_protected
+  log "=== loop-fix done: PROTECTED-VIOLATION ==="
+  exit 3
+}
+
 # ── BAC-626 ①: 전체 LOG의 러너 요약줄 합산 카운트 ──────────────────────────────────────────
 # verdict-run SUMMARY는 tail-60의 마지막 매치라 turbo 병렬 출력에선 "어느 한 패키지의 숫자"로
 # 회차마다 흔들린다(비결정 순서). 전체 LOG의 'Tests' 요약줄(vitest3 "Tests  3 failed | 245 passed"
@@ -637,6 +658,17 @@ while [ "$iter" -lt "$MAX_ITER" ]; do
   cat "$VERDICT_FILE"
 
   if [ "$vcode" -eq 0 ]; then
+    # ---- reward-hacking guard, PASS path (issue #34 round-4 adversarial finding) ----
+    # check_protected() used to run ONLY on the FAIL path below (right before looping back to the
+    # next verify) — never here. A fixer could background a detached mutation of a protected file
+    # timed to land AFTER that FAIL-path check but BEFORE the next verify call: the poisoned bytes
+    # would then be what verify reads, verify reports PASS, and this branch declared SUCCESS with no
+    # PROTECTED-VIOLATION log line, no restore, no compromise marker — the same silent-false-SUCCESS
+    # signature as every other bug this file exists to close. Must run before ANY success signal
+    # (including the "PASS — stopping" log line just below), not just before the exit 0.
+    if ! check_protected; then
+      handle_protect_violation
+    fi
     log "iter $iter: PASS — stopping (success)."
     # mark-clean wiring (issue #9): bump clean_pass_count on every lesson tied to this gate BEFORE
     # record — record's existing-lesson merge path resets clean_pass_count to 0 for the lesson that
@@ -784,13 +816,7 @@ while [ "$iter" -lt "$MAX_ITER" ]; do
 
   # ---- reward-hacking guard: protected files must be untouched ----
   if ! check_protected; then
-    log "iter $iter: PROTECTED FILE MODIFIED by the fixer. This is reward hacking — aborting."
-    log "Changed vs snapshot:"
-    diff <(printf '%s' "$PROTECT_SNAP_DATA") <(printf '%s' "$PROTECT_NOW_DATA") 2>/dev/null | sed 's/^/    /' | tee -a "$HISTORY"
-    restore_protected
-    cleanup_rogue_protected
-    log "=== loop-fix done: PROTECTED-VIOLATION ==="
-    exit 3
+    handle_protect_violation
   fi
 done
 

--- a/tools/loop-engine/bin/loop-fix.sh
+++ b/tools/loop-engine/bin/loop-fix.sh
@@ -58,24 +58,41 @@
 #                       at watchdog start; prefer the idle clock in that composition).
 #   --protect <glob>    File(s) the fixer must NOT modify (repeatable). Reward-hacking guard.
 #                       A pattern containing '**' recurses (resolved via `find`, skipping
-#                       node_modules/.git); otherwise it is a single-level glob or a literal path.
-#                       If a --protect pattern matches ZERO files, the loop refuses to run
-#                       (exit 2) rather than silently leaving the guard off.
+#                       node_modules/.git, and $LOOP_DIR itself so the guard's own backup copies
+#                       never self-match a broad glob like '**/*.test.*'); otherwise it is a
+#                       single-level glob or a literal path. If a --protect pattern matches ZERO
+#                       files, the loop refuses to run (exit 2) rather than silently leaving the
+#                       guard off.
 #   --loop-dir <dir>    State/handoff dir (default .loop).
 #   --lessons <dir>     Verified-lessons memory (Phase 3): recall past fixes for this same failure
 #                       into the fix prompt, and record a VERIFIED lesson on success. See bin/lessons.mjs.
 #
 # Exit: 0 = reached PASS. 1 = budget/iter/stall/infra/timeout exhausted. 2 = usage error / protect
 #       matched nothing / verdict-run itself refused (exit 2 — e.g. --guard-mutation outside git).
-#       3 = protected file mutated.
+#       3 = protected file mutated (restore attempted — see Guard scope below for what "restore"
+#       actually guarantees). 4 = refused to start: a PRIOR run's restore could not verify its own
+#       integrity and left $LOOP_DIR/protect-compromised behind — a human must inspect and clear it
+#       before retrying (see Guard scope below).
 #
 # Guard scope (read this — the guarantee is narrow): --protect aborts (exit 3) when a file that
 # existed at start AND was matched by --protect is edited or deleted. It does NOT cover files not
-# listed, files absent at start, or other inputs the verifier reads (fixtures, snapshots, config
-# like vitest.config/conftest.py). It detects the mutation AFTER the fact and, before aborting,
-# restores every protected file to the exact bytes it held when THIS run's snapshot was taken
-# (byte-for-byte from a backup copy — NOT `git checkout`, which would be wrong if a protected file
-# already had a legitimate uncommitted edit before this run even started).
+# listed, or other inputs the verifier reads (fixtures, snapshots, config like
+# vitest.config/conftest.py). It detects the mutation AFTER the fact and, before aborting: (a)
+# restores every protected file from a backup taken when THIS run's snapshot was taken
+# (byte-for-byte, NOT `git checkout` — a protected file may already have had a legitimate
+# uncommitted edit before this run even started); (b) deletes any NEW file that now matches a
+# --protect glob but did not exist at snapshot time, so a fixer cannot dodge the guard by dropping a
+# fresh trivially-passing file next to the real protected one; and (c) recomputes each restored
+# file's hash and compares it against the ORIGINAL hash recorded before iteration 1 ever ran. The
+# backup store lives on the same filesystem the fixer can write to, so a sufficiently motivated
+# fixer CAN poison the backup copy in the same move it poisons the live file — (c) exists to catch
+# exactly that. It is not a tamper-proof store; it is a check that notices when the store was
+# tampered with. When the restored bytes do NOT match the original hash, loop-fix.sh does NOT claim
+# success: it logs a loud, distinct failure, writes $LOOP_DIR/protect-compromised (which file(s),
+# why), and still exits 3. A SUBSEQUENT run then refuses to start at all (exit 4) until a human
+# inspects and clears that marker — so the actual guarantee is "detect, attempt an exact restore,
+# and if restoration integrity cannot itself be verified, refuse future runs until a human clears
+# it," not "always perfectly undoes any sabotage no matter how the fixer attacks the backup."
 # Stall caveat: stall detection is reliable when the verifier emits recognizable failure markers
 # or changing pass/fail counts; the hard guarantee against runaway is --max-iter.
 #
@@ -119,6 +136,31 @@ done
 [ -x "$VERDICT_RUN" ] || { echo "loop-fix.sh: cannot find verdict-run.sh next to me ($VERDICT_RUN)" >&2; exit 2; }
 
 mkdir -p "$LOOP_DIR"
+COMPROMISED_MARKER="$LOOP_DIR/protect-compromised"
+
+# Fail-closed startup check (issue #34 round-2 finding 1 / step 3): if a PRIOR run's protected-file
+# restore could not verify its own integrity (the backup store itself looked tampered with — see
+# restore_protected() below), it leaves this marker instead of silently reporting success. This is
+# what actually closes the "rerun reports false SUCCESS" case even under full double-poisoning: a
+# later run does not try to re-detect or re-trust a possibly-still-sabotaged workspace, it just
+# refuses to run at all until a human clears the marker. Placed before any real work — before the
+# sentinel arm, before snapshot_protected() — so a compromised workspace is never silently reused.
+if [ -s "$COMPROMISED_MARKER" ]; then
+  {
+    echo "loop-fix.sh: refusing to run — $COMPROMISED_MARKER exists from a prior run."
+    echo
+    echo "A previous run detected a protected-file violation, attempted to restore it from backup,"
+    echo "and could NOT verify that the restore actually worked (the backup itself appeared"
+    echo "tampered with — see the file above for which protected file(s) and why). This workspace"
+    echo "is left in an UNVERIFIED state on purpose rather than risking a false report of success."
+    echo
+    echo "A human must inspect the file(s) named in $COMPROMISED_MARKER, confirm they are"
+    echo "genuinely trustworthy (e.g. restore them from git or another trusted source), and then"
+    echo "remove that marker before retrying loop-fix.sh."
+  } >&2
+  exit 4
+fi
+
 HISTORY="$LOOP_DIR/history.log"
 VERDICT_FILE="$LOOP_DIR/last-verdict.txt"
 LOG_FILE="$LOOP_DIR/last-run.log"
@@ -126,6 +168,8 @@ PROMPT_FILE="$LOOP_DIR/fix-prompt.txt"
 PROTECT_SNAP="$LOOP_DIR/protected.sha"
 PROTECT_LIST_FILE="$LOOP_DIR/protected.files"   # relative paths captured at snapshot time (issue #34)
 PROTECT_BACKUP="$LOOP_DIR/protected-backup"     # byte-for-byte copies, mirroring relative paths
+PROTECT_MODES="$LOOP_DIR/protected.modes"       # original perm bits, same order as PROTECT_LIST_FILE
+                                                 # (undoes the backup's read-only chmod on restore, step 5)
 LESSONS_BIN="$HERE/lessons.sh"
 FIRST_VERDICT="$LOOP_DIR/first-verdict.txt"
 rm -f "$FIRST_VERDICT" 2>/dev/null   # reset per run: never inherit a prior run's first failure (sharing --loop-dir)
@@ -134,9 +178,30 @@ rm -f "$WATCHDOG_FIRED" 2>/dev/null  # reset per run: a stale fired flag must no
 WATCHDOG_PID=""
 
 sha_of() { shasum -a 256 "$1" 2>/dev/null || sha256sum "$1" 2>/dev/null; }
+mode_of() { stat -f '%Lp' "$1" 2>/dev/null || stat -c '%a' "$1" 2>/dev/null; }   # BSD vs GNU stat
+
+# Normalized form of $LOOP_DIR used to exclude the guard's own backup tree from '**' protect scans
+# (issue #34 round-2 finding 2): snapshot_protected() writes byte-backups under
+# $LOOP_DIR/protected-backup/<path>, which itself matches a broad glob like '**/*.test.*' — without
+# this exclusion, check_protected()'s rescan sees the backup as an extra unmatched file and
+# false-positives a violation even with a completely inert fixer. `find .`'s output is relative to
+# cwd with the leading './' stripped (see protect_files() below), so this must land in that same
+# relative form regardless of whether --loop-dir was left at the default relative ".loop", set to
+# another relative path, or given as an absolute path.
+case "$LOOP_DIR" in
+  /*)
+    case "$LOOP_DIR" in
+      "$PWD"/*) LOOP_DIR_EXCL="${LOOP_DIR#"$PWD"/}" ;;
+      "$PWD")   LOOP_DIR_EXCL="." ;;
+      *)        LOOP_DIR_EXCL="" ;;   # outside cwd's tree — `find .` can never see it anyway
+    esac
+    ;;
+  ./*) LOOP_DIR_EXCL="${LOOP_DIR#./}" ;;
+  *)   LOOP_DIR_EXCL="$LOOP_DIR" ;;
+esac
 
 # Expand the protect globs into a concrete file list.
-#  - a pattern with '**' recurses via find (skipping node_modules/.git)
+#  - a pattern with '**' recurses via find (skipping node_modules/.git, and $LOOP_DIR itself)
 #  - otherwise it is a single-level shell glob or a literal path
 protect_files() {
   printf '%s\n' "$PROTECT_LIST" | while IFS= read -r g; do
@@ -146,7 +211,15 @@ protect_files() {
         base="${g##*/}"   # e.g. '**/*.test.*' -> '*.test.*'
         find . -type f -name "$base" 2>/dev/null \
           | grep -vE '/(node_modules|\.git)/' \
-          | sed 's#^\./##' ;;
+          | sed 's#^\./##' \
+          | while IFS= read -r p; do
+              if [ -n "$LOOP_DIR_EXCL" ]; then
+                case "$p" in
+                  "$LOOP_DIR_EXCL"/*) continue ;;
+                esac
+              fi
+              printf '%s\n' "$p"
+            done ;;
       *)
         for f in $g; do [ -f "$f" ] && printf '%s\n' "$f"; done ;;
     esac
@@ -160,15 +233,24 @@ protect_files() {
 snapshot_protected() {
   : > "$PROTECT_SNAP"
   : > "$PROTECT_LIST_FILE"
+  : > "$PROTECT_MODES"
   rm -rf "$PROTECT_BACKUP"
   mkdir -p "$PROTECT_BACKUP"
   protect_files | sort -u | while IFS= read -r f; do
     [ -n "$f" ] || continue
     printf '%s\n' "$f" >> "$PROTECT_LIST_FILE"
     sha_of "$f" >> "$PROTECT_SNAP"
+    mode_of "$f" >> "$PROTECT_MODES"
     _dir="$(dirname "$f")"
     [ "$_dir" = "." ] || mkdir -p "$PROTECT_BACKUP/$_dir"
     cp -p "$f" "$PROTECT_BACKUP/$f" 2>/dev/null
+    # Best-effort friction (issue #34 round-2, step 5): NOT the guarantee — a same-UID fixer can
+    # chmod its own file back to writable given enough determination. The actual guarantee against
+    # backup-poisoning is the post-restore integrity check in restore_protected() below, plus the
+    # fail-closed marker it leaves for a future run to see. Note this chmod means `cp -p` back OUT
+    # of the backup during restore would otherwise propagate 0444 onto the live file too — restore
+    # explicitly re-chmods to the mode captured in $PROTECT_MODES above to undo that side effect.
+    chmod 0444 "$PROTECT_BACKUP/$f" 2>/dev/null
   done
 }
 
@@ -191,6 +273,15 @@ check_protected() {
 # a modified file (overwrite from backup) and a deleted file (recreate from backup). Always logs
 # what happened; a per-file restore failure is logged loudly rather than swallowed, but never
 # suppresses the PROTECTED-VIOLATION abort itself (caller still exits 3 regardless).
+#
+# Round-2 addition (issue #34 adversarial finding 1 — backup poisoning): after copying bytes back,
+# recomputes each restored file's sha256 and compares it against the ORIGINAL hash recorded in
+# $PROTECT_SNAP at run start (before iteration 1, so it predates any fixer action including
+# poisoning the backup). A mismatch proves $PROTECT_BACKUP was ALSO tampered with — cp'ing from a
+# poisoned backup "succeeds" as a copy but does not actually restore anything trustworthy. In that
+# case this does NOT log the normal success line; it logs a distinct, loud failure and appends to
+# $COMPROMISED_MARKER (consumed by the fail-closed startup check near the top of this script) so a
+# later run refuses to proceed rather than trusting a possibly-still-sabotaged workspace.
 restore_protected() {
   if [ ! -s "$PROTECT_LIST_FILE" ]; then
     log "  restore: no protected-file list captured — nothing to restore from."
@@ -198,8 +289,10 @@ restore_protected() {
   fi
   _restored=0
   _restore_failed=0
-  while IFS= read -r f; do
+  _integrity_failed=0
+  while IFS= read -r f <&3 && IFS= read -r _origline <&4 && IFS= read -r _origmode <&5; do
     [ -n "$f" ] || continue
+    _orig_hash="${_origline%% *}"
     _b="$PROTECT_BACKUP/$f"
     if [ ! -f "$_b" ]; then
       log "  RESTORE FAILED for $f: no backup copy at $_b — manual intervention needed."
@@ -209,14 +302,48 @@ restore_protected() {
     _dir="$(dirname "$f")"
     [ "$_dir" = "." ] || [ -d "$_dir" ] || mkdir -p "$_dir" 2>/dev/null
     if cp -p "$_b" "$f" 2>/dev/null; then
+      # cp -p just carried the backup's mode (0444, from snapshot_protected()'s step-5 chmod) onto
+      # $f — restore it to the mode the live file actually had at snapshot time instead.
+      [ -n "$_origmode" ] && chmod "$_origmode" "$f" 2>/dev/null
       _restored=$(( _restored + 1 ))
+      _now_hash="$(sha_of "$f" 2>/dev/null | awk '{print $1}')"
+      if [ "$_now_hash" != "$_orig_hash" ]; then
+        _integrity_failed=1
+        log "  INTEGRITY CHECK FAILED for $f: restored bytes do NOT match the original pre-run hash — the backup itself was tampered with, this file may still be compromised."
+        printf 'file=%s restored-hash=%s expected-original-hash=%s backup=%s reason=backup did not contain trustworthy pre-run bytes (likely poisoned by the same fixer that modified the live file)\n' \
+          "$f" "$_now_hash" "$_orig_hash" "$_b" >> "$COMPROMISED_MARKER"
+      fi
     else
       log "  RESTORE FAILED for $f: cp from backup did not succeed — manual intervention needed."
       _restore_failed=1
     fi
-  done < "$PROTECT_LIST_FILE"
-  log "  restored $_restored protected file(s) to their pre-run state."
-  [ "$_restore_failed" -eq 0 ]
+  done 3< "$PROTECT_LIST_FILE" 4< "$PROTECT_SNAP" 5< "$PROTECT_MODES"
+  if [ "$_integrity_failed" -eq 1 ]; then
+    log "  RESTORE COULD NOT BE VERIFIED — the backup store itself appears to have been tampered with. Do NOT trust this workspace; a human must inspect it. Marker written: $COMPROMISED_MARKER (future runs will refuse to start until it is cleared)."
+  else
+    log "  restored $_restored protected file(s) to their pre-run state."
+  fi
+  [ "$_restore_failed" -eq 0 ] && [ "$_integrity_failed" -eq 0 ]
+}
+
+# Deletes any file that currently matches a --protect glob but did NOT exist at snapshot time
+# (issue #34 adversarial finding 3): check_protected() only compares hashes for files it already
+# knew about, so a fixer that creates a brand-new file matching a broad glob (e.g. dropping a
+# second, trivially-passing test file next to the real protected one) still trips the violation,
+# but restore_protected() alone never removes it — it only walks $PROTECT_LIST_FILE (snapshot-time
+# names). Scope is deliberately narrow: only files protect_files() matches RIGHT NOW are
+# candidates; anything the fixer created that does not match a --protect pattern is left untouched.
+cleanup_rogue_protected() {
+  [ -s "$PROTECT_LIST_FILE" ] || return 0
+  protect_files | sort -u | while IFS= read -r f; do
+    [ -n "$f" ] || continue
+    grep -qFx "$f" "$PROTECT_LIST_FILE" && continue   # existed at snapshot time — restore_protected()'s job
+    if rm -f "$f" 2>/dev/null; then
+      log "  removed rogue new file matching --protect (not present at run start): $f"
+    else
+      log "  RM FAILED for rogue new protect-matching file $f — manual cleanup needed."
+    fi
+  done
 }
 
 # ── BAC-626 ①: 전체 LOG의 러너 요약줄 합산 카운트 ──────────────────────────────────────────
@@ -584,6 +711,7 @@ while [ "$iter" -lt "$MAX_ITER" ]; do
     log "Changed vs snapshot:"
     diff "$PROTECT_SNAP" "$LOOP_DIR/protected.now" 2>/dev/null | sed 's/^/    /' | tee -a "$HISTORY"
     restore_protected
+    cleanup_rogue_protected
     log "=== loop-fix done: PROTECTED-VIOLATION ==="
     exit 3
   fi

--- a/tools/loop-engine/bin/loop-fix.sh
+++ b/tools/loop-engine/bin/loop-fix.sh
@@ -87,12 +87,19 @@
 # backup store lives on the same filesystem the fixer can write to, so a sufficiently motivated
 # fixer CAN poison the backup copy in the same move it poisons the live file — (c) exists to catch
 # exactly that. It is not a tamper-proof store; it is a check that notices when the store was
-# tampered with. When the restored bytes do NOT match the original hash, loop-fix.sh does NOT claim
-# success: it logs a loud, distinct failure, writes $LOOP_DIR/protect-compromised (which file(s),
-# why), and still exits 3. A SUBSEQUENT run then refuses to start at all (exit 4) until a human
-# inspects and clears that marker — so the actual guarantee is "detect, attempt an exact restore,
-# and if restoration integrity cannot itself be verified, refuse future runs until a human clears
-# it," not "always perfectly undoes any sabotage no matter how the fixer attacks the backup."
+# tampered with. Whenever a protected file's restore cannot be independently verified — the
+# restored bytes do NOT match the original hash, the backup copy is missing entirely (e.g. the
+# fixer `rm`s it instead of overwriting it with matching content), or the `cp` from backup itself
+# fails — loop-fix.sh does NOT claim success: it logs a loud, distinct failure, writes
+# $LOOP_DIR/protect-compromised (which file(s), why), and still exits 3. A SUBSEQUENT run then
+# refuses to start at all (exit 4) until a human inspects and clears that marker — so the actual
+# guarantee is "detect, attempt an exact restore, and if restoration integrity cannot itself be
+# verified, refuse future runs until a human clears it," not "always perfectly undoes any sabotage
+# no matter how the fixer attacks the backup." Known narrow gap: restore uses `cp -p`, which
+# follows a symlink rather than replacing it — if the fixer replaces a protected file with a
+# symlink to an external path, the restored bytes land at the symlink's target and the file is
+# left as a symlink (content is correct, file type/identity is not) — this does not defeat
+# detection or let a rerun report false success, it is a restoration-fidelity gap, not a bypass.
 # Stall caveat: stall detection is reliable when the verifier emits recognizable failure markers
 # or changing pass/fail counts; the hard guarantee against runaway is --max-iter.
 #
@@ -297,6 +304,14 @@ restore_protected() {
     if [ ! -f "$_b" ]; then
       log "  RESTORE FAILED for $f: no backup copy at $_b — manual intervention needed."
       _restore_failed=1
+      # A missing backup is just as untrustworthy a post-state as a hash-mismatched one — the
+      # live file is left in whatever (possibly cheated) state the fixer put it in, with no way
+      # to verify it. Without this, a fixer that simply `rm`s its own backup (instead of
+      # overwriting it with matching content) skips the hash-mismatch branch entirely and no
+      # marker gets written, leaving a rerun free to take the cheated content as a fresh, trusted
+      # baseline — reopening the exact false-SUCCESS-on-rerun bug this guard exists to close.
+      printf 'file=%s reason=no backup copy found at %s — cannot verify or restore original pre-run bytes (the fixer may have deleted its own backup)\n' \
+        "$f" "$_b" >> "$COMPROMISED_MARKER"
       continue
     fi
     _dir="$(dirname "$f")"
@@ -316,10 +331,14 @@ restore_protected() {
     else
       log "  RESTORE FAILED for $f: cp from backup did not succeed — manual intervention needed."
       _restore_failed=1
+      # Same reasoning as the missing-backup branch above: an unverifiable live file must block
+      # future runs, not just log a warning this invocation will forget.
+      printf 'file=%s reason=cp from backup %s did not succeed — cannot verify or restore original pre-run bytes\n' \
+        "$f" "$_b" >> "$COMPROMISED_MARKER"
     fi
   done 3< "$PROTECT_LIST_FILE" 4< "$PROTECT_SNAP" 5< "$PROTECT_MODES"
-  if [ "$_integrity_failed" -eq 1 ]; then
-    log "  RESTORE COULD NOT BE VERIFIED — the backup store itself appears to have been tampered with. Do NOT trust this workspace; a human must inspect it. Marker written: $COMPROMISED_MARKER (future runs will refuse to start until it is cleared)."
+  if [ "$_integrity_failed" -eq 1 ] || [ "$_restore_failed" -eq 1 ]; then
+    log "  RESTORE COULD NOT BE VERIFIED — the workspace may still be compromised. Do NOT trust it; a human must inspect it. Marker written: $COMPROMISED_MARKER (future runs will refuse to start until it is cleared)."
   else
     log "  restored $_restored protected file(s) to their pre-run state."
   fi

--- a/tools/loop-engine/bin/loop-fix.sh
+++ b/tools/loop-engine/bin/loop-fix.sh
@@ -9,7 +9,8 @@
 #   - The VERIFIER is the ceiling. The verdict comes from verify-cmd's exit code, period.
 #   - GENERATOR != EVALUATOR. The fixer never decides success; only the verifier does.
 #   - HARD STOPPING CRITERIA. --max-iter (always), optional --budget-sec, stall detection.
-#   - NO REWARD HACKING. --protect snapshots verifier/test files; if a fix mutates them, abort.
+#   - NO REWARD HACKING. --protect snapshots verifier/test files; if a fix mutates them, restore
+#     them to their pre-run bytes and abort.
 #   - FILE-BASED HANDOFF. Each iteration writes the verdict, log, and a fix prompt to .loop/.
 #
 # Usage:
@@ -71,7 +72,10 @@
 # Guard scope (read this — the guarantee is narrow): --protect aborts (exit 3) when a file that
 # existed at start AND was matched by --protect is edited or deleted. It does NOT cover files not
 # listed, files absent at start, or other inputs the verifier reads (fixtures, snapshots, config
-# like vitest.config/conftest.py). It detects the mutation AFTER the fact and does not revert it.
+# like vitest.config/conftest.py). It detects the mutation AFTER the fact and, before aborting,
+# restores every protected file to the exact bytes it held when THIS run's snapshot was taken
+# (byte-for-byte from a backup copy — NOT `git checkout`, which would be wrong if a protected file
+# already had a legitimate uncommitted edit before this run even started).
 # Stall caveat: stall detection is reliable when the verifier emits recognizable failure markers
 # or changing pass/fail counts; the hard guarantee against runaway is --max-iter.
 #
@@ -120,6 +124,8 @@ VERDICT_FILE="$LOOP_DIR/last-verdict.txt"
 LOG_FILE="$LOOP_DIR/last-run.log"
 PROMPT_FILE="$LOOP_DIR/fix-prompt.txt"
 PROTECT_SNAP="$LOOP_DIR/protected.sha"
+PROTECT_LIST_FILE="$LOOP_DIR/protected.files"   # relative paths captured at snapshot time (issue #34)
+PROTECT_BACKUP="$LOOP_DIR/protected-backup"     # byte-for-byte copies, mirroring relative paths
 LESSONS_BIN="$HERE/lessons.sh"
 FIRST_VERDICT="$LOOP_DIR/first-verdict.txt"
 rm -f "$FIRST_VERDICT" 2>/dev/null   # reset per run: never inherit a prior run's first failure (sharing --loop-dir)
@@ -147,10 +153,22 @@ protect_files() {
   done
 }
 
+# Snapshots both the sha256 (detection, unchanged) AND a byte-for-byte backup copy of each
+# protected file's current content under $PROTECT_BACKUP (issue #34: without the backup, a
+# detected violation had nothing to restore FROM). Runs once per loop-fix.sh run, before the
+# iteration loop — it must reflect state at run start, not be re-taken every iteration.
 snapshot_protected() {
   : > "$PROTECT_SNAP"
+  : > "$PROTECT_LIST_FILE"
+  rm -rf "$PROTECT_BACKUP"
+  mkdir -p "$PROTECT_BACKUP"
   protect_files | sort -u | while IFS= read -r f; do
-    [ -n "$f" ] && sha_of "$f" >> "$PROTECT_SNAP"
+    [ -n "$f" ] || continue
+    printf '%s\n' "$f" >> "$PROTECT_LIST_FILE"
+    sha_of "$f" >> "$PROTECT_SNAP"
+    _dir="$(dirname "$f")"
+    [ "$_dir" = "." ] || mkdir -p "$PROTECT_BACKUP/$_dir"
+    cp -p "$f" "$PROTECT_BACKUP/$f" 2>/dev/null
   done
 }
 
@@ -163,6 +181,42 @@ check_protected() {
     [ -n "$f" ] && sha_of "$f" >> "$_tmp"
   done
   diff -q "$PROTECT_SNAP" "$_tmp" >/dev/null 2>&1
+}
+
+# Restores every protected file to the bytes captured by snapshot_protected() at run start —
+# called right before the PROTECTED-VIOLATION abort so "detect" becomes "detect and undo" (issue
+# #34). Deliberately restores from $PROTECT_BACKUP, NOT `git checkout`: a protected file may
+# already have had a legitimate uncommitted edit before this loop-fix run even started, and the
+# guarantee is "back to exactly what this run started with," not "back to git HEAD". Handles both
+# a modified file (overwrite from backup) and a deleted file (recreate from backup). Always logs
+# what happened; a per-file restore failure is logged loudly rather than swallowed, but never
+# suppresses the PROTECTED-VIOLATION abort itself (caller still exits 3 regardless).
+restore_protected() {
+  if [ ! -s "$PROTECT_LIST_FILE" ]; then
+    log "  restore: no protected-file list captured — nothing to restore from."
+    return 1
+  fi
+  _restored=0
+  _restore_failed=0
+  while IFS= read -r f; do
+    [ -n "$f" ] || continue
+    _b="$PROTECT_BACKUP/$f"
+    if [ ! -f "$_b" ]; then
+      log "  RESTORE FAILED for $f: no backup copy at $_b — manual intervention needed."
+      _restore_failed=1
+      continue
+    fi
+    _dir="$(dirname "$f")"
+    [ "$_dir" = "." ] || [ -d "$_dir" ] || mkdir -p "$_dir" 2>/dev/null
+    if cp -p "$_b" "$f" 2>/dev/null; then
+      _restored=$(( _restored + 1 ))
+    else
+      log "  RESTORE FAILED for $f: cp from backup did not succeed — manual intervention needed."
+      _restore_failed=1
+    fi
+  done < "$PROTECT_LIST_FILE"
+  log "  restored $_restored protected file(s) to their pre-run state."
+  [ "$_restore_failed" -eq 0 ]
 }
 
 # ── BAC-626 ①: 전체 LOG의 러너 요약줄 합산 카운트 ──────────────────────────────────────────
@@ -529,6 +583,7 @@ while [ "$iter" -lt "$MAX_ITER" ]; do
     log "iter $iter: PROTECTED FILE MODIFIED by the fixer. This is reward hacking — aborting."
     log "Changed vs snapshot:"
     diff "$PROTECT_SNAP" "$LOOP_DIR/protected.now" 2>/dev/null | sed 's/^/    /' | tee -a "$HISTORY"
+    restore_protected
     log "=== loop-fix done: PROTECTED-VIOLATION ==="
     exit 3
   fi

--- a/tools/loop-engine/bin/loop-fix.sh
+++ b/tools/loop-engine/bin/loop-fix.sh
@@ -84,10 +84,21 @@
 # --protect glob but did not exist at snapshot time, so a fixer cannot dodge the guard by dropping a
 # fresh trivially-passing file next to the real protected one; and (c) recomputes each restored
 # file's hash and compares it against the ORIGINAL hash recorded before iteration 1 ever ran. The
-# backup store lives on the same filesystem the fixer can write to, so a sufficiently motivated
-# fixer CAN poison the backup copy in the same move it poisons the live file — (c) exists to catch
-# exactly that. It is not a tamper-proof store; it is a check that notices when the store was
-# tampered with. Whenever a protected file's restore cannot be independently verified — the
+# per-file sha256 used for BOTH (c) and the live detection in check_protected() is held ONLY in
+# loop-fix.sh's own bash process memory (never written to a file) — a --fix subprocess runs as a
+# separate CHILD process and structurally cannot write into its parent's shell variables, only into
+# files/IPC the parent later reads (issue #34 round-3). Earlier revisions kept this hash in a plain
+# file under $LOOP_DIR instead, which the fixer subprocess could reach the same as any other file it
+# writes: overwriting it with the hash of its own sabotaged content made detection agree with itself
+# ("unchanged"), and simply deleting it was treated as "nothing to protect" — both were a SINGLE-run,
+# silent, complete bypass with no PROTECTED-VIOLATION log line at all. That specific file is gone
+# now; there is nothing on disk left for a fixer to rewrite to fake a match. The byte-CONTENT backup
+# under $PROTECT_BACKUP is different and DOES still live on disk (file content — as opposed to its
+# hash — is not something that belongs crammed into a shell variable), so it remains reachable by
+# the fixer the same as before: a sufficiently motivated fixer CAN poison the backup copy in the
+# same move it poisons the live file — (c) exists to catch exactly that. It is not a tamper-proof
+# store; it is a check that notices when the store was tampered with. Whenever a protected file's
+# restore cannot be independently verified — the
 # restored bytes do NOT match the original hash, the backup copy is missing entirely (e.g. the
 # fixer `rm`s it instead of overwriting it with matching content), or the `cp` from backup itself
 # fails — loop-fix.sh does NOT claim success: it logs a loud, distinct failure, writes
@@ -172,11 +183,34 @@ HISTORY="$LOOP_DIR/history.log"
 VERDICT_FILE="$LOOP_DIR/last-verdict.txt"
 LOG_FILE="$LOOP_DIR/last-run.log"
 PROMPT_FILE="$LOOP_DIR/fix-prompt.txt"
-PROTECT_SNAP="$LOOP_DIR/protected.sha"
-PROTECT_LIST_FILE="$LOOP_DIR/protected.files"   # relative paths captured at snapshot time (issue #34)
-PROTECT_BACKUP="$LOOP_DIR/protected-backup"     # byte-for-byte copies, mirroring relative paths
-PROTECT_MODES="$LOOP_DIR/protected.modes"       # original perm bits, same order as PROTECT_LIST_FILE
-                                                 # (undoes the backup's read-only chmod on restore, step 5)
+PROTECT_BACKUP="$LOOP_DIR/protected-backup"     # byte-for-byte copies, mirroring relative paths — the
+                                                 # ONLY protect bookkeeping that still lives on disk
+                                                 # (issue #34 round-3: large/binary content does not
+                                                 # belong crammed into a bash variable; content backups
+                                                 # were already documented as "not tamper-proof,
+                                                 # integrity-checked instead" — see restore_protected()).
+# PROTECT_FILES_DATA / PROTECT_SNAP_DATA / PROTECT_MODES_DATA (round-3 fix, issue #34 finding — a
+# SINGLE-run false SUCCESS): the hash/list/mode ground truth used to live in plain files under
+# $LOOP_DIR (protected.sha / protected.files / protected.modes) — a path the --fix subprocess has
+# the same filesystem write access to as loop-fix.sh itself. A fixer could overwrite protected.sha
+# with the hash of its OWN sabotaged content (check_protected()'s diff then agrees with itself and
+# reports "unchanged"), or simply `rm -f` it (an empty/missing snapshot was treated as "nothing to
+# protect"). No amount of chmod/backup/re-checking-against-another-file closes this while the
+# ground truth itself lives in a file the fixer can also reach — that is an infinite regress
+# (protect the snapshot -> now protect the backup-of-the-snapshot -> …). The actual fix: loop-fix.sh
+# runs as ONE continuous bash process for the whole loop; --fix runs as a SEPARATE CHILD subprocess
+# via `sh -c`, and a child process cannot write into its parent's in-memory shell variables — only
+# into files/IPC the parent later reads. So the ground truth now lives ONLY in these three bash
+# variables, held in loop-fix.sh's own process memory, which the fixer subprocess structurally
+# cannot touch no matter what it does to the filesystem (same idiom already used for PROTECT_LIST
+# itself — a newline-accumulated string built once from CLI args, never re-read from disk). All
+# three are newline-separated strings, one entry per line, walked in lockstep (same order, one line
+# per protected file) — set once by snapshot_protected() before the iteration loop and read-only
+# after that.
+PROTECT_FILES_DATA=""   # relative paths captured at snapshot time
+PROTECT_SNAP_DATA=""    # `sha_of` output per file, same order as PROTECT_FILES_DATA
+PROTECT_MODES_DATA=""   # original perm bits per file, same order (undoes the backup's read-only
+                         # chmod on restore, step 5)
 LESSONS_BIN="$HERE/lessons.sh"
 FIRST_VERDICT="$LOOP_DIR/first-verdict.txt"
 rm -f "$FIRST_VERDICT" 2>/dev/null   # reset per run: never inherit a prior run's first failure (sharing --loop-dir)
@@ -233,21 +267,31 @@ protect_files() {
   done
 }
 
-# Snapshots both the sha256 (detection, unchanged) AND a byte-for-byte backup copy of each
-# protected file's current content under $PROTECT_BACKUP (issue #34: without the backup, a
-# detected violation had nothing to restore FROM). Runs once per loop-fix.sh run, before the
-# iteration loop — it must reflect state at run start, not be re-taken every iteration.
+# Snapshots both the sha256 (detection, held in-memory — round-3 fix, see PROTECT_SNAP_DATA above)
+# AND a byte-for-byte backup copy of each protected file's current content under $PROTECT_BACKUP
+# (issue #34: without the backup, a detected violation had nothing to restore FROM). Runs once per
+# loop-fix.sh run, before the iteration loop — it must reflect state at run start, not be re-taken
+# every iteration.
+#
+# Builds PROTECT_FILES_DATA/PROTECT_SNAP_DATA/PROTECT_MODES_DATA via a `while` loop fed by PROCESS
+# SUBSTITUTION (`< <(...)`), not a pipe (`... | while`) — a bash pipe runs its last stage in a
+# subshell, so variable assignments inside a piped `while` body are invisible once the pipe exits.
+# Process substitution attaches the producer as an input redirection instead, so the `while` body
+# itself still runs in THIS shell and the accumulated variables survive the loop.
 snapshot_protected() {
-  : > "$PROTECT_SNAP"
-  : > "$PROTECT_LIST_FILE"
-  : > "$PROTECT_MODES"
+  PROTECT_FILES_DATA=""
+  PROTECT_SNAP_DATA=""
+  PROTECT_MODES_DATA=""
   rm -rf "$PROTECT_BACKUP"
   mkdir -p "$PROTECT_BACKUP"
-  protect_files | sort -u | while IFS= read -r f; do
+  while IFS= read -r f; do
     [ -n "$f" ] || continue
-    printf '%s\n' "$f" >> "$PROTECT_LIST_FILE"
-    sha_of "$f" >> "$PROTECT_SNAP"
-    mode_of "$f" >> "$PROTECT_MODES"
+    PROTECT_FILES_DATA="$PROTECT_FILES_DATA$f
+"
+    PROTECT_SNAP_DATA="$PROTECT_SNAP_DATA$(sha_of "$f")
+"
+    PROTECT_MODES_DATA="$PROTECT_MODES_DATA$(mode_of "$f")
+"
     _dir="$(dirname "$f")"
     [ "$_dir" = "." ] || mkdir -p "$PROTECT_BACKUP/$_dir"
     cp -p "$f" "$PROTECT_BACKUP/$f" 2>/dev/null
@@ -256,20 +300,28 @@ snapshot_protected() {
     # backup-poisoning is the post-restore integrity check in restore_protected() below, plus the
     # fail-closed marker it leaves for a future run to see. Note this chmod means `cp -p` back OUT
     # of the backup during restore would otherwise propagate 0444 onto the live file too — restore
-    # explicitly re-chmods to the mode captured in $PROTECT_MODES above to undo that side effect.
+    # explicitly re-chmods to the mode captured in PROTECT_MODES_DATA above to undo that side effect.
     chmod 0444 "$PROTECT_BACKUP/$f" 2>/dev/null
-  done
+  done < <(protect_files | sort -u)
 }
 
-# Returns 0 if unchanged, 1 if any protected file's hash changed (or a file vanished).
+# Returns 0 if unchanged, 1 if any protected file's hash changed (or a file vanished). Recomputes
+# the current state FRESH every call (protect_files() + sha_of() per file) and compares it directly
+# against PROTECT_SNAP_DATA via a plain string comparison — no temp file, no `diff -q` against a
+# file, nothing on disk a fixer could rewrite to fake a match (round-3 fix). Also stashes the fresh
+# scan in PROTECT_NOW_DATA (a global, not a return value) purely so the caller can render a
+# human-readable "changed vs snapshot" diff on a violation — that var is diagnostic output, not
+# ground truth, and nothing re-reads it for the actual pass/fail decision.
 check_protected() {
-  [ -s "$PROTECT_SNAP" ] || return 0
-  _tmp="$LOOP_DIR/protected.now"
-  : > "$_tmp"
-  protect_files | sort -u | while IFS= read -r f; do
-    [ -n "$f" ] && sha_of "$f" >> "$_tmp"
-  done
-  diff -q "$PROTECT_SNAP" "$_tmp" >/dev/null 2>&1
+  [ -n "$PROTECT_SNAP_DATA" ] || return 0
+  _now=""
+  while IFS= read -r f; do
+    [ -n "$f" ] || continue
+    _now="$_now$(sha_of "$f")
+"
+  done < <(protect_files | sort -u)
+  PROTECT_NOW_DATA="$_now"
+  [ "$_now" = "$PROTECT_SNAP_DATA" ]
 }
 
 # Restores every protected file to the bytes captured by snapshot_protected() at run start —
@@ -283,20 +335,25 @@ check_protected() {
 #
 # Round-2 addition (issue #34 adversarial finding 1 — backup poisoning): after copying bytes back,
 # recomputes each restored file's sha256 and compares it against the ORIGINAL hash recorded in
-# $PROTECT_SNAP at run start (before iteration 1, so it predates any fixer action including
+# $PROTECT_SNAP_DATA at run start (before iteration 1, so it predates any fixer action including
 # poisoning the backup). A mismatch proves $PROTECT_BACKUP was ALSO tampered with — cp'ing from a
 # poisoned backup "succeeds" as a copy but does not actually restore anything trustworthy. In that
 # case this does NOT log the normal success line; it logs a distinct, loud failure and appends to
 # $COMPROMISED_MARKER (consumed by the fail-closed startup check near the top of this script) so a
 # later run refuses to proceed rather than trusting a possibly-still-sabotaged workspace.
 restore_protected() {
-  if [ ! -s "$PROTECT_LIST_FILE" ]; then
+  if [ -z "$PROTECT_FILES_DATA" ]; then
     log "  restore: no protected-file list captured — nothing to restore from."
     return 1
   fi
   _restored=0
   _restore_failed=0
   _integrity_failed=0
+  # Three parallel in-memory lists (PROTECT_FILES_DATA / PROTECT_SNAP_DATA / PROTECT_MODES_DATA),
+  # walked together via three process-substitution fds — same shape as the old three-file-descriptor
+  # read (fd 3/4/5 against real files), just sourced from bash variables instead of disk (round-3
+  # fix). Not a pipe, so this `while` body still runs in THIS shell — _restored/_restore_failed/
+  # _integrity_failed set below correctly persist past the loop.
   while IFS= read -r f <&3 && IFS= read -r _origline <&4 && IFS= read -r _origmode <&5; do
     [ -n "$f" ] || continue
     _orig_hash="${_origline%% *}"
@@ -336,7 +393,7 @@ restore_protected() {
       printf 'file=%s reason=cp from backup %s did not succeed — cannot verify or restore original pre-run bytes\n' \
         "$f" "$_b" >> "$COMPROMISED_MARKER"
     fi
-  done 3< "$PROTECT_LIST_FILE" 4< "$PROTECT_SNAP" 5< "$PROTECT_MODES"
+  done 3< <(printf '%s' "$PROTECT_FILES_DATA") 4< <(printf '%s' "$PROTECT_SNAP_DATA") 5< <(printf '%s' "$PROTECT_MODES_DATA")
   if [ "$_integrity_failed" -eq 1 ] || [ "$_restore_failed" -eq 1 ]; then
     log "  RESTORE COULD NOT BE VERIFIED — the workspace may still be compromised. Do NOT trust it; a human must inspect it. Marker written: $COMPROMISED_MARKER (future runs will refuse to start until it is cleared)."
   else
@@ -349,14 +406,15 @@ restore_protected() {
 # (issue #34 adversarial finding 3): check_protected() only compares hashes for files it already
 # knew about, so a fixer that creates a brand-new file matching a broad glob (e.g. dropping a
 # second, trivially-passing test file next to the real protected one) still trips the violation,
-# but restore_protected() alone never removes it — it only walks $PROTECT_LIST_FILE (snapshot-time
-# names). Scope is deliberately narrow: only files protect_files() matches RIGHT NOW are
-# candidates; anything the fixer created that does not match a --protect pattern is left untouched.
+# but restore_protected() alone never removes it — it only walks PROTECT_FILES_DATA (snapshot-time
+# names, held in-memory — round-3 fix). Scope is deliberately narrow: only files protect_files()
+# matches RIGHT NOW are candidates; anything the fixer created that does not match a --protect
+# pattern is left untouched.
 cleanup_rogue_protected() {
-  [ -s "$PROTECT_LIST_FILE" ] || return 0
+  [ -n "$PROTECT_FILES_DATA" ] || return 0
   protect_files | sort -u | while IFS= read -r f; do
     [ -n "$f" ] || continue
-    grep -qFx "$f" "$PROTECT_LIST_FILE" && continue   # existed at snapshot time — restore_protected()'s job
+    printf '%s' "$PROTECT_FILES_DATA" | grep -qFx "$f" && continue   # existed at snapshot time — restore_protected()'s job
     if rm -f "$f" 2>/dev/null; then
       log "  removed rogue new file matching --protect (not present at run start): $f"
     else
@@ -527,12 +585,12 @@ fi
 snapshot_protected
 has_protect=0
 printf '%s\n' "$PROTECT_LIST" | grep -q '[^[:space:]]' && has_protect=1
-if [ "$has_protect" -eq 1 ] && [ ! -s "$PROTECT_SNAP" ]; then
+if [ "$has_protect" -eq 1 ] && [ -z "$PROTECT_SNAP_DATA" ]; then
   echo "loop-fix.sh: --protect matched 0 files — refusing to run with the reward-hacking guard OFF." >&2
   echo "             Check the path/glob (note: only '**' patterns recurse)." >&2
   exit 2
 fi
-[ -s "$PROTECT_SNAP" ] && log "protecting $(wc -l < "$PROTECT_SNAP" | tr -d ' ') file(s) from modification"
+[ -n "$PROTECT_SNAP_DATA" ] && log "protecting $(printf '%s' "$PROTECT_SNAP_DATA" | wc -l | tr -d ' ') file(s) from modification"
 
 # BAC-626 ③: 워치독 기동(opt-in). 원장 경로는 기동 시 1회 해석해 history에 남긴다(강등 가시화).
 if [ "$IDLE_T" -gt 0 ] || [ "$PROG_T" -gt 0 ]; then
@@ -728,7 +786,7 @@ while [ "$iter" -lt "$MAX_ITER" ]; do
   if ! check_protected; then
     log "iter $iter: PROTECTED FILE MODIFIED by the fixer. This is reward hacking — aborting."
     log "Changed vs snapshot:"
-    diff "$PROTECT_SNAP" "$LOOP_DIR/protected.now" 2>/dev/null | sed 's/^/    /' | tee -a "$HISTORY"
+    diff <(printf '%s' "$PROTECT_SNAP_DATA") <(printf '%s' "$PROTECT_NOW_DATA") 2>/dev/null | sed 's/^/    /' | tee -a "$HISTORY"
     restore_protected
     cleanup_rogue_protected
     log "=== loop-fix done: PROTECTED-VIOLATION ==="

--- a/tools/loop-engine/test/loop-fix-protect.test.sh
+++ b/tools/loop-engine/test/loop-fix-protect.test.sh
@@ -6,6 +6,14 @@
 # before this loop-fix run even started). Closes the false-SUCCESS bug: rerunning loop-fix.sh
 # against the same workspace after an abort used to see the still-sabotaged bytes and report a
 # false PASS.
+#
+# Round 2 (adversarial review of the round-1 fix above, cases 4-6): closes two CRITICAL bypasses
+# and one IMPORTANT gap the round-1 fix left open — a '**' glob false-positiving on the guard's own
+# backup dir (case 4), a fixer poisoning the backup copy itself to defeat restore_protected()
+# entirely while the log still claims success (case 5, the exact false-SUCCESS bug reopened via the
+# guard's own restore path — closed by a post-restore integrity hash check + a fail-closed
+# compromise marker that makes a subsequent run refuse to proceed), and a rogue new file matching
+# the protect glob that restore_protected() alone never cleans up (case 6).
 set -uo pipefail
 HERE="$(cd "$(dirname "$0")" && pwd)"
 LOOPFIX="$HERE/../bin/loop-fix.sh"
@@ -93,5 +101,83 @@ cmp -s seen-by-rerun.txt original-guard-file.txt \
   || fail "case3: rerun saw stale sabotaged bytes instead of the restored original — issue #34 false-SUCCESS bug is NOT closed"
 grep -q "SABOTAGED" seen-by-rerun.txt && fail "case3: rerun's verify saw sabotaged content"
 
-echo "PASS: --protect reverts a tampered/deleted protected file to its exact pre-run bytes before aborting, closing the false-SUCCESS rerun bug"
+# ── case 4: '**' glob + an INERT fixer must NOT false-positive (round-2 adversarial finding 2) ──
+# snapshot_protected() writes byte-backups under .loop/protected-backup/<path>, which itself
+# matches a broad glob like '**/*.test.sh' unless excluded. Before the fix, check_protected()'s
+# rescan picked up the backup as an extra unmatched entry and false-positived a violation on
+# iteration 1 even though the fixer ':' never touches anything — exactly the --protect
+# "**/*.test.*" pattern used in this repo's own docs (lessons.md / retrospect SKILL.md).
+C="$WORK/c4"; mkdir -p "$C/src"; cd "$C" || fail "cd c4"
+cp "$WORK/fake-verify-fail.sh" fake-verify-fail.sh
+printf 'a real pre-existing test\n' > src/real.test.sh
+
+"$LOOPFIX" --verify 'sh fake-verify-fail.sh' --fix ':' --protect '**/*.test.sh' --max-iter 2 >/dev/null 2>&1
+code=$?
+[ "$code" -eq 1 ] || fail "case4: expected exit 1 (MAX-ITER, no violation) with an inert fixer under a '**' glob, got $code"
+grep -q "PROTECTED FILE MODIFIED" .loop/history.log \
+  && fail "case4: false PROTECTED-VIOLATION — the guard's own backup dir was not excluded from the '**' glob scan (finding 2 regression)"
+grep -q "done: MAX-ITER" .loop/history.log || fail "case4: expected a normal MAX-ITER finish, not an aborted run"
+
+# ── case 5: fixer poisons BOTH the live file AND its own backup copy (round-2 finding 1) ───────
+# A sufficiently motivated fixer has the same filesystem access loop-fix.sh does, so it chmods the
+# backup back to writable (defeating the best-effort step-5 friction) before overwriting it with
+# the identical cheat value it wrote to the live file. restore_protected() must detect this via the
+# post-restore integrity hash check (NOT just trust a successful `cp`), refuse to claim success,
+# write the compromise marker, and still exit 3. A SUBSEQUENT invocation must then refuse to run at
+# all (exit 4) rather than silently reporting false SUCCESS against the still-cheated file — this
+# is the exact bug issue #34 was filed to close, reproduced through the guard's own restore path.
+C="$WORK/c5"; mkdir -p "$C"; cd "$C" || fail "cd c5"
+cp "$WORK/fake-verify-fail.sh" fake-verify-fail.sh
+printf 'ORIGINAL-CONTENT-c5\n' > guard-file.txt
+cp guard-file.txt original-guard-file.txt
+cat > fake-fix-double-poison.sh <<'EOF'
+#!/bin/sh
+echo "CHEAT-VALUE" > guard-file.txt
+chmod +w .loop/protected-backup/guard-file.txt 2>/dev/null
+echo "CHEAT-VALUE" > .loop/protected-backup/guard-file.txt
+EOF
+
+"$LOOPFIX" --verify 'sh fake-verify-fail.sh' --fix 'sh fake-fix-double-poison.sh' --protect 'guard-file.txt' --max-iter 3 >/dev/null 2>&1
+code=$?
+[ "$code" -eq 3 ] || fail "case5 run1: expected exit 3 (PROTECTED-VIOLATION) even though the backup was also poisoned, got $code"
+grep -q "INTEGRITY CHECK FAILED" .loop/history.log \
+  || fail "case5 run1: expected a loud integrity-check-failed line — poisoned backup must not be trusted just because cp succeeded"
+grep -q "restored 1 protected file(s) to their pre-run state" .loop/history.log \
+  && fail "case5 run1: must NOT log the normal success wording when the backup itself was tampered with"
+[ -f .loop/protect-compromised ] || fail "case5 run1: expected a compromise marker file to be written"
+grep -q "guard-file.txt" .loop/protect-compromised || fail "case5 run1: compromise marker must name the affected file"
+
+_hist_lines_before_rerun="$(wc -l < .loop/history.log | tr -d ' ')"
+"$LOOPFIX" --verify 'sh fake-verify-fail.sh' --fix ':' --protect 'guard-file.txt' --max-iter 1 >/dev/null 2>&1
+code=$?
+[ "$code" -eq 4 ] || fail "case5 run2 (rerun): expected exit 4 (refuse to start on a prior compromise marker), got $code — false SUCCESS would mean issue #34's round-2 bug is NOT closed"
+_hist_lines_after_rerun="$(wc -l < .loop/history.log | tr -d ' ')"
+[ "$_hist_lines_before_rerun" = "$_hist_lines_after_rerun" ] \
+  || fail "case5 run2: history.log grew during a refused run — it must exit before any real work/logging starts, not just before claiming success"
+
+# ── case 6: fixer creates a ROGUE new file matching the --protect glob (round-2 finding 3) ─────
+# check_protected() correctly flags the violation (the new file is an extra unmatched entry), but
+# restore_protected() alone only walks the snapshot-time file list and never deletes a brand-new
+# file. cleanup_rogue_protected() must remove it, and must NOT touch the real protected file's
+# restore.
+C="$WORK/c6"; mkdir -p "$C/src"; cd "$C" || fail "cd c6"
+cp "$WORK/fake-verify-fail.sh" fake-verify-fail.sh
+printf 'a real pre-existing test\n' > src/real.test.sh
+cp src/real.test.sh src/original-real.test.sh
+cat > fake-fix-rogue.sh <<'EOF'
+#!/bin/sh
+echo "SABOTAGED-c6" > src/real.test.sh
+echo "rogue trivially-passing test" > src/rogue-new.test.sh
+EOF
+
+"$LOOPFIX" --verify 'sh fake-verify-fail.sh' --fix 'sh fake-fix-rogue.sh' --protect '**/*.test.sh' --max-iter 3 >/dev/null 2>&1
+code=$?
+[ "$code" -eq 3 ] || fail "case6: expected exit 3 (PROTECTED-VIOLATION), got $code"
+cmp -s src/real.test.sh src/original-real.test.sh \
+  || fail "case6: the real pre-existing protected file was not restored to its exact pre-run content"
+[ -f src/rogue-new.test.sh ] && fail "case6: the fixer's rogue new protect-glob-matching file was NOT deleted — finding 3 is not closed"
+grep -q "removed rogue new file matching --protect" .loop/history.log \
+  || fail "case6: expected a log line naming the rogue file that was removed"
+
+echo "PASS: --protect reverts a tampered/deleted protected file to its exact pre-run bytes, excludes its own backup dir from '**' scans, detects+refuses on backup poisoning via a fail-closed marker, and deletes rogue new protect-glob-matching files before aborting"
 exit 0

--- a/tools/loop-engine/test/loop-fix-protect.test.sh
+++ b/tools/loop-engine/test/loop-fix-protect.test.sh
@@ -488,5 +488,77 @@ grep -q "PROTECTED FILE MODIFIED" .loop/history.log \
 cmp -s guard-file.txt original-guard-file.txt \
   || fail "case14: protected file bytes from an earlier iteration's pending background job were NOT restored on a STALLED abort"
 
-echo "PASS: --protect reverts a tampered/deleted protected file to its exact pre-run bytes, excludes its own backup dir from '**' scans, detects+refuses on backup poisoning OR backup deletion/unreadability via a fail-closed marker, deletes rogue new protect-glob-matching files before aborting, cannot be defeated by forging or deleting the on-disk hash bookkeeping (round-3: ground truth now lives in-process, not on disk), catches a mutation backgrounded to land after the FAIL-path check but before the next verify (round-4: check_protected() runs on the PASS path too), and now (round-5) raises the bar with a bounded grace-period recheck on both paths while honestly not claiming to catch delays past that window, plus restores/warns-but-preserves-exit-code on STALLED/BUDGET/watchdog/INFRA aborts that used to leave an earlier iteration's pending corruption unflagged"
+# ── case 15: round-6 — VERDICT-RUN-ERROR (exit 2) is a seventh abort point that used to skip ────
+# check_protected_on_abort() entirely (adversarial review found six call sites had it, this one
+# didn't). Fixer synchronously destroys the git worktree in the SAME iteration it backgrounds a
+# delayed protected-file mutation; the next iteration's --guard-mutation hits verdict-run's own
+# fail-closed rejection ("needs a git worktree") before the mutation would otherwise be noticed by
+# anything else. Must still restore + warn, while VERDICT-RUN-ERROR (2) stays 2, not 0 or 3.
+C="$WORK/c15"; mkdir -p "$C"; cd "$C" || fail "cd c15"
+git init -q . || fail "case15: git init failed"
+git config user.email t@t; git config user.name t
+printf 'ORIGINAL-CONTENT-c15\n' > guard-file.txt
+cp guard-file.txt original-guard-file.txt
+git add guard-file.txt && git commit -q -m init
+cat > fake-verify-fail.sh <<'EOF'
+#!/bin/sh
+echo "FAILED forcing fixer"
+exit 1
+EOF
+cat > fake-fix-delay-and-break-git.sh <<'EOF'
+#!/bin/sh
+if [ ! -f armed.marker ]; then
+  touch armed.marker
+  ( sleep 0.4; printf 'CHEAT-STRING-c15\n' > guard-file.txt ) &
+  rm -rf .git
+fi
+EOF
+
+LOOP_PROTECT_GRACE_SEC=0.2 "$LOOPFIX" --verify 'sh fake-verify-fail.sh' --fix 'sh fake-fix-delay-and-break-git.sh' --protect 'guard-file.txt' --guard-mutation --max-iter 3 >/dev/null 2>&1
+code=$?
+[ "$code" -eq 2 ] || fail "case15: expected exit 2 (VERDICT-RUN-ERROR, its own reason — the missing git worktree) got $code"
+grep -q "done: VERDICT-RUN-ERROR" .loop/history.log || fail "case15: expected the run to still report VERDICT-RUN-ERROR, unchanged by the protect hygiene check"
+grep -q "done: PROTECTED-VIOLATION" .loop/history.log \
+  && fail "case15: must NOT reclassify the exit reason — VERDICT-RUN-ERROR stays VERDICT-RUN-ERROR"
+grep -q "PROTECTED FILE MODIFIED" .loop/history.log \
+  || fail "case15: expected a protect-violation warning logged even though VERDICT-RUN-ERROR (not a protect check) is what actually aborted the run"
+cmp -s guard-file.txt original-guard-file.txt \
+  || fail "case15: protected file bytes were NOT restored on a VERDICT-RUN-ERROR abort"
+
+# ── case 16: round-6 — the watchdog's descendant-killer must not defeat the grace-period recheck ──
+# start_watchdog() sends SIGTERM/SIGKILL to every child process of loop-fix.sh when idle/progress
+# times out — including the grace sleep itself if the configured watchdog timeout is shorter than
+# PROTECT_GRACE_SEC (a real, demonstrated interaction, not hypothetical). Fixer backgrounds a single
+# delayed mutation; a 1s idle-timeout fires the watchdog mid-run. check_protected_with_grace() must
+# survive its sleep being killed and still complete the recheck (via the signal-exit-code retry),
+# not silently truncate the grace period and let the mutation slip through.
+C="$WORK/c16"; mkdir -p "$C"; cd "$C" || fail "cd c16"
+printf 'ORIGINAL-CONTENT-c16\n' > guard-file.txt
+cp guard-file.txt original-guard-file.txt
+cat > fake-verify-fail.sh <<'EOF'
+#!/bin/sh
+echo "FAILED forcing fixer"
+exit 1
+EOF
+cat > fake-fix-delay.sh <<'EOF'
+#!/bin/sh
+if [ ! -f armed.marker ]; then
+  touch armed.marker
+  ( sleep 2; printf 'CHEAT-STRING-c16\n' > guard-file.txt ) &
+fi
+EOF
+
+"$LOOPFIX" --verify 'sh fake-verify-fail.sh' --fix 'sh fake-fix-delay.sh' --protect 'guard-file.txt' --idle-timeout-sec 1 --max-iter 5 >/dev/null 2>&1
+code=$?
+[ "$code" -eq 3 ] || fail "case16: expected exit 3 (PROTECTED-VIOLATION) — a watchdog timeout shorter than the grace period must not let the mutation escape detection, got $code"
+grep -q "PROTECTED FILE MODIFIED" .loop/history.log || fail "case16: expected the PROTECTED FILE MODIFIED marker"
+cmp -s guard-file.txt original-guard-file.txt \
+  || fail "case16: protected file bytes were NOT restored — the watchdog killing the grace-period sleep defeated the recheck"
+# Settle past the corruption's original 2s delay and confirm restore held — proves this isn't a
+# timing accident where the corruption just hadn't landed yet when we happened to check.
+sleep 2
+cmp -s guard-file.txt original-guard-file.txt \
+  || fail "case16: file drifted from the restored content after settling — a residual write landed post-restore"
+
+echo "PASS: --protect reverts a tampered/deleted protected file to its exact pre-run bytes, excludes its own backup dir from '**' scans, detects+refuses on backup poisoning OR backup deletion/unreadability via a fail-closed marker, deletes rogue new protect-glob-matching files before aborting, cannot be defeated by forging or deleting the on-disk hash bookkeeping (round-3: ground truth now lives in-process, not on disk), catches a mutation backgrounded to land after the FAIL-path check but before the next verify (round-4: check_protected() runs on the PASS path too), raises the bar with a bounded grace-period recheck on both paths while honestly not claiming to catch delays past that window (round-5), and now (round-6) also covers the VERDICT-RUN-ERROR abort point and survives the watchdog's own descendant-killer trying to defeat the grace-period sleep, plus restores/warns-but-preserves-exit-code on STALLED/BUDGET/watchdog/INFRA/VERDICT-RUN-ERROR aborts that used to leave an earlier iteration's pending corruption unflagged"
 exit 0

--- a/tools/loop-engine/test/loop-fix-protect.test.sh
+++ b/tools/loop-engine/test/loop-fix-protect.test.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Regression test (issue #34): --protect detects a fixer that tampers with a protected file (this
+# part already worked) AND now reverts it before aborting — turning "detect and stop" into "detect
+# and undo". Restoration is byte-for-byte from a backup snapshotted at run start, NOT `git
+# checkout` (which would be wrong if a protected file already had a legitimate uncommitted edit
+# before this loop-fix run even started). Closes the false-SUCCESS bug: rerunning loop-fix.sh
+# against the same workspace after an abort used to see the still-sabotaged bytes and report a
+# false PASS.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+LOOPFIX="$HERE/../bin/loop-fix.sh"
+
+fail() { echo "FAIL: $1"; exit 1; }
+[ -x "$LOOPFIX" ] || fail "loop-fix.sh not executable at $LOOPFIX"
+
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/tmp.XXXXXXXX")" || fail "mktemp -d failed"
+trap 'rm -rf "$WORK"' EXIT
+
+# A verify that always fails, so the fixer is invoked on iteration 1 every time.
+cat > "$WORK/fake-verify-fail.sh" <<'EOF'
+#!/bin/sh
+echo "FAILED src/example.test.ts > forcing fixer invocation"
+exit 1
+EOF
+
+# ── case 1: baseline detect (a) + exact byte-restore after a MODIFY (b) ────────────────────────
+C="$WORK/c1"; mkdir -p "$C"; cd "$C" || fail "cd c1"
+cp "$WORK/fake-verify-fail.sh" fake-verify-fail.sh
+printf 'ORIGINAL-CONTENT-v1\nline two\n' > guard-file.txt
+cp guard-file.txt original-guard-file.txt   # reference copy, outside the --protect glob
+cat > fake-fix-modify.sh <<'EOF'
+#!/bin/sh
+echo "SABOTAGED-BY-FIXER" > guard-file.txt
+EOF
+
+"$LOOPFIX" --verify 'sh fake-verify-fail.sh' --fix 'sh fake-fix-modify.sh' --protect 'guard-file.txt' --max-iter 3 >/dev/null 2>&1
+code=$?
+[ "$code" -eq 3 ] || fail "case1: expected exit 3 (PROTECTED-VIOLATION) on a modified protected file, got $code"
+grep -q "PROTECTED FILE MODIFIED" .loop/history.log || fail "case1: expected the PROTECTED FILE MODIFIED marker in history"
+grep -q "done: PROTECTED-VIOLATION" .loop/history.log || fail "case1: expected the PROTECTED-VIOLATION done marker"
+grep -q "restored 1 protected file(s) to their pre-run state" .loop/history.log \
+  || fail "case1: expected a log line confirming the restore (abort must not be silent about recovery)"
+cmp -s guard-file.txt original-guard-file.txt \
+  || fail "case1: protected file bytes were NOT restored to the exact pre-run content"
+
+# ── case 2: fixer DELETES the protected file → detected, recreated with original content (c) ──
+C="$WORK/c2"; mkdir -p "$C"; cd "$C" || fail "cd c2"
+cp "$WORK/fake-verify-fail.sh" fake-verify-fail.sh
+printf 'ORIGINAL-CONTENT-v2\nkeepme\n' > guard-file.txt
+cp guard-file.txt original-guard-file.txt
+cat > fake-fix-delete.sh <<'EOF'
+#!/bin/sh
+rm -f guard-file.txt
+EOF
+
+"$LOOPFIX" --verify 'sh fake-verify-fail.sh' --fix 'sh fake-fix-delete.sh' --protect 'guard-file.txt' --max-iter 3 >/dev/null 2>&1
+code=$?
+[ "$code" -eq 3 ] || fail "case2: expected exit 3 (PROTECTED-VIOLATION) on a deleted protected file, got $code"
+grep -q "PROTECTED FILE MODIFIED" .loop/history.log || fail "case2: a vanished protected file must still be treated as changed"
+grep -q "restored 1 protected file(s) to their pre-run state" .loop/history.log \
+  || fail "case2: expected a log line confirming the restore"
+[ -f guard-file.txt ] || fail "case2: deleted protected file was not recreated from backup"
+cmp -s guard-file.txt original-guard-file.txt \
+  || fail "case2: recreated protected file does not match the exact pre-run content"
+
+# ── case 3: rerun after an abort does NOT see the old sabotage (d) — the false-SUCCESS bug ─────
+C="$WORK/c3"; mkdir -p "$C"; cd "$C" || fail "cd c3"
+cp "$WORK/fake-verify-fail.sh" fake-verify-fail.sh
+printf 'ORIGINAL-CONTENT-v3\nline two\nline three\n' > guard-file.txt
+cp guard-file.txt original-guard-file.txt
+cat > fake-fix-modify.sh <<'EOF'
+#!/bin/sh
+echo "SABOTAGED-BY-FIXER-c3" > guard-file.txt
+EOF
+"$LOOPFIX" --verify 'sh fake-verify-fail.sh' --fix 'sh fake-fix-modify.sh' --protect 'guard-file.txt' --max-iter 3 >/dev/null 2>&1
+code=$?
+[ "$code" -eq 3 ] || fail "case3 setup: expected exit 3 from the first (sabotaging) run, got $code"
+cmp -s guard-file.txt original-guard-file.txt || fail "case3 setup: first run must restore the file before the rerun"
+
+# Rerun loop-fix.sh with the SAME --protect argument against the now-restored (still-uncommitted)
+# workspace. A spy verify copies whatever loop-fix.sh finds on disk into seen-by-rerun.txt on its
+# very first call — before any new fix attempt — so we can assert the rerun's ground truth was
+# never the stale sabotage.
+cat > fake-verify-spy.sh <<'EOF'
+#!/bin/sh
+cp guard-file.txt seen-by-rerun.txt 2>/dev/null
+echo "FAILED spy verify — always fails so the captured snapshot can be inspected"
+exit 1
+EOF
+"$LOOPFIX" --verify 'sh fake-verify-spy.sh' --fix ':' --protect 'guard-file.txt' --max-iter 1 >/dev/null 2>&1
+[ -f seen-by-rerun.txt ] || fail "case3: rerun's verify never ran (spy file missing)"
+cmp -s seen-by-rerun.txt original-guard-file.txt \
+  || fail "case3: rerun saw stale sabotaged bytes instead of the restored original — issue #34 false-SUCCESS bug is NOT closed"
+grep -q "SABOTAGED" seen-by-rerun.txt && fail "case3: rerun's verify saw sabotaged content"
+
+echo "PASS: --protect reverts a tampered/deleted protected file to its exact pre-run bytes before aborting, closing the false-SUCCESS rerun bug"
+exit 0

--- a/tools/loop-engine/test/loop-fix-protect.test.sh
+++ b/tools/loop-engine/test/loop-fix-protect.test.sh
@@ -115,7 +115,7 @@ cp guard-file.txt seen-by-rerun.txt 2>/dev/null
 echo "FAILED spy verify — always fails so the captured snapshot can be inspected"
 exit 1
 EOF
-"$LOOPFIX" --verify 'sh fake-verify-spy.sh' --fix ':' --protect 'guard-file.txt' --max-iter 1 >/dev/null 2>&1
+LOOP_PROTECT_GRACE_SEC=0.2 "$LOOPFIX" --verify 'sh fake-verify-spy.sh' --fix ':' --protect 'guard-file.txt' --max-iter 1 >/dev/null 2>&1
 [ -f seen-by-rerun.txt ] || fail "case3: rerun's verify never ran (spy file missing)"
 cmp -s seen-by-rerun.txt original-guard-file.txt \
   || fail "case3: rerun saw stale sabotaged bytes instead of the restored original — issue #34 false-SUCCESS bug is NOT closed"
@@ -131,7 +131,7 @@ C="$WORK/c4"; mkdir -p "$C/src"; cd "$C" || fail "cd c4"
 cp "$WORK/fake-verify-fail.sh" fake-verify-fail.sh
 printf 'a real pre-existing test\n' > src/real.test.sh
 
-"$LOOPFIX" --verify 'sh fake-verify-fail.sh' --fix ':' --protect '**/*.test.sh' --max-iter 2 >/dev/null 2>&1
+LOOP_PROTECT_GRACE_SEC=0.2 "$LOOPFIX" --verify 'sh fake-verify-fail.sh' --fix ':' --protect '**/*.test.sh' --max-iter 2 >/dev/null 2>&1
 code=$?
 [ "$code" -eq 1 ] || fail "case4: expected exit 1 (MAX-ITER, no violation) with an inert fixer under a '**' glob, got $code"
 grep -q "PROTECTED FILE MODIFIED" .loop/history.log \
@@ -324,7 +324,11 @@ cmp -s guard-file.txt original-guard-file.txt \
 # The synthetic verify sleeps briefly on its PASS call to give the backgrounded mutation (a much
 # shorter delay) reliable margin to land before the new PASS-path check_protected() call runs —
 # widening the window on the test side rather than relying on a hair-trigger race, so this assertion
-# is not flaky.
+# is not flaky. (Round-5 note: with the grace-period recheck now on the FAIL path too, this scenario
+# is typically caught right there on iteration 1 rather than needing to reach the PASS path at all —
+# still a valid regression check either way, since the assertions below only require SOME
+# PROTECTED-VIOLATION catch, not which path caught it. A small grace override keeps this fast while
+# staying comfortably above the fixer's 0.05s mutation delay.)
 C="$WORK/c11"; mkdir -p "$C"; cd "$C" || fail "cd c11"
 printf 'ORIGINAL-CONTENT-c11\n' > guard-file.txt
 cp guard-file.txt original-guard-file.txt
@@ -348,18 +352,141 @@ cat > fake-fix-race.sh <<'EOF'
 true
 EOF
 
-"$LOOPFIX" --verify 'sh fake-verify-race.sh' --fix 'sh fake-fix-race.sh' --protect 'guard-file.txt' --max-iter 3 >/dev/null 2>&1
+LOOP_PROTECT_GRACE_SEC=0.2 "$LOOPFIX" --verify 'sh fake-verify-race.sh' --fix 'sh fake-fix-race.sh' --protect 'guard-file.txt' --max-iter 3 >/dev/null 2>&1
 code=$?
 [ "$code" -eq 3 ] || fail "case11: expected exit 3 (PROTECTED-VIOLATION) for a mutation backgrounded to land after the FAIL-path check but before the next verify, got $code — round-4 PASS-path gap is NOT closed"
 grep -q "done: SUCCESS" .loop/history.log \
   && fail "case11: must NOT report false SUCCESS — the protected file was left corrupted by a timed background mutation"
 grep -q "PROTECTED FILE MODIFIED" .loop/history.log \
-  || fail "case11: expected the PROTECTED FILE MODIFIED marker from the new PASS-path check"
+  || fail "case11: expected the PROTECTED FILE MODIFIED marker (FAIL-path or PASS-path, either is a valid catch)"
 grep -q "done: PROTECTED-VIOLATION" .loop/history.log || fail "case11: expected the PROTECTED-VIOLATION done marker"
 grep -q "restored 1 protected file(s) to their pre-run state" .loop/history.log \
   || fail "case11: expected a log line confirming the restore"
 cmp -s guard-file.txt original-guard-file.txt \
   || fail "case11: protected file bytes were NOT restored to the exact pre-run content"
 
-echo "PASS: --protect reverts a tampered/deleted protected file to its exact pre-run bytes, excludes its own backup dir from '**' scans, detects+refuses on backup poisoning OR backup deletion/unreadability via a fail-closed marker, deletes rogue new protect-glob-matching files before aborting, cannot be defeated by forging or deleting the on-disk hash bookkeeping (round-3: ground truth now lives in-process, not on disk), and now also catches a mutation backgrounded to land after the FAIL-path check but before the next verify (round-4: check_protected() runs on the PASS path too)"
+# ── Round 5 (independent adversarial review of the round-4 fix): the PASS-path check_protected()
+# call round 4 added is still a SINGLE, IMMEDIATE check — it only proves "clean at the instant it
+# ran". A fixer invoked via `sh -c "$FIX"` can return immediately while a `(sleep D; corrupt) &`
+# subshell it backgrounded is NOT waited on by that `sh -c` wrapper: any D longer than roughly
+# "however long loop-fix.sh takes to run its own check and exit" lands the corruption strictly AFTER
+# every check_protected() call in the run has already completed. Root cause: no single check, placed
+# ANYWHERE, can see a mutation that has not happened yet — this is a structural property of a
+# short-lived supervisor process, not a fixable logic bug. The round-5 fix does not claim to close
+# this (nothing can); it raises the bar with a bounded grace-period recheck (Part 1) and closes a
+# separate, secondary hygiene gap on non-protect abort paths (Part 2).
+
+# ── case 12: Part 1 — the grace-period recheck catches a short delay an immediate-only check ───
+# (round-4's bare check_protected(), reproduced here via LOOP_PROTECT_GRACE_SEC=0, which collapses
+# check_protected_with_grace() to two back-to-back instant checks — functionally the same "clean at
+# the instant it ran" guarantee the old bare call had) would miss. Same fixer/verify shape, same
+# mutation delay D, run twice with only the grace period differing — isolating the recheck itself as
+# the variable under test rather than relying on incidental timing of an unrelated verify call.
+#
+# case 12a: grace=0 (old-code-equivalent) — a D=0.4s backgrounded mutation is NOT caught; the run
+# reaches MAX-ITER (exit 1) with no PROTECTED FILE MODIFIED line, because the FAIL-path check runs
+# and completes in low milliseconds, long before D elapses.
+C="$WORK/c12a"; mkdir -p "$C"; cd "$C" || fail "cd c12a"
+cp "$WORK/fake-verify-fail.sh" fake-verify-fail.sh
+printf 'ORIGINAL-CONTENT-c12\n' > guard-file.txt
+cp guard-file.txt original-guard-file.txt
+cat > fake-fix-short-delay.sh <<'EOF'
+#!/bin/sh
+( sleep 0.4; printf 'CHEAT-STRING-c12\n' >> guard-file.txt ) &
+true
+EOF
+
+LOOP_PROTECT_GRACE_SEC=0 "$LOOPFIX" --verify 'sh fake-verify-fail.sh' --fix 'sh fake-fix-short-delay.sh' --protect 'guard-file.txt' --max-iter 1 >/dev/null 2>&1
+code=$?
+[ "$code" -eq 1 ] || fail "case12a: expected exit 1 (MAX-ITER, no violation caught) with grace=0 simulating an immediate-only check, got $code"
+grep -q "PROTECTED FILE MODIFIED" .loop/history.log \
+  && fail "case12a: an immediate-only check (grace=0) should NOT have caught a mutation still 0.4s away — if it did, this test's premise about the old code's blind spot is wrong"
+grep -q "done: MAX-ITER" .loop/history.log || fail "case12a: expected a normal MAX-ITER finish"
+
+# case 12b: same shape, grace=0.5s (> D=0.15s this time) — the recheck DOES catch it. Uses a smaller
+# D than 12a purely so this case finishes quickly; the two cases are independent, not a before/after
+# pair on the same D.
+C="$WORK/c12b"; mkdir -p "$C"; cd "$C" || fail "cd c12b"
+cp "$WORK/fake-verify-fail.sh" fake-verify-fail.sh
+printf 'ORIGINAL-CONTENT-c12b\n' > guard-file.txt
+cp guard-file.txt original-guard-file.txt
+cat > fake-fix-short-delay.sh <<'EOF'
+#!/bin/sh
+( sleep 0.15; printf 'CHEAT-STRING-c12b\n' >> guard-file.txt ) &
+true
+EOF
+
+LOOP_PROTECT_GRACE_SEC=0.5 "$LOOPFIX" --verify 'sh fake-verify-fail.sh' --fix 'sh fake-fix-short-delay.sh' --protect 'guard-file.txt' --max-iter 3 >/dev/null 2>&1
+code=$?
+[ "$code" -eq 3 ] || fail "case12b: expected exit 3 (PROTECTED-VIOLATION) — the grace-period recheck must catch a 0.15s delay under a 0.5s grace period, got $code"
+grep -q "PROTECTED FILE MODIFIED" .loop/history.log || fail "case12b: expected the PROTECTED FILE MODIFIED marker from the grace-period recheck"
+grep -q "done: PROTECTED-VIOLATION" .loop/history.log || fail "case12b: expected the PROTECTED-VIOLATION done marker"
+cmp -s guard-file.txt original-guard-file.txt \
+  || fail "case12b: protected file bytes were NOT restored to the exact pre-run content"
+
+# ── case 13: Part 1 boundary, honestly disclosed — a delay LONGER than the grace period is NOT a ──
+# false positive, it is the documented, expected limit (see the round-5 Guard-scope comment in
+# loop-fix.sh). A clean run whose fixer backgrounds a mutation past the grace window must still
+# report ordinary SUCCESS — the grace-period recheck must never cry wolf on a mutation it structurally
+# cannot see yet.
+C="$WORK/c13"; mkdir -p "$C"; cd "$C" || fail "cd c13"
+printf 'ORIGINAL-CONTENT-c13\n' > guard-file.txt
+cat > fake-verify-pass-once.sh <<'EOF'
+#!/bin/sh
+echo "PASS immediately"
+exit 0
+EOF
+cat > fake-fix-long-delay.sh <<'EOF'
+#!/bin/sh
+( sleep 2; printf 'CHEAT-STRING-c13-TOO-LATE\n' >> guard-file.txt ) &
+true
+EOF
+# Fixer is never actually invoked here (verify PASSes on iteration 1), so this exercises the
+# PASS-path grace recheck directly against a clean, untouched file — confirming the recheck itself
+# adds no false positives on an ordinary clean run.
+LOOP_PROTECT_GRACE_SEC=0.3 "$LOOPFIX" --verify 'sh fake-verify-pass-once.sh' --fix 'sh fake-fix-long-delay.sh' --protect 'guard-file.txt' --max-iter 1 >/dev/null 2>&1
+code=$?
+[ "$code" -eq 0 ] || fail "case13: expected exit 0 (ordinary SUCCESS, no fixer even invoked) got $code"
+grep -q "done: SUCCESS" .loop/history.log || fail "case13: expected a normal SUCCESS finish"
+grep -q "PROTECTED FILE MODIFIED" .loop/history.log \
+  && fail "case13: grace-period recheck must not false-positive on a clean run"
+
+# ── case 14: Part 2 — an EARLIER iteration's still-pending delayed background job must still be ──
+# caught (restored + warned about) by a LATER abort path that isn't itself a protect check — here,
+# STALLED — without changing that path's own exit code (round-5 secondary finding). Timeline:
+# iteration 1's fixer backgrounds a D=1.5s mutation and returns instantly; iteration 1's own FAIL-path
+# grace recheck (grace=1s) still sees it clean (D > grace) and lets the run continue; iteration 2
+# repeats the IDENTICAL failure fingerprint, tripping --stall 2 BEFORE iteration 2's own fixer would
+# ever run. By the time check_protected_on_abort() runs for that STALL abort (after ~2x the grace
+# period has elapsed since the mutation was scheduled), D has elapsed and the mutation is now visible
+# — proving the fix without needing to touch the STALL-detection code path itself.
+C="$WORK/c14"; mkdir -p "$C"; cd "$C" || fail "cd c14"
+printf 'ORIGINAL-CONTENT-c14\n' > guard-file.txt
+cp guard-file.txt original-guard-file.txt
+cat > fake-verify-stall.sh <<'EOF'
+#!/bin/sh
+echo "FAILED src/example.test.ts > case14 stall fingerprint (always identical)"
+exit 1
+EOF
+cat > fake-fix-stall-delay.sh <<'EOF'
+#!/bin/sh
+if [ ! -f .fixer-ran-once ]; then
+  touch .fixer-ran-once
+  ( sleep 1.5; printf 'CHEAT-STRING-c14\n' >> guard-file.txt ) &
+fi
+true
+EOF
+
+LOOP_PROTECT_GRACE_SEC=1 "$LOOPFIX" --verify 'sh fake-verify-stall.sh' --fix 'sh fake-fix-stall-delay.sh' --protect 'guard-file.txt' --stall 2 --max-iter 10 >/dev/null 2>&1
+code=$?
+[ "$code" -eq 1 ] || fail "case14: expected exit 1 (STALLED's own code, NOT 0 and NOT 3) got $code"
+grep -q "done: STALLED" .loop/history.log || fail "case14: expected the run to still report its own STALLED reason, unchanged by the protect hygiene check"
+grep -q "done: PROTECTED-VIOLATION" .loop/history.log \
+  && fail "case14: must NOT reclassify the exit reason to PROTECTED-VIOLATION — STALLED stays STALLED (workspace hygiene, not re-diagnosis)"
+grep -q "PROTECTED FILE MODIFIED" .loop/history.log \
+  || fail "case14: expected a protect-violation warning logged even though STALLED (not a protect check) is what actually aborted the run"
+cmp -s guard-file.txt original-guard-file.txt \
+  || fail "case14: protected file bytes from an earlier iteration's pending background job were NOT restored on a STALLED abort"
+
+echo "PASS: --protect reverts a tampered/deleted protected file to its exact pre-run bytes, excludes its own backup dir from '**' scans, detects+refuses on backup poisoning OR backup deletion/unreadability via a fail-closed marker, deletes rogue new protect-glob-matching files before aborting, cannot be defeated by forging or deleting the on-disk hash bookkeeping (round-3: ground truth now lives in-process, not on disk), catches a mutation backgrounded to land after the FAIL-path check but before the next verify (round-4: check_protected() runs on the PASS path too), and now (round-5) raises the bar with a bounded grace-period recheck on both paths while honestly not claiming to catch delays past that window, plus restores/warns-but-preserves-exit-code on STALLED/BUDGET/watchdog/INFRA aborts that used to leave an earlier iteration's pending corruption unflagged"
 exit 0

--- a/tools/loop-engine/test/loop-fix-protect.test.sh
+++ b/tools/loop-engine/test/loop-fix-protect.test.sh
@@ -14,6 +14,17 @@
 # guard's own restore path — closed by a post-restore integrity hash check + a fail-closed
 # compromise marker that makes a subsequent run refuse to proceed), and a rogue new file matching
 # the protect glob that restore_protected() alone never cleans up (case 6).
+#
+# Round 3 (adversarial review, cases 9-10): closes a CRITICAL, complete, SILENT bypass of the
+# entire guard — .loop/protected.sha (the detection ground truth) was a plain file the --fix
+# subprocess could write to just like any other file: overwriting it with the hash of its own
+# sabotaged content made check_protected() agree with itself ("unchanged"), and simply `rm -f`ing
+# it was treated as "nothing to protect" — either way, exit 0, false SUCCESS, in a SINGLE run, with
+# NO PROTECTED FILE MODIFIED log line and no restore attempt at all. Root-cause fix: the detection
+# hash (and the parallel file-list/mode-list bookkeeping) now lives ONLY in bash variables held in
+# loop-fix.sh's own process memory (PROTECT_SNAP_DATA / PROTECT_FILES_DATA / PROTECT_MODES_DATA),
+# never written to a file — a --fix child subprocess structurally cannot write into its parent
+# shell's variables, so there is nothing left on disk to forge or delete.
 set -uo pipefail
 HERE="$(cd "$(dirname "$0")" && pwd)"
 LOOPFIX="$HERE/../bin/loop-fix.sh"
@@ -237,5 +248,60 @@ EOF
   chmod 644 .loop/protected-backup/guard-file.txt 2>/dev/null   # let the trap's rm -rf clean up
 fi
 
-echo "PASS: --protect reverts a tampered/deleted protected file to its exact pre-run bytes, excludes its own backup dir from '**' scans, detects+refuses on backup poisoning OR backup deletion/unreadability via a fail-closed marker, and deletes rogue new protect-glob-matching files before aborting"
+# ── case 9: fixer sabotages the live file AND FORGES .loop/protected.sha to match (round-3) ────
+# Before the fix, the sha256 ground truth lived in a plain file (.loop/protected.sha) the fixer
+# subprocess had the same filesystem write access to as loop-fix.sh itself. Overwriting it with the
+# hash of the fixer's OWN sabotaged content made check_protected()'s diff agree with itself — no
+# violation ever detected, no restore, no compromise marker, loop just continues to MAX-ITER/STALL
+# (or PASS, if the sabotaged content happened to satisfy verify) having never noticed. After the
+# round-3 fix, the ground truth lives only in an in-process bash variable the fixer cannot reach, so
+# forging the on-disk file (if the fixer even still bothers to write one) has zero effect — the next
+# check_protected() recomputes the hash fresh and compares in memory.
+C="$WORK/c9"; mkdir -p "$C"; cd "$C" || fail "cd c9"
+cp "$WORK/fake-verify-fail.sh" fake-verify-fail.sh
+printf 'ORIGINAL-CONTENT-c9\n' > guard-file.txt
+cp guard-file.txt original-guard-file.txt
+cat > fake-fix-forge-sha.sh <<'EOF'
+#!/bin/sh
+echo "CHEAT-FORGE-SHA-c9" > guard-file.txt
+shasum -a 256 guard-file.txt > .loop/protected.sha 2>/dev/null \
+  || sha256sum guard-file.txt > .loop/protected.sha 2>/dev/null
+EOF
+
+"$LOOPFIX" --verify 'sh fake-verify-fail.sh' --fix 'sh fake-fix-forge-sha.sh' --protect 'guard-file.txt' --max-iter 3 >/dev/null 2>&1
+code=$?
+[ "$code" -eq 3 ] || fail "case9: expected exit 3 (PROTECTED-VIOLATION) even though the fixer forged a matching .loop/protected.sha, got $code — the on-disk hash file must have zero effect on detection (round-3 bypass NOT closed)"
+grep -q "PROTECTED FILE MODIFIED" .loop/history.log \
+  || fail "case9: expected the PROTECTED FILE MODIFIED marker — forging the (now-vestigial) hash file must not suppress detection"
+grep -q "restored 1 protected file(s) to their pre-run state" .loop/history.log \
+  || fail "case9: expected a log line confirming the restore"
+cmp -s guard-file.txt original-guard-file.txt \
+  || fail "case9: protected file bytes were NOT restored to the exact pre-run content"
+
+# ── case 10: fixer just `rm -f`s .loop/protected.sha instead of forging it (round-3) ───────────
+# Before the fix, check_protected() started with `[ -s "$PROTECT_SNAP" ] || return 0` — a
+# missing/empty on-disk snapshot was silently treated as "nothing to protect", an even simpler
+# bypass than case 9 (no need to compute a matching hash at all). After the round-3 fix there is no
+# on-disk snapshot file to delete in the first place — the equivalent fixer action is inert.
+C="$WORK/c10"; mkdir -p "$C"; cd "$C" || fail "cd c10"
+cp "$WORK/fake-verify-fail.sh" fake-verify-fail.sh
+printf 'ORIGINAL-CONTENT-c10\n' > guard-file.txt
+cp guard-file.txt original-guard-file.txt
+cat > fake-fix-rm-sha.sh <<'EOF'
+#!/bin/sh
+echo "CHEAT-RM-SHA-c10" > guard-file.txt
+rm -f .loop/protected.sha 2>/dev/null
+EOF
+
+"$LOOPFIX" --verify 'sh fake-verify-fail.sh' --fix 'sh fake-fix-rm-sha.sh' --protect 'guard-file.txt' --max-iter 3 >/dev/null 2>&1
+code=$?
+[ "$code" -eq 3 ] || fail "case10: expected exit 3 (PROTECTED-VIOLATION) even though the fixer deleted .loop/protected.sha, got $code — a missing on-disk hash file must not be read as 'nothing to protect' (round-3 bypass NOT closed)"
+grep -q "PROTECTED FILE MODIFIED" .loop/history.log \
+  || fail "case10: expected the PROTECTED FILE MODIFIED marker — deleting the (now-vestigial) hash file must not suppress detection"
+grep -q "restored 1 protected file(s) to their pre-run state" .loop/history.log \
+  || fail "case10: expected a log line confirming the restore"
+cmp -s guard-file.txt original-guard-file.txt \
+  || fail "case10: protected file bytes were NOT restored to the exact pre-run content"
+
+echo "PASS: --protect reverts a tampered/deleted protected file to its exact pre-run bytes, excludes its own backup dir from '**' scans, detects+refuses on backup poisoning OR backup deletion/unreadability via a fail-closed marker, deletes rogue new protect-glob-matching files before aborting, and cannot be defeated by forging or deleting the on-disk hash bookkeeping (round-3: ground truth now lives in-process, not on disk)"
 exit 0

--- a/tools/loop-engine/test/loop-fix-protect.test.sh
+++ b/tools/loop-engine/test/loop-fix-protect.test.sh
@@ -179,5 +179,63 @@ cmp -s src/real.test.sh src/original-real.test.sh \
 grep -q "removed rogue new file matching --protect" .loop/history.log \
   || fail "case6: expected a log line naming the rogue file that was removed"
 
-echo "PASS: --protect reverts a tampered/deleted protected file to its exact pre-run bytes, excludes its own backup dir from '**' scans, detects+refuses on backup poisoning via a fail-closed marker, and deletes rogue new protect-glob-matching files before aborting"
+# ── case 7: fixer DELETES its own backup copy instead of poisoning it (round-3 adversarial re-check) ──
+# round-2's integrity-hash check only ran in the "cp succeeded" branch of restore_protected() — the
+# pre-existing "no backup copy" branch set _restore_failed but never wrote the compromise marker.
+# Deleting the backup is strictly easier for a fixer than overwriting it with matching content (no
+# need to even defeat the step-5 chmod-0444 friction — `rm` only needs directory write access), and
+# it used to leave a rerun completely unblocked, silently taking the cheated content as a fresh
+# trusted baseline. Any restore failure — missing backup OR hash mismatch — must be equally
+# fail-closed.
+C="$WORK/c7"; mkdir -p "$C"; cd "$C" || fail "cd c7"
+cp "$WORK/fake-verify-fail.sh" fake-verify-fail.sh
+printf 'ORIGINAL-CONTENT-c7\n' > guard-file.txt
+cp guard-file.txt original-guard-file.txt
+cat > fake-fix-delete-backup.sh <<'EOF'
+#!/bin/sh
+echo "CHEAT-DELBACKUP" > guard-file.txt
+rm -f .loop/protected-backup/guard-file.txt
+EOF
+
+"$LOOPFIX" --verify 'sh fake-verify-fail.sh' --fix 'sh fake-fix-delete-backup.sh' --protect 'guard-file.txt' --max-iter 3 >/dev/null 2>&1
+code=$?
+[ "$code" -eq 3 ] || fail "case7 run1: expected exit 3 (PROTECTED-VIOLATION), got $code"
+grep -q "no backup copy" .loop/history.log || fail "case7 run1: expected a 'no backup copy' RESTORE FAILED line"
+[ -f .loop/protect-compromised ] \
+  || fail "case7 run1: expected a compromise marker even though the failure was a missing backup (not a hash mismatch) — deleting the backup must be just as fail-closed as poisoning it"
+grep -q "guard-file.txt" .loop/protect-compromised || fail "case7 run1: compromise marker must name the affected file"
+
+_hist_before_c7="$(wc -l < .loop/history.log | tr -d ' ')"
+"$LOOPFIX" --verify 'sh fake-verify-fail.sh' --fix ':' --protect 'guard-file.txt' --max-iter 1 >/dev/null 2>&1
+code=$?
+[ "$code" -eq 4 ] || fail "case7 run2 (rerun): expected exit 4 (refuse to start on a prior compromise marker), got $code — deleting the backup instead of overwriting it must not bypass the fail-closed rerun block"
+_hist_after_c7="$(wc -l < .loop/history.log | tr -d ' ')"
+[ "$_hist_before_c7" = "$_hist_after_c7" ] \
+  || fail "case7 run2: history.log grew during a refused run"
+
+# ── case 8: `cp` from backup itself fails (e.g. backup unreadable) — same fail-closed requirement ──
+# Skipped under root: chmod-based unreadability is meaningless to a root process (permission checks
+# are bypassed), which would make this assertion flaky rather than meaningful in that environment.
+if [ "$(id -u)" != "0" ]; then
+  C="$WORK/c8"; mkdir -p "$C"; cd "$C" || fail "cd c8"
+  cp "$WORK/fake-verify-fail.sh" fake-verify-fail.sh
+  printf 'ORIGINAL-CONTENT-c8\n' > guard-file.txt
+  cp guard-file.txt original-guard-file.txt
+  cat > fake-fix-break-backup.sh <<'EOF'
+#!/bin/sh
+echo "CHEAT-BREAKBACKUP" > guard-file.txt
+chmod 000 .loop/protected-backup/guard-file.txt 2>/dev/null
+EOF
+
+  "$LOOPFIX" --verify 'sh fake-verify-fail.sh' --fix 'sh fake-fix-break-backup.sh' --protect 'guard-file.txt' --max-iter 3 >/dev/null 2>&1
+  code=$?
+  [ "$code" -eq 3 ] || fail "case8 run1: expected exit 3 (PROTECTED-VIOLATION), got $code"
+  grep -q "cp from backup did not succeed" .loop/history.log \
+    || fail "case8 run1: expected a 'cp from backup did not succeed' RESTORE FAILED line"
+  [ -f .loop/protect-compromised ] \
+    || fail "case8 run1: expected a compromise marker even though the failure was an unreadable backup (not a hash mismatch)"
+  chmod 644 .loop/protected-backup/guard-file.txt 2>/dev/null   # let the trap's rm -rf clean up
+fi
+
+echo "PASS: --protect reverts a tampered/deleted protected file to its exact pre-run bytes, excludes its own backup dir from '**' scans, detects+refuses on backup poisoning OR backup deletion/unreadability via a fail-closed marker, and deletes rogue new protect-glob-matching files before aborting"
 exit 0

--- a/tools/loop-engine/test/loop-fix-protect.test.sh
+++ b/tools/loop-engine/test/loop-fix-protect.test.sh
@@ -25,6 +25,15 @@
 # loop-fix.sh's own process memory (PROTECT_SNAP_DATA / PROTECT_FILES_DATA / PROTECT_MODES_DATA),
 # never written to a file — a --fix child subprocess structurally cannot write into its parent
 # shell's variables, so there is nothing left on disk to forge or delete.
+#
+# Round 4 (independent adversarial review of the round-3 fix, case 11): closes a separate,
+# pre-existing, CRITICAL, 100%-reliable bypass that predates round 3 — check_protected() was only
+# ever invoked on the FAIL path (right before looping back to the next verify), never on the path
+# that declares PASS and exits 0. A fixer could background a detached mutation of a protected file
+# timed to land AFTER that FAIL-path check but BEFORE the next verify call: the poisoned bytes are
+# what the next verify reads, verify reports PASS, and the loop declared SUCCESS with the protected
+# file left cheated — no PROTECTED FILE MODIFIED line, no restore, no compromise marker. Fixed by
+# also calling check_protected() on the PASS path, immediately before declaring success.
 set -uo pipefail
 HERE="$(cd "$(dirname "$0")" && pwd)"
 LOOPFIX="$HERE/../bin/loop-fix.sh"
@@ -303,5 +312,54 @@ grep -q "restored 1 protected file(s) to their pre-run state" .loop/history.log 
 cmp -s guard-file.txt original-guard-file.txt \
   || fail "case10: protected file bytes were NOT restored to the exact pre-run content"
 
-echo "PASS: --protect reverts a tampered/deleted protected file to its exact pre-run bytes, excludes its own backup dir from '**' scans, detects+refuses on backup poisoning OR backup deletion/unreadability via a fail-closed marker, deletes rogue new protect-glob-matching files before aborting, and cannot be defeated by forging or deleting the on-disk hash bookkeeping (round-3: ground truth now lives in-process, not on disk)"
+# ── case 11: fixer backgrounds a delayed mutation timed to land AFTER the FAIL-path check but ──
+# BEFORE the next verify reads the file (round-4 adversarial finding) ───────────────────────────
+# check_protected() used to run ONLY on the FAIL path (right before looping back to the next
+# verify) — never on the PASS path. A fixer that returns immediately without touching the protected
+# file synchronously (so the FAIL-path check right after it sees no violation), but backgrounds a
+# detached job that mutates the file a little later, gets the poisoned bytes in place by the time
+# the NEXT verify call reads them. If that verify does not care about the file's content (as here —
+# it just reports PASS on its second invocation), the loop used to declare SUCCESS with the
+# protected file left corrupted, no PROTECTED FILE MODIFIED line, no restore, no compromise marker.
+# The synthetic verify sleeps briefly on its PASS call to give the backgrounded mutation (a much
+# shorter delay) reliable margin to land before the new PASS-path check_protected() call runs —
+# widening the window on the test side rather than relying on a hair-trigger race, so this assertion
+# is not flaky.
+C="$WORK/c11"; mkdir -p "$C"; cd "$C" || fail "cd c11"
+printf 'ORIGINAL-CONTENT-c11\n' > guard-file.txt
+cp guard-file.txt original-guard-file.txt
+cat > fake-verify-race.sh <<'EOF'
+#!/bin/sh
+if [ -f .verify-called-once ]; then
+  # Second+ call: sleep briefly so the fixer's backgrounded mutation (a much shorter delay) has
+  # landed well before this verify — and therefore the loop's PASS-path check — completes.
+  sleep 0.2
+  echo "PASS on iteration >=2 (delayed on purpose, see case11 comment)"
+  exit 0
+else
+  touch .verify-called-once
+  echo "FAILED forcing fixer invocation"
+  exit 1
+fi
+EOF
+cat > fake-fix-race.sh <<'EOF'
+#!/bin/sh
+( sleep 0.05; printf 'CHEAT-STRING-c11\n' >> guard-file.txt ) &
+true
+EOF
+
+"$LOOPFIX" --verify 'sh fake-verify-race.sh' --fix 'sh fake-fix-race.sh' --protect 'guard-file.txt' --max-iter 3 >/dev/null 2>&1
+code=$?
+[ "$code" -eq 3 ] || fail "case11: expected exit 3 (PROTECTED-VIOLATION) for a mutation backgrounded to land after the FAIL-path check but before the next verify, got $code — round-4 PASS-path gap is NOT closed"
+grep -q "done: SUCCESS" .loop/history.log \
+  && fail "case11: must NOT report false SUCCESS — the protected file was left corrupted by a timed background mutation"
+grep -q "PROTECTED FILE MODIFIED" .loop/history.log \
+  || fail "case11: expected the PROTECTED FILE MODIFIED marker from the new PASS-path check"
+grep -q "done: PROTECTED-VIOLATION" .loop/history.log || fail "case11: expected the PROTECTED-VIOLATION done marker"
+grep -q "restored 1 protected file(s) to their pre-run state" .loop/history.log \
+  || fail "case11: expected a log line confirming the restore"
+cmp -s guard-file.txt original-guard-file.txt \
+  || fail "case11: protected file bytes were NOT restored to the exact pre-run content"
+
+echo "PASS: --protect reverts a tampered/deleted protected file to its exact pre-run bytes, excludes its own backup dir from '**' scans, detects+refuses on backup poisoning OR backup deletion/unreadability via a fail-closed marker, deletes rogue new protect-glob-matching files before aborting, cannot be defeated by forging or deleting the on-disk hash bookkeeping (round-3: ground truth now lives in-process, not on disk), and now also catches a mutation backgrounded to land after the FAIL-path check but before the next verify (round-4: check_protected() runs on the PASS path too)"
 exit 0


### PR DESCRIPTION
Closes #34

## 배경

harness-maturity-audit(PR #31)이 발견한 major: `loop-fix.sh --protect`가 조작을 탐지는 하는데
원복하지 않는다 — abort 후 같은 워크스페이스에서 재실행하면 거짓 SUCCESS.

## 이 PR의 성격 — 7라운드 적대적 하드닝

이 가드는 정확히 "reward-hacking 방지"가 목적이라, 겉보기엔 방어됐지만 실제로는 안 방어되는 경로가
계속 나왔다. 매 라운드 독립 적대적 에이전트가 실제 재현 스크립트로 뚫으려 시도했고, 뚫리면
구조적으로 고쳤다. 순서대로:

1. **round 1**: 원복 자체를 추가(백업에서 byte-restore). 신규 테스트 파일
   `loop-fix-protect.test.sh` 신설(이전엔 `--protect` 전용 테스트가 아예 없었음).
2. **round 2 재검증**: critical 2건 — (a) 백업 자체를 fixer가 같이 조작하면 원복이 무력화되는데
   로그는 "restored"라고 거짓 주장, (b) `**` 글롭이 가드 자신의 백업 디렉토리를 재매치해 무해한
   fixer에도 오탐. 수정: 원복 후 원본 해시로 무결성 재검증(불일치 시 성공 주장 대신
   `protect-compromised` 마커 기록 + 다음 실행 fail-closed), 백업 디렉토리를 글롭 스캔에서 제외.
3. **round 3 재검증**: critical — 탐지 근거인 `.loop/protected.sha`가 그냥 파일이라 fixer가
   위조/삭제하면 탐지 자체가 통째로 무력화(단일 실행에 조용한 거짓 SUCCESS). 근본 수정: 탐지용
   해시/파일목록/권한을 파일이 아니라 `loop-fix.sh` 자신의 프로세스 메모리(bash 변수)로만 보관 —
   자식 프로세스(fixer)는 부모 셸의 변수를 구조적으로 못 건드림.
4. **round 4 재검증**: critical — `check_protected()`가 verify FAIL 경로에서만 불렸지 PASS
   경로(exit 0)에선 한 번도 안 불렸음. fixer가 지연 백그라운드 변조를 타이밍만 맞추면 그대로
   SUCCESS. PASS 경로에도 동일 체크 추가.
5. **round 5 재검증**: critical — 단일 즉시 체크는 "체크 시점까지"만 증명 가능 — fixer가
   `(sleep D; 변조) &`로 지연을 verify 소요시간보다 길게 잡으면 그 어떤 체크 지점도 항상 우회
   (구조적 한계, 로직 버그 아님). Grace-period 재확인(짧은 유예 후 한 번 더 체크) 추가 + 이 시점부터
   그래도 못 잡는 잔여 한계를 정직하게 문서화 시작. STALLED/BUDGET/watchdog 등 6개 abort 경로에도
   원복+경고 추가(단, exit code는 그대로 유지).
6. **round 6 재검증**: bypassable — watchdog의 자손-프로세스 킬러가 grace-period sleep 자체도
   죽여서(idle-timeout이 grace보다 짧으면) grace 우회 가능; abort 경로 6개 중 `VERDICT-RUN-ERROR`
   (exit 2)가 누락; "clean 체크는 공짜"라는 주석이 과장(실제론 클린 체크도 유예를 다 씀).
7. **round 7(이 라운드, 직접 수정)**: 세 건 모두 수정 — grace sleep을 백그라운드+`wait`로 돌려
   `wait`의 종료코드(시그널로 죽으면 128+시그널)로 감지해 같은 길이로 재시도(watchdog이 최대 1회만
   발화하므로 최대 1회 재시도로 충분) — `date +%s`식 벽시계 차분은 초 단위 정밀도뿐이라(BSD date엔
   `%N` 없음) 기존 서브초 단위 grace 테스트들(0.2s~1s)을 다 깨뜨려서 안 씀; `VERDICT-RUN-ERROR`
   경로에 동일 원복+경고 추가; 주석 정정.

## 정직하게 남겨두는 한계

`sh -c "$FIX"`가 백그라운드시킨 작업은 fixer 프로세스 자신이 끝나도 안 죽는다(고아화) — grace
period(기본 1.5초, `LOOP_PROTECT_GRACE_SEC`로 조정)보다 긴 지연은 여전히 이 프로세스가 이미 체크를
마치고 종료된 *이후*에 도착한다. 이건 로직 버그가 아니라 "유한 수명 프로세스는 자기 수명 이후 벌어질
일을 감지할 수 없다"는 구조적 한계이며, 이걸 완전히 닫으려면 fixer 실행 환경 자체를 샌드박싱(프로세스
그룹 격리 등)해야 한다 — 이번 이슈 범위 밖으로 명시적으로 남긴다. `-h`/`--help`의 Guard scope 절에
그대로 문서화돼 있다.

## 검증

```
$ bash tools/loop-engine/test/run.sh
loop-engine selftest: 27/27 passed
```

각 라운드의 수정은 재현 스크립트로 수정 전(재현됨) → 수정 후(닫힘)를 직접 확인했다(round 6→7 전환은
독립 에이전트 세션이 아니라 직접 재현+수정+검증).

머지는 하지 않고 여기서 멈춥니다 — 사람 확인 대기.
