### PR TITLE
fix(loop-memory): hook 발동 graduate/recall에 source 태그 (관측용, 위조방지 아님)

### DIFF
--- a/tools/loop-memory/dist/cli.js
+++ b/tools/loop-memory/dist/cli.js
@@ -40,12 +40,12 @@ var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__ge
 var require_postgres_array = __commonJS({
   "node_modules/postgres-array/index.js"(exports) {
     "use strict";
-    exports.parse = function(source, transform) {
-      return new ArrayParser(source, transform).parse();
+    exports.parse = function(source2, transform) {
+      return new ArrayParser(source2, transform).parse();
     };
     var ArrayParser = class _ArrayParser {
-      constructor(source, transform) {
-        this.source = source;
+      constructor(source2, transform) {
+        this.source = source2;
         this.transform = transform || identity;
         this.position = 0;
         this.entries = [];
@@ -135,10 +135,10 @@ var require_arrayParser = __commonJS({
   "node_modules/pg-types/lib/arrayParser.js"(exports, module) {
     var array = require_postgres_array();
     module.exports = {
-      create: function(source, transform) {
+      create: function(source2, transform) {
         return {
           parse: function() {
-            return array.parse(source, transform);
+            return array.parse(source2, transform);
           }
         };
       }
@@ -240,10 +240,10 @@ var require_mutable = __commonJS({
     var hasOwnProperty = Object.prototype.hasOwnProperty;
     function extend(target) {
       for (var i = 1; i < arguments.length; i++) {
-        var source = arguments[i];
-        for (var key in source) {
-          if (hasOwnProperty.call(source, key)) {
-            target[key] = source[key];
+        var source2 = arguments[i];
+        for (var key in source2) {
+          if (hasOwnProperty.call(source2, key)) {
+            target[key] = source2[key];
           }
         }
       }
@@ -9993,9 +9993,9 @@ var PgSelectBuilder = class {
    *
    * {@link https://www.postgresql.org/docs/current/sql-select.html#SQL-FROM | Postgres from documentation}
    */
-  from(source) {
+  from(source2) {
     const isPartialSelect = !!this.fields;
-    const src = source;
+    const src = source2;
     let fields;
     if (this.fields) {
       fields = this.fields;
@@ -11262,8 +11262,8 @@ var PgUpdateBase = class extends QueryPromise {
   tableName;
   joinsNotNullableMap;
   cacheConfig;
-  from(source) {
-    const src = source;
+  from(source2) {
+    const src = source2;
     const tableName = getTableLikeName(src);
     if (typeof tableName === "string") {
       this.joinsNotNullableMap[tableName] = true;
@@ -11453,11 +11453,11 @@ var PgCountBuilder = class _PgCountBuilder extends SQL {
   static [entityKind] = "PgCountBuilder";
   [Symbol.toStringTag] = "PgCountBuilder";
   session;
-  static buildEmbeddedCount(source, filters) {
-    return sql`(select count(*) from ${source}${sql.raw(" where ").if(filters)}${filters})`;
+  static buildEmbeddedCount(source2, filters) {
+    return sql`(select count(*) from ${source2}${sql.raw(" where ").if(filters)}${filters})`;
   }
-  static buildCount(source, filters) {
-    return sql`select count(*) as count from ${source}${sql.raw(" where ").if(filters)}${filters};`;
+  static buildCount(source2, filters) {
+    return sql`select count(*) as count from ${source2}${sql.raw(" where ").if(filters)}${filters};`;
   }
   /** @intrnal */
   setToken(token) {
@@ -11714,8 +11714,8 @@ var PgDatabase = class {
     };
     return { as };
   };
-  $count(source, filters) {
-    return new PgCountBuilder({ source, filters, session: this.session });
+  $count(source2, filters) {
+    return new PgCountBuilder({ source: source2, filters, session: this.session });
   }
   $cache;
   /**
@@ -12653,7 +12653,8 @@ async function addNote(db, embedder, input) {
       keywords: input.keywords,
       tags: input.tags,
       context: input.context,
-      links: input.links
+      links: input.links,
+      source: input.source
     }
   });
   return note;
@@ -12678,7 +12679,8 @@ async function updateNote(db, embedder, noteId, patch) {
       keywords: patch.keywords,
       tags: patch.tags,
       context: patch.context,
-      links: patch.links
+      links: patch.links,
+      source: patch.source
     }
   });
 }
@@ -12831,7 +12833,7 @@ var noteKeywords = (chunk) => [
   `${HASH_PREFIX}${chunk.hash}`
 ];
 var LOCK_NAMESPACE = 1802398823;
-async function syncKnowledge(db, pool, embedder, tag, desired) {
+async function syncKnowledge(db, pool, embedder, tag, desired, source2) {
   const client = await pool.connect();
   try {
     const lock = await client.query(
@@ -12881,7 +12883,8 @@ async function syncKnowledge(db, pool, embedder, tag, desired) {
           // 수렴 대상 네임스페이스(tag)로 저장 — chunk.tag가 아니라 tag로 불변식을 구조적으로 보장.
           tags: [tag],
           context: chunk.context,
-          embedding: embeddings[ei++]
+          embedding: embeddings[ei++],
+          source: source2
         });
         result.added++;
       }
@@ -12890,7 +12893,8 @@ async function syncKnowledge(db, pool, embedder, tag, desired) {
           content: chunk.content,
           keywords: noteKeywords(chunk),
           context: chunk.context,
-          embedding: embeddings[ei++]
+          embedding: embeddings[ei++],
+          source: source2
         });
         result.updated++;
       }
@@ -12913,7 +12917,7 @@ async function syncKnowledge(db, pool, embedder, tag, desired) {
   }
 }
 var SKIP_FILES = /* @__PURE__ */ new Set(["0000-template.md", "README.md"]);
-async function graduateKnowledge(db, pool, embedder, adrDir) {
+async function graduateKnowledge(db, pool, embedder, adrDir, source2) {
   const desired = [];
   for (const f of readdirSync(adrDir)) {
     if (!f.endsWith(".md") || SKIP_FILES.has(f)) continue;
@@ -12922,14 +12926,14 @@ async function graduateKnowledge(db, pool, embedder, adrDir) {
     desired.push(...parseAdrChunks(readFileSync(join(adrDir, f), "utf8"), adrId));
   }
   if (desired.length === 0) return { added: 0, updated: 0, deleted: 0, noop: 0 };
-  return syncKnowledge(db, pool, embedder, ADR_TAG, desired);
+  return syncKnowledge(db, pool, embedder, ADR_TAG, desired, source2);
 }
-async function graduateContext(db, pool, embedder, contextPath) {
+async function graduateContext(db, pool, embedder, contextPath, source2) {
   const desired = parseContextChunks(readFileSync(contextPath, "utf8"));
   if (desired.length === 0) return { added: 0, updated: 0, deleted: 0, noop: 0 };
-  return syncKnowledge(db, pool, embedder, CONTEXT_TAG, desired);
+  return syncKnowledge(db, pool, embedder, CONTEXT_TAG, desired, source2);
 }
-async function graduateMarkdownDir(db, pool, embedder, dir, tag, sourceLabel) {
+async function graduateMarkdownDir(db, pool, embedder, dir, tag, sourceLabel, source2) {
   const desired = [];
   const skipped = [];
   for (const f of readdirSync(dir)) {
@@ -12944,7 +12948,7 @@ async function graduateMarkdownDir(db, pool, embedder, dir, tag, sourceLabel) {
       ...parseMarkdownChunks(readFileSync(join(dir, f), "utf8"), tag, docId, `${sourceLabel}/${f}`)
     );
   }
-  const result = desired.length === 0 ? { added: 0, updated: 0, deleted: 0, noop: 0 } : await syncKnowledge(db, pool, embedder, tag, desired);
+  const result = desired.length === 0 ? { added: 0, updated: 0, deleted: 0, noop: 0 } : await syncKnowledge(db, pool, embedder, tag, desired, source2);
   return { ...result, skipped };
 }
 async function recallKnowledge(db, embedder, query, k = 5, tags = KNOWLEDGE_TAGS) {
@@ -13020,11 +13024,11 @@ function readLessonRecords(dir) {
   return out;
 }
 function readVerifiedLessons(dir) {
-  return readLessonRecords(dir).filter(isGraduationEligible).map(({ id, title, fix, source, signature, count, lastSeen }) => ({
+  return readLessonRecords(dir).filter(isGraduationEligible).map(({ id, title, fix, source: source2, signature, count, lastSeen }) => ({
     id,
     title,
     fix,
-    source,
+    source: source2,
     signature,
     count,
     lastSeen
@@ -13047,7 +13051,7 @@ function decideLessonReap(currentContent, rec) {
   if (rec.rejected) return { op: "purge", reason: "challenge verdict=reject" };
   return { op: "keep" };
 }
-async function graduateLessons(db, pool, embedder, dir, signingKey) {
+async function graduateLessons(db, pool, embedder, dir, signingKey, source2) {
   const client = await pool.connect();
   try {
     const lock = await client.query(
@@ -13076,7 +13080,8 @@ async function graduateLessons(db, pool, embedder, dir, signingKey) {
           keywords: [key],
           tags: [LESSON_TAG, l.source],
           context: l.source,
-          provenance: signingKey ? signContent(content, signingKey) : void 0
+          provenance: signingKey ? signContent(content, signingKey) : void 0,
+          source: source2
         });
         added++;
       }
@@ -13091,7 +13096,8 @@ async function graduateLessons(db, pool, embedder, dir, signingKey) {
         if (decision.op === "stub") {
           await updateNote(db, embedder, note.id, {
             content: decision.content,
-            provenance: signingKey ? signContent(decision.content, signingKey) : void 0
+            provenance: signingKey ? signContent(decision.content, signingKey) : void 0,
+            source: source2
           });
           stubbed++;
         } else if (decision.op === "purge") {
@@ -13326,6 +13332,7 @@ var opt = {
   hits: ""
   // record-recall: [{id, distance?, corpus?}, ...] JSON 문자열 (BAC-586)
 };
+var source = process.env.LOOP_MEMORY_SOURCE || void 0;
 for (let i = 0; i < argv.length; i++) {
   const a = argv[i];
   const val = () => {
@@ -13441,7 +13448,7 @@ async function runStats(json2) {
     await pool.end();
   }
 }
-async function runRecordRecall(hitsJson) {
+async function runRecordRecall(hitsJson, source2) {
   let hits;
   try {
     hits = JSON.parse(hitsJson || "[]");
@@ -13454,7 +13461,7 @@ async function runRecordRecall(hitsJson) {
   try {
     for (const h of hits) {
       if (!h?.id) continue;
-      await recordRecall(db, h.id, { distance: h.distance, corpus: h.corpus });
+      await recordRecall(db, h.id, { distance: h.distance, corpus: h.corpus, source: source2 });
     }
   } finally {
     await pool.end();
@@ -13502,7 +13509,7 @@ async function main() {
     return;
   }
   if (cmd === "record-recall") {
-    await runRecordRecall(opt.hits);
+    await runRecordRecall(opt.hits, source);
     return;
   }
   if (cmd === "consolidate") {
@@ -13531,7 +13538,7 @@ async function main() {
   const { db, pool } = createLoopDb();
   try {
     if (cmd === "graduate") {
-      const r = await graduateLessons(db, pool, embedder, opt.lessons, signingKey);
+      const r = await graduateLessons(db, pool, embedder, opt.lessons, signingKey, source);
       if (r.locked) {
         process.stdout.write(
           "loop-memory: lessons \u2014 skipped (\uB3D9\uC2DC \uC878\uC5C5 \uC9C4\uD589 \uC911, \uB2E4\uC74C \uC138\uC158\uC774 \uC774\uC5B4\uAC10)\n"
@@ -13543,11 +13550,11 @@ async function main() {
         );
       }
       if (opt.knowledge) {
-        const k = await graduateKnowledge(db, pool, embedder, opt.knowledge);
+        const k = await graduateKnowledge(db, pool, embedder, opt.knowledge, source);
         printKnowledgeResult("ADR", k);
       }
       if (opt.context) {
-        const c = await graduateContext(db, pool, embedder, opt.context);
+        const c = await graduateContext(db, pool, embedder, opt.context, source);
         printKnowledgeResult("CONTEXT", c);
       }
       if (opt.research) {
@@ -13557,7 +13564,8 @@ async function main() {
           embedder,
           opt.research,
           RESEARCH_TAG,
-          opt.research
+          opt.research,
+          source
         );
         printKnowledgeResult("research", r2);
         for (const s of r2.skipped) {
@@ -13566,7 +13574,15 @@ async function main() {
         }
       }
       if (opt.design) {
-        const d = await graduateMarkdownDir(db, pool, embedder, opt.design, DESIGN_TAG, opt.design);
+        const d = await graduateMarkdownDir(
+          db,
+          pool,
+          embedder,
+          opt.design,
+          DESIGN_TAG,
+          opt.design,
+          source
+        );
         printKnowledgeResult("design", d);
         for (const s of d.skipped) {
           process.stdout.write(`loop-memory: knowledge (design) skip ${s.file} \u2014 ${s.reason}

--- a/tools/loop-memory/hooks/graduate-lessons.mjs
+++ b/tools/loop-memory/hooks/graduate-lessons.mjs
@@ -39,6 +39,14 @@ for (const [pluginOpt, plain] of [
 ]) {
   if (!childEnv[plain] && env[pluginOpt]) childEnv[plain] = env[pluginOpt];
 }
+// Source tag (paul-loop issue #35) — self-reported, good-faith metadata for observability/debugging,
+// NOT a security or forgery-proof signal. Anyone with shell access can run `node dist/cli.js graduate`
+// directly and set this same env var by hand, at the same trust level as querying the database
+// directly — there is nothing here that only a real, live-firing hook could produce. This tags rows as
+// "explicitly marked as coming from the hook code path" vs. "not marked", nothing stronger. Always
+// overwrite (this script's own invocation IS that code path — no legitimate reason for an inherited
+// value to survive here).
+childEnv.LOOP_MEMORY_SOURCE = 'hook';
 
 try {
   if (env.LOOP_RECALL_OFF !== '1' && (childEnv.OPENAI_API_KEY || childEnv.GEMINI_API_KEY)) {

--- a/tools/loop-memory/hooks/recall-lessons.mjs
+++ b/tools/loop-memory/hooks/recall-lessons.mjs
@@ -68,6 +68,14 @@ try {
   ]) {
     if (!childEnv[plain] && env[pluginOpt]) childEnv[plain] = env[pluginOpt];
   }
+  // Source tag (paul-loop issue #35) — self-reported, good-faith metadata for observability/debugging,
+  // NOT a security or forgery-proof signal. Anyone with shell access can run the CLI directly and set
+  // this same env var by hand, at the same trust level as querying the database directly — there is
+  // nothing here that only a real, live-firing hook could produce. Tags both subprocesses spawned below
+  // (the `recall` call and the fire-and-forget `record-recall` inside recordInjected, which reuses this
+  // same childEnv) as "explicitly marked as coming from the hook code path" vs. "not marked", nothing
+  // stronger. Always overwrite — this script's own invocation IS that code path.
+  childEnv.LOOP_MEMORY_SOURCE = 'hook';
   dbg(
     `fired: key=${!!(childEnv.OPENAI_API_KEY || childEnv.GEMINI_API_KEY)} off=${env.LOOP_RECALL_OFF === '1'}`,
   );

--- a/tools/loop-memory/src/cli.ts
+++ b/tools/loop-memory/src/cli.ts
@@ -37,6 +37,17 @@
  *
  * Exit: 0 ok · 2 usage · 1 runtime(연결/임베드 실패). 호출자(훅)는 nonzero/빈 출력을 "회상 없음"으로
  * 보고 그냥 진행한다(fail-open) — 메모리 인프라가 없거나 죽어도 세션을 절대 막지 않는다.
+ *
+ * `LOOP_MEMORY_SOURCE`(paul-loop 이슈 #35): graduate/record-recall이 쓰는 memory_op 행의 `payload.source`
+ * 로 그대로 남는 호출 출처 태그. hooks/*.mjs가 이 CLI를 spawn할 때만 `hook`으로 심는다 — 수동 CLI
+ * 호출·테스트는 안 심으므로 생략(payload에 키 자체가 안 남는다).
+ * ⚠️ 이건 **자기신고(self-reported) 관측용 메타데이터**일 뿐, 보안/위조방지 신호가 아니다. 셸 접근이
+ * 있는 누구나(사람이 디버깅 중이든, CI 스크립트든, 테스트든, 다른 에이전트든, 손으로
+ * `LOOP_MEMORY_SOURCE=hook`을 export해두고 잊었든) `node dist/cli.js graduate ...`를 직접 돌려 이
+ * env를 손으로 심으면 실제 훅 발동과 바이트 단위로 구분 불가능한 행이 남는다 — DB를 직접 질의하는 것과
+ * 같은 신뢰 수준이다. 이 값이 있고 없고가 증명하는 건 "훅 코드 경로에서 왔다고 명시적으로 표시됨" 대
+ * "표시 안 됨" 뿐이다. "실제 라이브 세션에서 훅이 발동했다"는 더 강한 주장은 이걸로 증명되지 않는다
+ * (paul-loop 이슈 #35는 이 커밋으로 완전히 닫히지 않는다 — 그 증거는 여전히 없다).
  */
 import { readFileSync } from 'node:fs';
 import { sql } from 'drizzle-orm';
@@ -145,6 +156,16 @@ const opt = {
   decay: false, // recall --decay: lessons 코퍼스를 decay 랭킹(BAC/paul-loop #12)으로 재정렬
   hits: '', // record-recall: [{id, distance?, corpus?}, ...] JSON 문자열 (BAC-586)
 };
+// source 태그(paul-loop 이슈 #35). hooks/graduate-lessons.mjs와 hooks/recall-lessons.mjs가
+// "node dist/cli.js ..." 하위프로세스를 spawn할 때만 이 env를 심는다(env `LOOP_MEMORY_SOURCE=hook`) —
+// 수동 CLI 호출·테스트는 안 심으므로 undefined로 남는다. graduate/record-recall이 이 값을
+// memory_op.payload.source에 그대로 적는다. ⚠️ 자기신고 메타데이터일 뿐 위조방지 신호가 아니다 — 셸
+// 접근이 있으면 누구든 이 env를 손으로 심어 진짜 훅 발동과 구분 불가능한 행을 만들 수 있다(DB 직접
+// 질의와 같은 신뢰 수준). "훅 코드 경로로 명시 표시됨" 대 "표시 안 됨"만 구분하지, "실제 훅이
+// 발동했다"는 증명하지 않는다. 없어도 오도하는 기본값(예: 'cli')으로 채우지 않는다 — 생략은 생략인 채로
+// 남는다.
+const source = process.env.LOOP_MEMORY_SOURCE || undefined;
+
 for (let i = 0; i < argv.length; i++) {
   const a = argv[i];
   const val = () => {
@@ -265,7 +286,7 @@ async function runStats(json: boolean): Promise<void> {
 /** record-recall: 훅이 실제로 주입한 노트 id들을 memory_op에 RECALL 행으로 남긴다(계측, BAC-586).
  *  임베더가 필요 없다(노트/거리는 이미 훅이 확정한 값을 그대로 받아 적을 뿐) — pickEmbedder를 거치지
  *  않아 임베딩 키 없이도 동작한다. --hits는 [{id, distance?, corpus?}, ...] JSON 배열. */
-async function runRecordRecall(hitsJson: string): Promise<void> {
+async function runRecordRecall(hitsJson: string, source: string | undefined): Promise<void> {
   let hits: unknown;
   try {
     hits = JSON.parse(hitsJson || '[]');
@@ -278,7 +299,7 @@ async function runRecordRecall(hitsJson: string): Promise<void> {
   try {
     for (const h of hits as Array<{ id?: string; distance?: number; corpus?: string }>) {
       if (!h?.id) continue;
-      await recordRecall(db, h.id, { distance: h.distance, corpus: h.corpus });
+      await recordRecall(db, h.id, { distance: h.distance, corpus: h.corpus, source });
     }
   } finally {
     await pool.end();
@@ -329,7 +350,7 @@ async function main(): Promise<void> {
     return;
   }
   if (cmd === 'record-recall') {
-    await runRecordRecall(opt.hits);
+    await runRecordRecall(opt.hits, source);
     return;
   }
   if (cmd === 'consolidate') {
@@ -363,7 +384,7 @@ async function main(): Promise<void> {
   const { db, pool } = createLoopDb();
   try {
     if (cmd === 'graduate') {
-      const r = await graduateLessons(db, pool, embedder, opt.lessons, signingKey);
+      const r = await graduateLessons(db, pool, embedder, opt.lessons, signingKey, source);
       // locked를 "0 added, 0 skipped"와 구분해 찍는다(BAC-372, printKnowledgeResult와 동일 이유) —
       // 동시 졸업 중이라 이번엔 아무 것도 안 봤다는 뜻이지 "이미 최신"이 아니다.
       if (r.locked) {
@@ -378,11 +399,11 @@ async function main(): Promise<void> {
       // knowledge 코퍼스(BAC-355: ADR·CONTEXT·research·design 4개 소스, 각자 독립 플래그가 주어질
       // 때만). 전부 멱등(증분 재임베드) — syncKnowledge 미러-싱크 위에 얹혀 있다.
       if (opt.knowledge) {
-        const k = await graduateKnowledge(db, pool, embedder, opt.knowledge);
+        const k = await graduateKnowledge(db, pool, embedder, opt.knowledge, source);
         printKnowledgeResult('ADR', k);
       }
       if (opt.context) {
-        const c = await graduateContext(db, pool, embedder, opt.context);
+        const c = await graduateContext(db, pool, embedder, opt.context, source);
         printKnowledgeResult('CONTEXT', c);
       }
       if (opt.research) {
@@ -393,6 +414,7 @@ async function main(): Promise<void> {
           opt.research,
           RESEARCH_TAG,
           opt.research,
+          source,
         );
         printKnowledgeResult('research', r2);
         // silent truncation 금지(BAC-355 AC) — .md 아닌 항목(HTML 리포트 등)은 사유와 함께 드러낸다.
@@ -401,7 +423,15 @@ async function main(): Promise<void> {
         }
       }
       if (opt.design) {
-        const d = await graduateMarkdownDir(db, pool, embedder, opt.design, DESIGN_TAG, opt.design);
+        const d = await graduateMarkdownDir(
+          db,
+          pool,
+          embedder,
+          opt.design,
+          DESIGN_TAG,
+          opt.design,
+          source,
+        );
         printKnowledgeResult('design', d);
         for (const s of d.skipped) {
           process.stdout.write(`loop-memory: knowledge (design) skip ${s.file} — ${s.reason}\n`);

--- a/tools/loop-memory/src/knowledge.ts
+++ b/tools/loop-memory/src/knowledge.ts
@@ -272,6 +272,11 @@ export const LOCK_NAMESPACE = 0x6b6e6c67;
  * 동시 졸업 가드(BAC-367): 함수 진입 시 세션-스코프 advisory lock을 걸고(획득 실패 시 즉시 skip),
  * 이후 쓰기는 여전히 노트별 개별 auto-commit(트랜잭션으로 안 묶음) — 12s SessionStart 타임아웃에
  * 잘려도 그때까지 커밋된 노트는 살아남아 다음 세션이 이어받는다(기존 증분 수렴 설계 유지).
+ *
+ * 호출 출처 태그(paul-loop 이슈 #35): `source`가 있으면 ADD/UPDATE하는 memory_op 행의 `payload.source`로
+ * 남는다(ops.ts의 NoteInput.source 참고) — graduateKnowledge/graduateContext/graduateMarkdownDir이
+ * 그대로 흘려보낸다. NOOP/DELETE는 ops.ts 범위 밖(addNote/updateNote/recordRecall만 payload.source를
+ * 지원) — 그대로 둔다.
  */
 export async function syncKnowledge(
   db: LoopDb,
@@ -279,6 +284,7 @@ export async function syncKnowledge(
   embedder: Embedder,
   tag: string,
   desired: KnowledgeChunk[],
+  source?: string,
 ): Promise<KnowledgeSyncResult> {
   const client = await pool.connect();
   try {
@@ -349,6 +355,7 @@ export async function syncKnowledge(
           tags: [tag],
           context: chunk.context,
           embedding: embeddings[ei++],
+          source,
         });
         result.added++;
       }
@@ -358,6 +365,7 @@ export async function syncKnowledge(
           keywords: noteKeywords(chunk),
           context: chunk.context,
           embedding: embeddings[ei++],
+          source,
         });
         result.updated++;
       }
@@ -394,6 +402,7 @@ export async function graduateKnowledge(
   pool: Pool,
   embedder: Embedder,
   adrDir: string,
+  source?: string,
 ): Promise<KnowledgeSyncResult> {
   const desired: KnowledgeChunk[] = [];
   for (const f of readdirSync(adrDir)) {
@@ -405,7 +414,7 @@ export async function graduateKnowledge(
   // 안전장치: 빈 결과는 잘못 가리킨 디렉토리일 개연이 크다 → 전체 코퍼스를 지우지 않고 no-op.
   // (실 ADR 디렉토리는 항상 비-폐기 ADR을 하나 이상 낸다. 진짜 전량 삭제는 이 경로로 하지 않는다.)
   if (desired.length === 0) return { added: 0, updated: 0, deleted: 0, noop: 0 };
-  return syncKnowledge(db, pool, embedder, ADR_TAG, desired);
+  return syncKnowledge(db, pool, embedder, ADR_TAG, desired, source);
 }
 
 /**
@@ -418,10 +427,11 @@ export async function graduateContext(
   pool: Pool,
   embedder: Embedder,
   contextPath: string,
+  source?: string,
 ): Promise<KnowledgeSyncResult> {
   const desired = parseContextChunks(readFileSync(contextPath, 'utf8'));
   if (desired.length === 0) return { added: 0, updated: 0, deleted: 0, noop: 0 };
-  return syncKnowledge(db, pool, embedder, CONTEXT_TAG, desired);
+  return syncKnowledge(db, pool, embedder, CONTEXT_TAG, desired, source);
 }
 
 export interface GraduateMarkdownDirResult extends KnowledgeSyncResult {
@@ -441,6 +451,9 @@ export async function graduateMarkdownDir(
   dir: string,
   tag: string,
   sourceLabel: string,
+  // 호출 출처 태그(paul-loop 이슈 #35, syncKnowledge 참고) — `sourceLabel`(사람이 읽는 문서 출처 접두)과는
+  // 무관한 별개 파라미터. 이름 충돌에 주의.
+  source?: string,
 ): Promise<GraduateMarkdownDirResult> {
   const desired: KnowledgeChunk[] = [];
   const skipped: { file: string; reason: string }[] = [];
@@ -462,7 +475,7 @@ export async function graduateMarkdownDir(
   const result =
     desired.length === 0
       ? { added: 0, updated: 0, deleted: 0, noop: 0 }
-      : await syncKnowledge(db, pool, embedder, tag, desired);
+      : await syncKnowledge(db, pool, embedder, tag, desired, source);
   return { ...result, skipped };
 }
 

--- a/tools/loop-memory/src/lessons.ts
+++ b/tools/loop-memory/src/lessons.ts
@@ -235,6 +235,14 @@ export interface GraduateResult {
  * 모르는 다른 쓰기 경로(직접 SQL INSERT 등)는 이 서명을 위조할 수 없어, `recallLessons`가 구조적으로
  * 걸러낸다. `signingKey`가 없으면(secret 미설정) 서명 없이 그대로 쓴다 — 쓰기 자체를 막지 않는다
  * (fail-closed는 recall 쪽 책임, README 참고).
+ *
+ * 호출 출처 태그(paul-loop 이슈 #35): `source`가 있으면 이 함수가 ADD/스텁 UPDATE하는 memory_op 행의
+ * `payload.source`로 그대로 남는다(ops.ts의 NoteInput.source 참고) — hooks/graduate-lessons.mjs가 실
+ * SessionStart에서 CLI를 spawn할 때만 `LOOP_MEMORY_SOURCE=hook`을 심어 cli.ts가 여기로 흘려보낸다.
+ * 수동 CLI 호출·테스트는 생략하므로 payload에 이 키 자체가 안 남는다. ⚠️ 이건 자기신고 관측용
+ * 메타데이터일 뿐 위조방지 신호가 아니다 — 셸 접근이 있으면 누구든 이 env를 손으로 심어 같은 값을 낼 수
+ * 있다(DB 직접 질의와 같은 신뢰 수준). 이 값의 존재 여부는 "훅 코드 경로로 명시 표시됨"과 "안 됨"만
+ * 구분할 뿐, "훅이 실제로 발동했다"는 증명하지 않는다.
  */
 export async function graduateLessons(
   db: LoopDb,
@@ -242,6 +250,7 @@ export async function graduateLessons(
   embedder: Embedder,
   dir: string,
   signingKey: string | undefined,
+  source?: string,
 ): Promise<GraduateResult> {
   const client = await pool.connect();
   try {
@@ -279,6 +288,7 @@ export async function graduateLessons(
           tags: [LESSON_TAG, l.source],
           context: l.source,
           provenance: signingKey ? signContent(content, signingKey) : undefined,
+          source,
         });
         added++;
       }
@@ -301,6 +311,7 @@ export async function graduateLessons(
           await updateNote(db, embedder, note.id, {
             content: decision.content,
             provenance: signingKey ? signContent(decision.content, signingKey) : undefined,
+            source,
           });
           stubbed++;
         } else if (decision.op === 'purge') {

--- a/tools/loop-memory/src/ops.ts
+++ b/tools/loop-memory/src/ops.ts
@@ -20,6 +20,13 @@ export interface NoteInput {
   /** write-path provenance(BAC-619) — HMAC-SHA256(content, secret) hex. lessons.ts의 graduateLessons만
    * 채운다(src/provenance.ts). 생략하면 컬럼은 null(서명 없음 — recallLessons가 제외한다). */
   provenance?: string;
+  /** 호출 출처 태그(paul-loop 이슈 #35) — memory_op.payload.source로 그대로 남는다. hooks/*.mjs가
+   * "node dist/cli.js graduate ..." 하위프로세스를 spawn할 때만 env `LOOP_MEMORY_SOURCE=hook`을 심어
+   * cli.ts가 이 값을 채운다. 수동 CLI 호출·테스트는 안 심으므로 생략(undefined) — 생략 시 이 필드는
+   * payload에 키 자체가 안 남는다(JSON.stringify가 undefined 값을 드롭), 'cli' 같은 오도하는 기본값으로
+   * 채우지 않는다. lessons.ts의 `LessonFile.source`(교훈 파일 자체의 출처, 예: 'loop-fix')와는 무관한
+   * 별개 개념 — 혼동 주의. */
+  source?: string;
 }
 
 export interface RecallHit {
@@ -60,6 +67,7 @@ export async function addNote(db: LoopDb, embedder: Embedder, input: NoteInput) 
       tags: input.tags,
       context: input.context,
       links: input.links,
+      source: input.source,
     },
   });
   return note;
@@ -96,6 +104,7 @@ export async function updateNote(
       tags: patch.tags,
       context: patch.context,
       links: patch.links,
+      source: patch.source,
     },
   });
 }
@@ -118,7 +127,13 @@ export async function noop(db: LoopDb, noteId: string, reason?: string) {
  *  건드리고 원장(memory_op)에만 이벤트를 남긴다 — recall()의 후보 반환과 달리, 훅의 거리컷오프를
  *  통과해 *실제 주입*된 노트만 이걸 호출해야 사후에 "그 시점 컨텍스트에 실제로 있었는가"를 증명할 수
  *  있다(회상 실패표본 분류 (B): lesson이 있었고 주입됐는데 무시됨). */
-export async function recordRecall(db: LoopDb, noteId: string, payload?: Record<string, unknown>) {
+export async function recordRecall(
+  db: LoopDb,
+  noteId: string,
+  // source(paul-loop 이슈 #35): NoteInput.source와 같은 개념 — 호출부(cli.ts)가 이미 완성된 payload
+  // 객체를 통째로 넘기므로 여기서 별도 병합은 없다. 타입에만 명시해 호출부가 이 필드를 discover하게 한다.
+  payload?: Record<string, unknown> & { source?: string },
+) {
   await db.insert(memoryOp).values({ op: 'RECALL', noteId, payload: payload ?? null });
 }
 

--- a/tools/loop-memory/test/cli.integration.test.ts
+++ b/tools/loop-memory/test/cli.integration.test.ts
@@ -34,6 +34,9 @@ const cliEnv: NodeJS.ProcessEnv = { ...process.env };
 cliEnv.OPENAI_API_KEY = '';
 cliEnv.GEMINI_API_KEY = '';
 cliEnv.LOOP_DATABASE_URL = LOOP_DATABASE_URL; // 서브프로세스가 같은 DB를 보게
+// 이슈 #35 — '' (delete 아님, 위 두 키와 같은 이유)로 존재하되 falsy: 이 프로세스를 실행하는 셸에
+// LOOP_MEMORY_SOURCE가 export돼 있어도(예: 사람이 훅 디버깅 중) "source 없음" 테스트들이 결정적이게.
+cliEnv.LOOP_MEMORY_SOURCE = '';
 // write-path provenance(BAC-619) — 없으면 lesson recall이 fail-closed로 항상 빈 배열이라(README
 // "위협모델"), 이 CLI 서브프로세스 테스트도 고정 테스트 secret을 명시로 심어준다(실 dev 워크스테이션의
 // .env 값이 있어도 덮어써 결정적으로).
@@ -183,6 +186,95 @@ describe('cli — graduate/recall knowledge 결선 (서브프로세스 end-to-en
   });
 });
 
+// 이슈 #35: hooks/*.mjs가 CLI 서브프로세스를 spawn할 때만 LOOP_MEMORY_SOURCE=hook을 심고, cli.ts가 그
+// 값을 graduate/record-recall이 쓰는 memory_op 행의 payload.source로 흘려보내는 배관을 CLI 서브프로세스
+// 경계까지 포함해 end-to-end로 증명한다(hooks/*.mjs 자체는 별도 프로세스라 이 테스트가 흉내내는 것이
+// 실제 계약). ⚠️ 이 태그는 자기신고 메타데이터일 뿐이다 — 셸 접근이 있는 누구나 같은 env를 손으로
+// 심어 이 테스트가 검증하는 것과 동일한 payload.source="hook" 행을 만들 수 있다. 이 테스트는 배관이
+// 정확한지를 증명하는 것이지, 실제 라이브 세션에서 훅이 발동했다는 증거를 만드는 게 아니다(이슈 #35의
+// 그 부분은 여전히 미해결).
+describe('cli — LOOP_MEMORY_SOURCE env → memory_op.payload.source (issue #35, 훅 경로 표시 태그 배관)', () => {
+  it('LOOP_MEMORY_SOURCE=hook으로 graduate를 돌리면 ADD 행의 payload.source가 "hook"으로 남는다', async () => {
+    const id = randomUUID();
+    const key = `lesson:${id}`;
+    const dir = mkdtempSync(join(tmpdir(), 'loop-cli-source-tagged-'));
+    writeFileSync(
+      join(dir, `${id}.json`),
+      JSON.stringify({
+        id,
+        title: `source env 확인 교훈 ${run}`,
+        fix: 'LOOP_MEMORY_SOURCE=hook',
+        source: 'manual',
+        verified: true,
+        signature: [`source env fixture ${run}`],
+      }),
+    );
+    try {
+      const r = spawnSync(tsx, [cli, 'graduate', '--lessons', dir, '--allow-stub'], {
+        encoding: 'utf8',
+        env: { ...cliEnv, LOOP_MEMORY_SOURCE: 'hook' },
+        timeout: 30000,
+      });
+      expect(r.status).toBe(0);
+      const [note] = await db
+        .select({ id: memoryNote.id })
+        .from(memoryNote)
+        .where(sql`${key} = any(${memoryNote.keywords})`);
+      expect(note).toBeDefined();
+      const [op] = await db
+        .select({ payload: memoryOp.payload })
+        .from(memoryOp)
+        .where(and(eq(memoryOp.noteId, note?.id as string), eq(memoryOp.op, 'ADD')));
+      expect((op?.payload as Record<string, unknown> | null)?.source).toBe('hook');
+    } finally {
+      const mine = await db
+        .select({ id: memoryNote.id })
+        .from(memoryNote)
+        .where(sql`${key} = any(${memoryNote.keywords})`);
+      for (const n of mine) await softDeleteNote(db, n.id, 'test cleanup');
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('LOOP_MEMORY_SOURCE 없이(수동 CLI 호출) graduate를 돌리면 payload에 source 키가 없다', async () => {
+    const id = randomUUID();
+    const key = `lesson:${id}`;
+    const dir = mkdtempSync(join(tmpdir(), 'loop-cli-source-absent-'));
+    writeFileSync(
+      join(dir, `${id}.json`),
+      JSON.stringify({
+        id,
+        title: `source 부재 확인 교훈 ${run}`,
+        fix: '수동 CLI 호출은 LOOP_MEMORY_SOURCE를 안 심는다',
+        source: 'manual',
+        verified: true,
+        signature: [`source absent fixture ${run}`],
+      }),
+    );
+    try {
+      const r = runCli(['graduate', '--lessons', dir, '--allow-stub']); // cliEnv에는 LOOP_MEMORY_SOURCE가 ''(falsy)
+      expect(r.status).toBe(0);
+      const [note] = await db
+        .select({ id: memoryNote.id })
+        .from(memoryNote)
+        .where(sql`${key} = any(${memoryNote.keywords})`);
+      expect(note).toBeDefined();
+      const [op] = await db
+        .select({ payload: memoryOp.payload })
+        .from(memoryOp)
+        .where(and(eq(memoryOp.noteId, note?.id as string), eq(memoryOp.op, 'ADD')));
+      expect(Object.hasOwn((op?.payload ?? {}) as object, 'source')).toBe(false);
+    } finally {
+      const mine = await db
+        .select({ id: memoryNote.id })
+        .from(memoryNote)
+        .where(sql`${key} = any(${memoryNote.keywords})`);
+      for (const n of mine) await softDeleteNote(db, n.id, 'test cleanup');
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
 // BAC-586 선행 슬라이스: 훅이 실제 주입 확정한 노트 id를 memory_op에 RECALL 행으로 남기는 계측.
 // 임베더가 필요 없다(노트/거리는 훅이 이미 확정한 값을 그대로 적을 뿐) — 키 없이도 동작해야 한다.
 describe('cli — record-recall (계측, 임베더 불필요)', () => {
@@ -212,6 +304,30 @@ describe('cli — record-recall (계측, 임베더 불필요)', () => {
     } finally {
       await softDeleteNote(db, noteA.id, 'test cleanup');
       await softDeleteNote(db, noteB.id, 'test cleanup');
+    }
+  });
+
+  // 이슈 #35: hooks/recall-lessons.mjs가 record-recall 하위프로세스에 LOOP_MEMORY_SOURCE=hook을 심는
+  // 실제 경로 — 그 값이 CLI를 거쳐 payload.source로 남는지 서브프로세스 경계까지 포함해 증명한다.
+  it('LOOP_MEMORY_SOURCE=hook으로 record-recall을 돌리면 RECALL 행의 payload.source가 "hook"으로 남는다', async () => {
+    const stub = stubEmbedder();
+    const note = await addNote(db, stub, { content: `record-recall source 태그 대상 ${run}` });
+    try {
+      const hits = [{ id: note.id, distance: 0.2, corpus: 'lessons' }];
+      const r = spawnSync(tsx, [cli, 'record-recall', '--hits', JSON.stringify(hits)], {
+        encoding: 'utf8',
+        env: { ...cliEnv, LOOP_MEMORY_SOURCE: 'hook' },
+        timeout: 30000,
+      });
+      expect(r.status).toBe(0);
+      const rows = await db
+        .select()
+        .from(memoryOp)
+        .where(and(eq(memoryOp.op, 'RECALL'), eq(memoryOp.noteId, note.id)));
+      expect(rows).toHaveLength(1);
+      expect(rows[0]?.payload).toEqual({ distance: 0.2, corpus: 'lessons', source: 'hook' });
+    } finally {
+      await softDeleteNote(db, note.id, 'test cleanup');
     }
   });
 

--- a/tools/loop-memory/test/lessons.integration.test.ts
+++ b/tools/loop-memory/test/lessons.integration.test.ts
@@ -10,7 +10,7 @@ import { LOCK_NAMESPACE } from '../src/knowledge';
 import { graduateLessons, LESSON_TAG, lessonStub, recallLessons } from '../src/lessons';
 import { addNote, softDeleteNote } from '../src/ops';
 import { signContent } from '../src/provenance';
-import { memoryNote } from '../src/schema/memory';
+import { memoryNote, memoryOp } from '../src/schema/memory';
 
 // 통합 테스트(docker pgvector 필요): lessons → loop-memory 졸업을 end-to-end로 증명한다.
 // 검증된 교훈만 올라가고(검증기=천장), 재실행은 멱등이며, 의미검색으로 다시 건져진다.
@@ -446,5 +446,85 @@ describe('recallLessons — write-path provenance 방어(BAC-619, SMSR arXiv:260
       for (const n of mine) await softDeleteNote(db, n.id, 'test cleanup');
       rmSync(dir2, { recursive: true, force: true });
     }
+  });
+});
+
+// paul-loop 이슈 #35: hooks/*.mjs가 CLI를 spawn할 때 명시적으로 심는 source 태그(자기신고 메타데이터 —
+// 위조방지 신호 아님, 셸 접근이 있으면 누구든 같은 env를 손으로 심을 수 있다) 배관을 증명한다.
+// graduateLessons(..., source)가 ADD/스텁 UPDATE 행의 payload.source에 그대로 남는지, 생략 시 그
+// 키 자체가 없는지(오도하는 기본값으로 안 채움) 증명한다.
+describe('graduateLessons — source 태그가 memory_op에 남는다(issue #35, 훅 경로 표시 태그)', () => {
+  const taggedId = randomUUID();
+  const untaggedId = randomUUID();
+  const taggedKey = `lesson:${taggedId}`;
+  const untaggedKey = `lesson:${untaggedId}`;
+  let taggedDir: string;
+  let untaggedDir: string;
+
+  beforeAll(() => {
+    taggedDir = mkdtempSync(join(tmpdir(), 'loop-lessons-source-tagged-'));
+    writeFileSync(
+      join(taggedDir, `${taggedId}.json`),
+      JSON.stringify({
+        id: taggedId,
+        title: 'source 태그 대상 교훈',
+        fix: 'graduateLessons(..., source) 스레딩 확인',
+        source: 'manual',
+        verified: true,
+        signature: ['issue-35 source tagging fixture'],
+      }),
+    );
+    untaggedDir = mkdtempSync(join(tmpdir(), 'loop-lessons-source-untagged-'));
+    writeFileSync(
+      join(untaggedDir, `${untaggedId}.json`),
+      JSON.stringify({
+        id: untaggedId,
+        title: 'source 미지정 교훈',
+        fix: 'source 생략 시 payload에 키가 없어야 함',
+        source: 'manual',
+        verified: true,
+        signature: ['issue-35 source omission fixture'],
+      }),
+    );
+  });
+
+  afterAll(async () => {
+    for (const key of [taggedKey, untaggedKey]) {
+      const mine = await db
+        .select({ id: memoryNote.id })
+        .from(memoryNote)
+        .where(sql`${key} = any(${memoryNote.keywords})`);
+      for (const n of mine) await softDeleteNote(db, n.id, 'test cleanup');
+    }
+    rmSync(taggedDir, { recursive: true, force: true });
+    rmSync(untaggedDir, { recursive: true, force: true });
+  });
+
+  async function addOpPayload(key: string): Promise<Record<string, unknown> | null> {
+    const [note] = await db
+      .select({ id: memoryNote.id })
+      .from(memoryNote)
+      .where(sql`${key} = any(${memoryNote.keywords})`);
+    expect(note).toBeDefined();
+    const [op] = await db
+      .select({ payload: memoryOp.payload })
+      .from(memoryOp)
+      .where(and(eq(memoryOp.noteId, note?.id as string), eq(memoryOp.op, 'ADD')));
+    return (op?.payload as Record<string, unknown> | null) ?? null;
+  }
+
+  it('source를 넘기면 ADD 행의 payload.source에 그대로 남는다(예: 훅이 심는 "hook")', async () => {
+    const r = await graduateLessons(db, pool, embedder, taggedDir, SIGNING_KEY, 'hook');
+    expect(r.added).toBe(1);
+    const payload = await addOpPayload(taggedKey);
+    expect(payload?.source).toBe('hook');
+  });
+
+  it('source를 생략하면 payload에 source 키 자체가 없다(오도하는 기본값으로 안 채운다)', async () => {
+    const r = await graduateLessons(db, pool, embedder, untaggedDir, SIGNING_KEY);
+    expect(r.added).toBe(1);
+    const payload = await addOpPayload(untaggedKey);
+    expect(payload).not.toBeNull();
+    expect(payload && Object.hasOwn(payload, 'source')).toBe(false);
   });
 });

--- a/tools/loop-memory/test/recall.integration.test.ts
+++ b/tools/loop-memory/test/recall.integration.test.ts
@@ -45,6 +45,30 @@ describe('loop-memory recall (pgvector)', () => {
       .where(and(eq(memoryOp.noteId, note.id), eq(memoryOp.op, 'RECALL')));
     expect(rows).toHaveLength(1);
     expect(rows[0]?.payload).toEqual({ distance: 0.123, corpus: 'lessons' });
+    // 이슈 #35: source를 안 넘기면 payload에 그 키 자체가 없어야 한다(오도하는 기본값 금지) — jsonb
+    // 왕복(JSON.stringify가 undefined 값을 드롭)까지 거친 뒤의 실제 컬럼 값으로 확인한다.
+    expect(Object.hasOwn((rows[0]?.payload ?? {}) as object, 'source')).toBe(false);
+
+    await softDeleteNote(db, note.id, 'test cleanup');
+  });
+
+  // 이슈 #35: hooks/recall-lessons.mjs가 실제로 주입-확정한 노트를 record-recall로 남길 때만
+  // LOOP_MEMORY_SOURCE=hook을 심는다(cli.ts) — 그 값이 recordRecall을 거쳐 payload.source로 남는지
+  // ops.ts 레벨에서 직접 증명한다(cli.integration.test.ts는 CLI 서브프로세스 경유로 같은 경로를 증명).
+  it('recordRecall에 source를 넘기면 payload.source로 그대로 남는다(훅 경로 표시 태그, 자기신고)', async () => {
+    const note = await addNote(db, embedder, {
+      content: '회상 계측 대상 노트 — source 태그(issue #35)',
+      tags: ['lesson'],
+    });
+
+    await recordRecall(db, note.id, { distance: 0.045, corpus: 'knowledge', source: 'hook' });
+
+    const rows = await db
+      .select()
+      .from(memoryOp)
+      .where(and(eq(memoryOp.noteId, note.id), eq(memoryOp.op, 'RECALL')));
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.payload).toEqual({ distance: 0.045, corpus: 'knowledge', source: 'hook' });
 
     await softDeleteNote(db, note.id, 'test cleanup');
   });


### PR DESCRIPTION
Contributes to #35 — 이 PR 머지 후에도 이슈 #35는 닫히지 않습니다(아래 이유).

## 배경

harness-maturity-audit(PR #31)이 발견한 major: loop-memory 훅이 실제 라이브 세션에서 발동한 증거가
전무 — DB에 있는 294행은 전부 통합테스트 픽스처와 문자열이 일치, 실사용 흔적이 아님.

## 이 PR이 하는 것과 하지 않는 것

**하는 것**: `memory_op.payload`(기존 jsonb 컬럼, 스키마 마이그레이션 없음)에 `source` 태그를
추가 — `hooks/graduate-lessons.mjs`/`recall-lessons.mjs`가 `dist/cli.js` 서브프로세스를 스폰할 때
`LOOP_MEMORY_SOURCE=hook`을 설정하고, 이게 `cli.ts` → `lessons.ts`/`knowledge.ts` → `ops.ts`를
거쳐 최종 `memory_op` 행에 남는다. 앞으로 훅이 실제로 발동하면 그 흔적이 테스트 픽스처와 구분 가능해짐.

**하지 않는 것 — 그리고 왜**: 이 태그는 **위조 방지가 아니다**. 셸 접근 권한이 있는 누구든
`LOOP_MEMORY_SOURCE=hook node dist/cli.js graduate ...`를 손으로 쳐서 동일한 행을 만들 수 있다(1라운드
적대적 검증에서 실제로 재현·확인됨). 이 코드베이스엔 다른 필드(`provenance`)에 HMAC 서명이 이미
있지만, 이걸 `source`에도 적용하는 건 문제를 안 푼다 — 서명키를 가진 사람은 훅 없이도 똑같이 위조된
서명을 만들 수 있기 때문("서명키 보유"와 "실제 훅이 발동함"은 다른 명제). Claude Code는 훅 호출을
플러그인에 암호학적으로 인증해주지 않는다 — 그런 시크릿 자체가 존재하지 않는다. 그래서 이 태그는
"선의의 self-reported 관측 메타데이터"로만 문서화했고, 커밋 트레일러도 `Closes #35`가 아니라
`Contributes to #35`로 바꿨다 — 이슈의 실제 요구(실제 라이브 세션에서 훅이 발동한 증거)는 여전히
미해결이다(이 레포에 `.claude/settings.json`으로 loop-memory를 활성화한 적이 아직 없음).

## 적대적 검증 (2라운드)

- **라운드 1**: BYPASSABLE — 위 스푸핑 가능성 + 정직하지 않은 `Closes #35` 트레일러.
- **라운드 2**: SAFE — 문서/주석을 정직하게 재작성, 트레일러를 `Contributes to`로 교체, 배관 자체는
  그대로 유지. 유닛 72/72, 통합 49/49 재확인.

## 검증

```
$ cd tools/loop-memory && npm test
72 passed | 2 skipped
$ npm run test:integration   # docker pgvector
49 passed
```

머지는 하지 않고 여기서 멈춥니다 — 사람 확인 대기. **머지 후에도 이슈 #35는 자동으로 안 닫히니,
사람이 판단해서 닫거나 열어두시면 됩니다.**
