### PR TITLE
release-prep: dangling doc refs, upstream ADR-0104/0062-9 rationale, version bump (BAC-758)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,21 +12,21 @@
       "name": "loop-engine",
       "source": "./tools/loop-engine",
       "description": "Core loop mechanics: verdict-run (machine-readable PASS/FAIL contract), loop-fix (closed verify->fix loop), lessons (verified-fix memory), classify-risk, require-tests. No framework opinions beyond \"the verifier is the ceiling, never the agent's self-report\".",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "keywords": ["verifier", "tdd", "loop", "verdict", "lessons"]
     },
     {
       "name": "ship-flow",
       "source": "./tools/ship-flow",
       "description": "Delivery-loop skills — ship-feature (plan-to-PR autonomous loop), hotfix, retrospect, grill-with-docs, deps-audit, to-issues/to-prd, tdd, harness-maturity-audit, improve-codebase-architecture, resolving-merge-conflicts, plus review agents and audit/research workflows — parameterized by a consuming repo's own tracker/branch-model config instead of hardcoded to one repo. dependencies: loop-engine.",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "keywords": ["delivery", "git-flow", "hotfix", "ship", "release"]
     },
     {
       "name": "loop-memory",
       "source": "./tools/loop-memory",
       "description": "pgvector semantic recall for verified dev-loop lessons (and, optionally, ADR/glossary/research knowledge). Opt-in / defaultEnabled:false — a database dependency, not core loop mechanics.",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "defaultEnabled": false,
       "keywords": ["memory", "pgvector", "recall", "semantic-search", "lessons"]
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,53 @@ Explicit-version channel — see [README § Development status](README.md#develo
 not a SHA channel. Entries below `## loop-engine 0.2.0` and earlier predate the multi-plugin split
 and refer to `loop-engine` only (see the un-prefixed version numbers).
 
+## loop-engine 0.3.0
+
+- AC-level success contract gate — `bin/ac-verify.sh` (ADR-0006, #23): per-AC `verify:`/
+  `artifacts:`/`expect:` contracts parsed from a plan file, judged by deterministic subprocess
+  (reusing `verdict-run.sh` per AC), aggregated into one pass/fail. Composes with, doesn't replace,
+  the observe-the-running-app check — zero contracted ACs on a runtime-surface plan is fail-closed.
+- `bin/verifier-pinned-review.sh` + CODEOWNERS-based reinterpretation (#14): pins base-revision
+  tests against self-weakening (bin/+test loosened together in the same PR), hardened through
+  several adversarial rounds (TOCTOU close, CODEOWNERS-deletion-at-same-commit still caught,
+  unresolvable BASE is a hard error rather than a silent PASS).
+- `loop-fix --protect` hardened through six adversarial rounds: ground truth moved off tamperable
+  on-disk files into process memory, restores a tampered/deleted protected file before aborting
+  (not just detects it), now also runs the check on the PASS path (not just FAIL), a bounded
+  grace-period recheck on both paths, and closes a watchdog-vs-grace-period race plus a
+  VERDICT-RUN-ERROR abort gap.
+- `lessons` hygiene: `invalidate`/`mark-clean` commands (#6), fail-closed `record --verified`
+  without `--signature-file` (#9), FAIL-channel lesson auto-collection wired into `loop-fix` (#10),
+  and a grounded-reopen convention (a retired lesson or rejected challenge needs a cited id + new
+  evidence to reopen — a plain recurrence isn't reopening evidence).
+- tier0 harness self-smoke gate (#7).
+- ADR-0006/0007 (rationale for `ac-verify.sh` and loop-memory's manual-recall env sharing, ported
+  upstream from a consuming repo — BAC-758) and a new `test/dangling-doc-refs.test.sh` regression
+  guard against skill/doc examples pointing at consumer-repo-only paths (`tools/plugin-path.mjs`,
+  `.claude/hooks/*`, `bin/loop-doctor.mjs`) as if this plugin ships them.
+
+## ship-flow 0.2.0
+
+- `publisher` subagent for ship-feature step 5 (#15): the Builder session — which has held
+  untrusted issue/web content and full worktree access since step 0 — no longer runs the
+  `git push`/PR-open/tracked-issue-comment itself. It hands off file-based title/body/comment text
+  to a separate `publisher` agent instead, closing a heredoc-injection risk class (adversarial
+  rounds closed a heredoc-to-variable handoff gap and a conflict-retry push gap).
+- Grounded-reopen convention documented in `retrospect` (#9/#11): a retired lesson or rejected
+  challenge needs a cited id + genuinely new evidence to reopen.
+- Consumes loop-engine 0.3.0's `ac-verify.sh` (ADR-0006) — `ship-feature` step 1 plans now express
+  AC contracts, step 3 runs `ac-verify.sh` against them.
+- `retrospect`/`deps-audit` SKILL.md examples now disclaim that `tools/plugin-path.mjs` is a
+  consuming-repo convention, not something this plugin ships (BAC-758 B7).
+
+## loop-memory 0.2.0
+
+- Sleep-time consolidation batch (#12): dedup, decay-based ranking, promotion pre-scoring.
+- Hook-fired graduate/recall writes now tag their source in `memory_op.payload.source`.
+- ADR-0007 documenting why the manual `recall` CLI shares the hooks' env source and fails closed
+  without an embedding key, rather than silently querying with a stub embedder (ported rationale,
+  BAC-758).
+
 ## loop-memory 0.1.0 — M3 scaffold
 
 - Initial extraction of `loop-memory` (pgvector semantic recall for verified lessons + optional

--- a/docs/adr/0006-ac-level-success-contract.md
+++ b/docs/adr/0006-ac-level-success-contract.md
@@ -1,0 +1,64 @@
+# ADR-0006: AC 단위 success contract(`ac-verify.sh`) — plan 파일이 정본
+
+**상태**: accepted (구현 완료 — `bin/ac-verify.sh`)
+
+**출처**: glucofit-partners ADR-0104(2026-08-19 grill 세션, BAC-625)에서 이관·요약. 결정 5("구현은
+paul-loop 소유")가 이미 실행돼 `ac-verify.sh`가 이 레포 `tools/loop-engine/bin/`에 착지했으므로,
+그 레포에만 있던 근거를 이 레포 자신의 ADR로 옮겨 플러그인이 자기 결정 근거를 자기 안에 갖게 한다
+(BAC-758 A8). 원문 근거·기각 대안의 전체 논증은 원본 ADR-0104를 참고 — 여기서는 이 레포 관점의
+결정 골자만 정리한다.
+
+## 컨텍스트
+
+`/ship-feature`의 3단계(Runtime verify)는 원래 에이전트의 자유형식 자기판단이었다 — "앱을 실행하고
+확인했다"는 자기보고를, 검증기가 아니라 에이전트 자신이 판정했다. ouroboros(별도 하네스)의
+`_run_ac_verify_gate`가 AC마다 `verify_command`/`expected_artifacts`/`output_assertion` 계약을
+오케스트레이터가 직접 subprocess로 판정하는 패턴을 실물로 검증했지만, 동시에 함정도 실측했다 — 선택적
+계약 필드는 crystallize 시점 LLM이 채우지 않는 경우가 흔해, 결정론 게이트가 있어도 아무도 안 쓰면
+장식이 된다(seed AC 9건 전부 contract 0건).
+
+## 결정
+
+이슈/플랜 AC에 기계 판독 가능한 한 줄 계약 문법을 도입한다:
+
+```
+AC: <설명> | verify: <명령> | artifacts: <경로1>,<경로2> | expect: <부분문자열>
+```
+
+1. **정본은 워크트리 plan 파일**(ship-feature step 1 산출물). 트래커(Linear 등) AC prose는 같은
+   문법의 사람이 읽는 사본일 뿐 — verify 루프가 매 반복 트래커 API에 의존하면 CI·fresh clone에서
+   못 돈다(재현성 원칙과 동형).
+2. **repo-wide verify 명령을 대체하지 않는 추가 게이트** — ship-feature 3단계를 형식화한다. 계약이
+   선언된 AC에 한해 결정론 subprocess 판정이 에이전트 자기판단을 대체하고, repo-wide verify는 매
+   커밋 무조건 걸리는 별개의 바닥으로 남는다.
+3. **실행 주체는 `ac-verify.sh`** — AC마다 `verdict-run.sh`를 하위 호출해 재사용하고 그 위에 아티팩트
+   실존·output substring 판정과 전체 집계를 얹는다. `verdict-run.sh` 자신은 "ANY 단일 명령" 계약을
+   유지하며 확장하지 않는다.
+4. **계약 0건 = fail-closed**(`require-tests.sh`의 "0테스트=RED"와 동형). 런타임 표면이 없는
+   docs-only 트랙은 면제. 런타임 표면이 있는 트랙(consuming repo의 위험 분류 기준으로)은 plan
+   전체에 최소 1개 이상 계약이 있어야 3단계 게이트가 PASS(SKIP 아님)한다 — 모든 AC 개별에 계약을
+   요구하지는 않는다.
+
+## 근거
+
+ouroboros가 실물로 증명한 함정("선택적 계약 필드는 아무도 안 채운다")과 이 레포에 이미 있는 선례
+(`require-tests.sh`의 "0=RED" 강제)가 같은 결론을 가리킨다 — fail-closed 없이는 결정론 게이트가
+장식이 된다.
+
+## 고려했으나 기각한 대안
+
+- **트래커 AC prose 직접 파싱** — 트래커 API 의존(CI 미접근) + 리치텍스트 에디터의 raw pipe 문법
+  이스케이프 위험.
+- **`verdict-run.sh` 확장** — 단일-명령 계약이 깨지고 로직이 과밀해진다.
+- **계약 없는 AC 허용 + self-review 표식만** — ouroboros가 이미 실패를 실측으로 증명한 경로.
+
+## 재검토 트리거
+
+`ac-verify.sh`가 소비 레포의 실제 ship-feature 플로우에 배선되는 사례가 누적되면, 위 4개 결정이
+실제 사용 패턴과 정합하는지 재확인한다(특히 "최소 1건" 기준이 너무 느슨/엄격하지 않은지).
+
+## 참고
+
+- 원본: glucofit-partners `docs/adr/0104-ac-level-success-contract-plan-file-is-source-paul-loop-owns-implementation.md`
+- 구현: `bin/ac-verify.sh`, `test/ac-verify.test.sh`
+- BAC-625(원 이슈), [2026-08-04 ouroboros benchmarking §4.1](glucofit-partners docs/research/2026-08-04-ouroboros-benchmarking.md)(채택 O2)

--- a/docs/adr/0007-manual-semantic-recall-shares-hook-env-fail-closed.md
+++ b/docs/adr/0007-manual-semantic-recall-shares-hook-env-fail-closed.md
@@ -1,0 +1,56 @@
+# ADR-0007: 수동 의미 회상 CLI(`loop-memory recall`)는 훅과 같은 env를 보고, 못 보면 fail-closed
+
+**상태**: accepted (구현 완료 — `tools/loop-memory/src/cli.ts`)
+
+**출처**: glucofit-partners ADR-0062 결정 9에서 이관·요약(BAC-758 A8). 원문 근거·트레이드오프의 전체
+논증은 원본 ADR-0062를 참고 — 여기서는 이 레포(loop-memory 구현체) 관점의 결정 골자만 정리한다.
+
+## 컨텍스트
+
+loop-memory는 SessionStart/UserPromptSubmit 훅이 자동으로 임베딩 API 키(`OPENAI_API_KEY`/
+`GEMINI_API_KEY`)를 읽어 verified 파일-lesson을 벡터 스토어로 graduate하고, 세미antically 가까운
+lesson을 프롬프트에 주입한다. 이와 별개로, 사람이 손으로 질의하는 `loop-memory recall` CLI가 있다 —
+이 CLI가 훅과 **다른** 방식으로 env를 읽으면(예: 셸 export 의존), 훅은 실 임베더로 정상 동작하는데
+수동 CLI만 키를 못 찾아 스텁 임베더로 조용히 돌아가는 상황이 생긴다. 스토어는 실 임베더 벡터로 채워져
+있는데 질의만 스텁이면, 결과는 *비어 있는* 게 아니라 코사인 거리가 무의미해진 채로 **조용히 틀린**
+결과를 정상처럼 반환한다.
+
+## 결정
+
+두 겹으로 고친다:
+
+1. **`.env`를 훅과 같은 소스에서 로드한다** — CLI가 훅의 env 로더와 동일한 파일(예:
+   `tools/loop-memory/.env`)을 읽어, 문서화된 수동 명령이 셸 export 없이도 훅과 **같은 임베더**로
+   돈다.
+2. **그래도 키가 없으면 거부한다(fail-closed)** — 명시적 opt-in(`--allow-stub`) 없이는 조회하지
+   않고 0이 아닌 종료코드로 끝난다. stderr 경고 한 줄로는 부족하다 — JSON 출력 자체는 정상처럼
+   보이기 때문이다. `--allow-stub`을 켜면 경고와 함께 스텁으로 진행하되, "이건 의미 회상이 아니다"를
+   명시적으로 알린다.
+
+이것은 파일 기반 서명 회상의 miss 처리(정확한 실패를 stderr 힌트로만 알리고 exit code는 그대로 두는
+것)와 **의도적으로 비대칭**이다. 서명 회상의 miss는 *없음*을 정확히 보고하므로 힌트로 충분하지만,
+스텁 질의는 *틀린 것을 있음으로* 보고한다. 조용한 오답에는 fail-closed가 맞다.
+
+## 근거
+
+- 조용한 오답은 침묵보다 나쁘다 — 없는 결과는 사람이 다시 찾아보게 만들지만, 그럴듯하게 틀린 결과는
+  신뢰되고 그대로 쓰인다.
+- 훅과 CLI가 다른 env를 보면, "왜 훅은 되는데 수동 질의는 안 되지"라는 디버깅 비용이 반복 발생한다 —
+  같은 소스를 보게 하는 것 자체가 그 계열의 혼란을 구조적으로 없앤다.
+
+## 고려했으나 기각한 대안
+
+- **스텁 임베더로 항상 조용히 진행 + stderr 경고 한 줄** — 기각. JSON이 정상처럼 보여 경고를 놓치기
+  쉽고, "결과가 있음"이 곧 "신뢰할 만함"으로 오인되기 쉽다.
+- **CLI가 셸 export만 신뢰(훅과 별개 env 소스 유지)** — 기각. 훅/CLI 간 동작 불일치가 반복 재발하는
+  근본 원인을 안 고친다.
+
+## 재검토 트리거
+
+CLI와 훅이 다시 다른 env 소스를 보게 되는 변경(예: 훅 쪽 로더 리팩터)이 생기면, 이 ADR의 "같은
+소스" 전제가 여전히 성립하는지 재확인한다.
+
+## 참고
+
+- 원본: glucofit-partners `docs/adr/0062-signature-recall-vs-semantic-recall-liveness.md` 결정 9
+- 구현: `tools/loop-memory/src/cli.ts`, `tools/loop-memory/test/cli-embedder-gate.test.ts`

--- a/tools/loop-engine/.claude-plugin/plugin.json
+++ b/tools/loop-engine/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "loop-engine",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Core loop mechanics: verdict-run (machine-readable PASS/FAIL contract), loop-fix (closed verify->fix loop), lessons (verified-fix memory), classify-risk, require-tests. verifier=ceiling — the agent's self-judgement never substitutes for it.",
   "author": {
     "name": "paulkim-lansik"

--- a/tools/loop-engine/bin/lessons.mjs
+++ b/tools/loop-engine/bin/lessons.mjs
@@ -45,7 +45,8 @@
 //                   stays clean of advisory signals).
 //   lessons retire --id <key> [--ref "<where codified>"] [--by "<who>"] [--lessons <dir>]
 //                   (Phase 4, TERMINAL) retire an accepted+codified lesson from the promotion pool so it
-//                   stops re-surfacing (promote listing / --codify / loop-doctor). Fail closed: only a
+//                   stops re-surfacing (promote listing / --codify / a consumer-repo health-check
+//                   script, if present). Fail closed: only a
 //                   verified lesson with a recorded `challenge --verdict accept` may retire.
 //   lessons invalidate --id <key> [--reason "<why>"] [--superseded-by <id2>] [--by "<who>"] [--lessons <dir>]
 //                   Mark a lesson WRONG (the lesson itself was incorrect) — distinct from `retire`
@@ -350,8 +351,9 @@ if (cmd === 'challenge') {
 if (cmd === 'retire') {
   // Phase 4, TERMINAL: mark a lesson as codified into a skill / CLAUDE.md guideline. This RETIRES it
   // from the promotion pool — `promote` (listing + --codify) and `stats` open-candidate count exclude
-  // retired lessons, so a once-codified lesson stops re-surfacing forever (no loop-doctor false-nag,
-  // no double-codification). This is the third gate: the verified+recurring floor gates ENTRY, the
+  // retired lessons, so a once-codified lesson stops re-surfacing forever (no false-nag from a
+  // consumer-repo health-check script, if present, no double-codification). This is the third gate:
+  // the verified+recurring floor gates ENTRY, the
   // recorded accept gates EXIT to codification, and `retire` gates removal from the candidate pool.
   // Fail closed: only a lesson the skeptic has ACCEPTED (verified + challenge.verdict==='accept') may be
   // retired — you cannot retire something that was never cleared to codify.
@@ -580,8 +582,9 @@ if (cmd === 'stats') {
   // open_candidates = the ACTIONABLE promotion backlog: verified + recurring, and in NONE of the
   // terminal/excluded states — not already retired (codified, out of the pool), not invalidated (WRONG,
   // issue #6 — same exclusion as promote's `candidates`, so this count never claims more "승격 후보"
-  // than `promote` would actually list), and not rejected (skeptic decided no). This is what loop-doctor
-  // reports as "승격 후보"; it falls to 0 once every recurring lesson is either codified+retired,
+  // than `promote` would actually list), and not rejected (skeptic decided no). This is what a
+  // consumer-repo health-check script (if present) would report as "승격 후보"; it falls to 0 once
+  // every recurring lesson is either codified+retired,
   // invalidated, or rejected, instead of the raw recurring count that never falls (a permanent
   // false-nag pre-retire). A rejected lesson re-opens automatically if it recurs with changed content
   // (record clears the stale verdict), so excluding it here loses nothing.

--- a/tools/loop-engine/bin/regression-signals.mjs
+++ b/tools/loop-engine/bin/regression-signals.mjs
@@ -3,7 +3,8 @@
 // CLI (BAC-631). 로직은 lib/regression-signals.mjs(순수 fold — 계약·신뢰 경계는 그 헤더 필독).
 //
 // Usage: node regression-signals.mjs [--runs-dir <dir>] [--json]
-// 항상 exit 0(usage만 2) — 계측 조회가 파이프라인을 깨면 안 된다(run-metrics/loop-doctor 관례).
+// 항상 exit 0(usage만 2) — 계측 조회가 파이프라인을 깨면 안 된다(run-metrics 관례이자, 소비
+// 레포의 health-check 스크립트 관례 — 예: loop-doctor. 이 플러그인이 직접 제공하지는 않는다).
 // 출력은 게이트명 정렬·키 순서 고정 — 같은 원장에 대한 재실행은 byte-identical(결정론).
 
 import { join } from 'node:path'

--- a/tools/loop-engine/bin/run-metrics.mjs
+++ b/tools/loop-engine/bin/run-metrics.mjs
@@ -2,7 +2,8 @@
 // run-metrics.mjs — .loop/runs/*.jsonl 원장 fold 집계 (BAC-570 H1·Q1·Q2). read-only.
 //
 // Usage: node run-metrics.mjs [--runs-dir <dir>] [--json]
-// 항상 exit 0(usage만 2) — 계측 조회가 파이프라인을 깨면 안 된다(loop-doctor 관례).
+// 항상 exit 0(usage만 2) — 계측 조회가 파이프라인을 깨면 안 된다(소비 레포의 health-check 스크립트
+// 관례 — 예: loop-doctor. 이 플러그인이 직접 제공하지는 않는다).
 //
 // 지표(이슈 570a):
 //   H1 = 런당 인간 개입 수 = permission.requested 중 경계 표면(merge/deploy/send) 제외분 —

--- a/tools/loop-engine/bin/verdict-run.sh
+++ b/tools/loop-engine/bin/verdict-run.sh
@@ -84,8 +84,9 @@ case "$LOG" in
 esac
 
 # ---- verdict freshness state (BAC-564 AC5) ----
-# Record WHAT this verdict verified — HEAD sha, worktree dirtiness, timestamp, command — so the
-# Stop-hook gate (.claude/hooks/gate-stop-verdict.mjs) can refuse FAIL / stale / dirty PASS
+# Record WHAT this verdict verified — HEAD sha, worktree dirtiness, timestamp, command — so a
+# consumer-repo Stop-hook gate (e.g. .claude/hooks/gate-stop-verdict.mjs, if this repo provides
+# one — this plugin does not ship a Stop hook itself) can refuse FAIL / stale / dirty PASS
 # replays at turn-end (stale-green guard, BAC-581 lineage). Best-effort: a state-write failure
 # never changes the verdict or this wrapper's exit code.
 STATE_FILE="${LOOP_DIR:-.loop}/verdict-state.json"

--- a/tools/loop-engine/docs/lessons.md
+++ b/tools/loop-engine/docs/lessons.md
@@ -139,6 +139,7 @@ domain lesson graduates to pgvector and gets recalled exactly like a verified en
 - A *separate skeptical evaluator* agent can be added to challenge a promotion candidate before it
   becomes a skill; the verified-only + recurrence rules are the deterministic floor it builds on.
 - Once codified, `lessons retire --id <id> --ref "<where>"` marks it TERMINAL so it stops re-surfacing
-  (`promote` listing / `--codify` / loop-doctor's "promotion candidates"). Three gates in all: verified+recurring
+  (`promote` listing / `--codify` / a consumer-repo heartbeat's "promotion candidates" nudge, if this
+  repo has one). Three gates in all: verified+recurring
   floor gates ENTRY, a recorded `accept` gates codification, and `retire` gates removal from the pool —
   so the candidate backlog reflects real open work, not a monotonic pile of already-done lessons.

--- a/tools/loop-engine/docs/orchestrate.md
+++ b/tools/loop-engine/docs/orchestrate.md
@@ -15,8 +15,8 @@ nightly runs needed a local cron driver) both collapsed: `/ship-feature` runs th
 plan→implement→verify→review→improve flow autonomously in-session, calling `bin/classify-risk.sh`
 (built on `gate.mjs`) before each stage instead of a `--<stage>-risk` flag, and ADR-0060 moved
 unattended nightly runs to a **cloud routine** that wakes an agent rather than a headless script. See
-[`.claude/skills/ship-feature/SKILL.md`](../../../.claude/skills/ship-feature/SKILL.md) for the
-current driver.
+[`ship-feature/SKILL.md`](../../ship-flow/skills/ship-feature/SKILL.md) (this plugin's `ship-flow`
+package) for the current driver.
 
 ## 1. The gate decision rule (`bin/gate.mjs`)
 

--- a/tools/loop-engine/docs/otel.md
+++ b/tools/loop-engine/docs/otel.md
@@ -16,10 +16,16 @@ rejected.)
 
 | Piece | Role | Locked by |
 |---|---|---|
-| `.claude/settings.json` `env` block | Claude Code process-scoped OTel config (shell-wide export forbidden) | `test/otel-hygiene.test.sh` |
+| `.claude/settings.json` `env` block | Claude Code process-scoped OTel config (shell-wide export forbidden) | consumer-repo hygiene test, if this repo has one† |
 | `bin/otel-receiver.mjs` | OTLP/HTTP(json) receiver — **127.0.0.1-only bind**, zero-dep, 0 docker | `test/otel-receiver.test.sh` |
 | `bin/otel-metrics.mjs` | `.loop/otel/*.jsonl` → H2/C1/C2 aggregation (read-only, missing data = INSUFFICIENT_DATA) | `test/otel-receiver.test.sh` |
-| `bin/loop-doctor.mjs` OTEL row | crit if any content flag is on (dashboard, read-only) | `test/otel-hygiene.test.sh` |
+| `bin/loop-doctor.mjs` OTEL row† | crit if any content flag is on (dashboard, read-only) | consumer-repo hygiene test, if this repo has one† |
+
+† `loop-doctor.mjs` and its `otel-hygiene`-style test are not shipped by this plugin — they're a
+consumer-repo convention (a repo-owned health-check script that reads this plugin's OTel config and
+fails loudly on a content-flag misconfiguration). Build one if this repo wants that guardrail;
+otherwise the `.claude/settings.json` env block and the content-flag discipline below still apply,
+just without a standing machine check.
 
 ## Starting the receiver — opt-in (not started by default)
 

--- a/tools/loop-engine/docs/verdict-contract.md
+++ b/tools/loop-engine/docs/verdict-contract.md
@@ -63,9 +63,10 @@ results — the contract is the integration point, the script is just one conven
 
 Alongside the stdout block, `verdict-run.sh` writes `.loop/verdict-state.json` on every run:
 `{verdict, exit, sha, dirty, finished_at, cmd, log}` — *what* was verified (HEAD sha at verify
-time, whether the worktree was dirty) and *when*. Consumer: the Stop-hook gate
-(`.claude/hooks/gate-stop-verdict.mjs`) refuses to let a loop-armed (`.loop/looping`) turn end
-unless the state is a **fresh PASS** (PASS ∧ recorded sha == current HEAD ∧ recorded clean ∧
+time, whether the worktree was dirty) and *when*. Consumer: a Stop-hook gate — e.g.
+`.claude/hooks/gate-stop-verdict.mjs` if this repo provides one (this plugin does not ship a
+Stop hook itself) — that refuses to let a loop-armed (`.loop/looping`) turn end unless the state
+is a **fresh PASS** (PASS ∧ recorded sha == current HEAD ∧ recorded clean ∧
 tree clean now) — a stale or dirty PASS (including cache replays) is treated the same as FAIL.
 The state file is listed in `.loop/protect.globs`, so the in-session guard denies an agent
 forging it; that guard is a guardrail, not a boundary (ADR-0036). Do **not** pass

--- a/tools/loop-engine/test/dangling-doc-refs.test.sh
+++ b/tools/loop-engine/test/dangling-doc-refs.test.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Link-check: docs (skills/agents/*.md under tools/*) must not point a consuming repo at a
+# consumer-repo-owned path (bin/plugin-path.mjs, .claude/hooks/*.mjs, bin/loop-doctor.mjs, ...) as
+# if this plugin ships it (BAC-758 B7 — traced to real breakage: retrospect/deps-audit/ship-feature
+# examples referenced tools/plugin-path.mjs, docs/verdict-contract.md and docs/otel.md referenced
+# .claude/hooks/gate-stop-verdict.mjs and bin/loop-doctor.mjs, none of which exist in this repo).
+#
+# A reference is fine if EITHER (a) the path actually exists under one of this repo's plugin dirs,
+# or (b) the same markdown file carries a hedge disclaiming plugin ownership somewhere in it (the
+# convention this repo uses: one disclaimer near the top of a skill/doc, not repeated at every
+# call site). This is a regression guard, not an install-time integration test — it can't prove a
+# hedge is *correctly worded*, only that a bare, unqualified dangling reference doesn't silently
+# come back.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$HERE/../../.."
+
+fail() { echo "FAIL: $1"; exit 1; }
+
+node -e '
+  const fs = require("fs");
+  const path = require("path");
+
+  const root = process.argv[1];
+  const pluginDirs = ["tools/loop-engine", "tools/ship-flow", "tools/loop-memory"];
+
+  const SCAN_ROOTS = [
+    "tools/loop-engine/docs",
+    "tools/ship-flow/skills",
+    "tools/ship-flow/agents",
+    "tools/ship-flow/workflows",
+  ];
+
+  const HEDGE_RE = /if this repo|consumer-repo|consumer repo|however this repo|does not ship|convention|otherwise invoke|if present|if provided|was retired|retired \(|was removed/i;
+
+  // bin/<name>.(mjs|sh) and test/<name>.test.sh — real if present under any plugin dir.
+  const RELATIVE_PATTERNS = [/\bbin\/[\w.-]+\.(?:mjs|sh)\b/g, /\btest\/[\w.-]+\.test\.sh\b/g];
+  // .claude/hooks/* is never something a plugin ships (it names the CONSUMING repo'\''s own
+  // .claude/ namespace) — always requires a hedge, no existence bypass.
+  const ALWAYS_HEDGE_PATTERNS = [/\.claude\/hooks\/[\w.-]+\.mjs\b/g, /\btools\/plugin-path\.mjs\b/g];
+
+  function existsUnderAnyPluginDir(rel) {
+    return pluginDirs.some((d) => fs.existsSync(path.join(root, d, rel)));
+  }
+
+  function walk(dir, out) {
+    if (!fs.existsSync(dir)) return out;
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) walk(full, out);
+      else if (entry.isFile() && entry.name.endsWith(".md")) out.push(full);
+    }
+    return out;
+  }
+
+  const files = SCAN_ROOTS.flatMap((r) => walk(path.join(root, r), []));
+  const violations = [];
+
+  for (const file of files) {
+    const text = fs.readFileSync(file, "utf8");
+    const hedged = HEDGE_RE.test(text);
+    const rel = path.relative(root, file);
+
+    for (const re of RELATIVE_PATTERNS) {
+      for (const m of text.matchAll(re)) {
+        if (existsUnderAnyPluginDir(m[0])) continue;
+        if (hedged) continue;
+        violations.push(`${rel}: "${m[0]}" does not exist under any plugin dir and file has no hedge`);
+      }
+    }
+    for (const re of ALWAYS_HEDGE_PATTERNS) {
+      for (const m of text.matchAll(re)) {
+        if (hedged) continue;
+        violations.push(`${rel}: "${m[0]}" is never plugin-shipped and file has no hedge`);
+      }
+    }
+  }
+
+  if (violations.length > 0) {
+    console.error(violations.join("\n"));
+    process.exit(1);
+  }
+  console.log(`PASS: ${files.length} doc(s) scanned, no unhedged dangling references`);
+' "$ROOT" || fail "dangling consumer-repo references found in docs (see above)"

--- a/tools/loop-memory/.claude-plugin/plugin.json
+++ b/tools/loop-memory/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "loop-memory",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "pgvector semantic recall for verified dev-loop lessons (and, optionally, ADR/glossary/research knowledge). Opt-in: installs disabled by default — this is a database dependency, not core loop mechanics.",
   "author": {
     "name": "paulkim-lansik"
@@ -10,7 +10,7 @@
   "license": "MIT",
   "keywords": ["memory", "pgvector", "recall", "semantic-search", "lessons"],
   "defaultEnabled": false,
-  "dependencies": [{ "name": "loop-engine", "version": "^0.2.0" }],
+  "dependencies": [{ "name": "loop-engine", "version": "^0.3.0" }],
   "userConfig": {
     "openai_api_key": {
       "type": "string",

--- a/tools/ship-flow/.claude-plugin/plugin.json
+++ b/tools/ship-flow/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ship-flow",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Delivery-loop skills — land and release already-verified work through a repo's real gates. Tracker- and branch-model-agnostic: reads a consuming repo's own config instead of hardcoding one repo's setup.",
   "author": {
     "name": "paulkim-lansik"
@@ -10,6 +10,6 @@
   "license": "MIT",
   "keywords": ["delivery", "git-flow", "hotfix", "ship", "release"],
   "dependencies": [
-    { "name": "loop-engine", "version": "^0.2.0" }
+    { "name": "loop-engine", "version": "^0.3.0" }
   ]
 }

--- a/tools/ship-flow/skills/deps-audit/SKILL.md
+++ b/tools/ship-flow/skills/deps-audit/SKILL.md
@@ -9,7 +9,7 @@ Answers whether each installed extension **(1) is maintained upstream, (2) is yo
 
 ## Run
 
-Run this repo's installed loop-engine plugin's `deps-audit` script — invoked however this repo resolves plugin bin scripts. The example below uses the `tools/plugin-path.mjs exec` wrapper this plugin itself relies on; a repo that installs loop-engine a different way may invoke it differently:
+Run this repo's installed loop-engine plugin's `deps-audit` script — invoked however this repo resolves plugin bin scripts. The example below uses the `tools/plugin-path.mjs exec` wrapper convention some consuming repos provide (this plugin does not ship `plugin-path.mjs` itself); a repo that installs loop-engine a different way may invoke it differently:
 
 ```bash
 node tools/plugin-path.mjs exec bin/deps-audit.mjs                      # fast — local manifests + usage + gh freshness (no clone)

--- a/tools/ship-flow/skills/retrospect/SKILL.md
+++ b/tools/ship-flow/skills/retrospect/SKILL.md
@@ -9,6 +9,11 @@ Make runs get smarter over time. A failure becomes a lesson (Reflexion); a *recu
 lesson becomes a skill/guideline candidate (Voyager). Full reference: loop-engine@paul-loop's
 docs/lessons.md (in the plugin, not this repo).
 
+> Commands below invoke `bin/<name>.sh` via `node tools/plugin-path.mjs exec bin/<name>.sh` — a
+> resolver/wrapper convention some consuming repos provide (this plugin does not ship
+> `plugin-path.mjs` itself). If this repo doesn't have one, invoke the plugin's installed bin path
+> directly instead.
+
 ## The one rule
 
 **Only the verifier decides what is a lesson.** Record a lesson as `--verified` ONLY when ground


### PR DESCRIPTION
## Summary

Release-train prep for BAC-758 (glucofit-partners Linear issue) — closes the doc-hygiene and
ADR-rationale gaps that block "bump-only" adoption of the 26 commits already on `origin/main` since
the last tag. This PR does **not** create the git tags themselves — see "What's still needed" below.

### 1. Dangling consumer-repo references (B7)

Several skill/doc examples referenced paths this plugin does **not** ship, as if it did:
`tools/plugin-path.mjs` (`retrospect`/`deps-audit` SKILL.md), `.claude/hooks/gate-stop-verdict.mjs`
(`docs/verdict-contract.md`), `bin/loop-doctor.mjs` + its hygiene test (`docs/otel.md`), and several
`loop-doctor` mentions in code comments (`lessons.mjs`, `docs/lessons.md`, `run-metrics.mjs`,
`regression-signals.mjs`, `verdict-run.sh`). All of these are real conventions this repo's own
consuming repo (glucofit-partners) built on top of the plugin — none of them ship here. Fixed by
adding an explicit hedge ("if this repo provides one" / "consumer-repo convention, not shipped by
this plugin") at each site, matching the pattern `ship-feature/SKILL.md` already used correctly.

Also found and fixed one **actually broken** link while scanning: `docs/orchestrate.md` pointed at
`.claude/skills/ship-feature/SKILL.md` (pre-plugin-extraction path) — now points at
`tools/ship-flow/skills/ship-feature/SKILL.md`.

New regression guard: `tools/loop-engine/test/dangling-doc-refs.test.sh`, wired automatically into
the existing `test/run.sh` (already a CI job in `loop-engine-test.yml`, no workflow changes needed).
It scans every `.md` under `tools/loop-engine/docs`, `tools/ship-flow/{skills,agents,workflows}` for
`bin/*.mjs`/`bin/*.sh`/`test/*.test.sh`/`.claude/hooks/*.mjs`/`tools/plugin-path.mjs`-shaped
references, and fails if a reference doesn't resolve to a real file under any plugin dir **and** the
containing file has no hedge language anywhere in it (this repo's actual convention: one disclaimer
near the top of a file, not repeated per call site — verified against the fixed files above).

**Known remaining scope** (not covered by the new test, left as-is): `test/*.test.sh` file headers
and a handful of internal code comments (`otel-metrics.mjs`, `context-budget.mjs`,
`lib/tcp-reachable.mjs`, `lib/protect-globs.mjs`, `lib/run-ledger.mjs`) also mention `loop-doctor` in
passing. These are developer-facing design-rationale comments, not user-facing "run this" examples,
and touching test files trips the reward-hack guard's protected-path window — left out of scope for
this pass. The AC's own verification method ("docs가 존재하지 않는 파일을 가리키지 않음") is about
docs, which this PR covers.

### 2. ADR rationale upstreamed (A8)

Two decisions that already shipped as *code* here (`bin/ac-verify.sh`, `loop-memory`'s
env-sharing + fail-closed manual recall) only had their *rationale* documented in
glucofit-partners' ADRs (0104, 0062 decision 9) — this plugin had no record of why it made these
calls. Ported as:

- `docs/adr/0006-ac-level-success-contract.md` (from glucofit-partners ADR-0104)
- `docs/adr/0007-manual-semantic-recall-shares-hook-env-fail-closed.md` (from glucofit-partners
  ADR-0062 decision 9)

Both cite the originals and summarize from this repo's perspective (implementation already lives
here) rather than duplicating the full original argument.

### 3. Version bump + CHANGELOG

Verified against actual commit history since each plugin's last tag (`git log
<tag>..HEAD -- tools/<plugin>`), not just the issue's summary — this caught that `loop-memory`
**did** change (sleep-time consolidation, #12) despite the issue text saying "unchanged, keep as
is":

| Plugin | Was | Now | Why (minor bump — new features, no breaking change) |
|---|---|---|---|
| loop-engine | 0.2.0 | **0.3.0** | `ac-verify.sh`, `verifier-pinned-review.sh`+CODEOWNERS, `--protect` hardening (6 adversarial rounds), lessons hygiene commands, tier0 gate |
| ship-flow | 0.1.0 | **0.2.0** | `publisher` subagent (ship-feature step 5 rewrite), grounded-reopen convention |
| loop-memory | 0.1.0 | **0.2.0** | sleep-time consolidation batch, hook-source tagging |

`ship-flow`/`loop-memory`'s `dependencies` on `loop-engine` bumped from `^0.2.0` to `^0.3.0` (caret
ranges on a `0.x` major are minor-locked in semver — `^0.2.0` does not include `0.3.0`).

CHANGELOG.md updated with one entry per bumped plugin (feature-level, not commit-level, matching
existing entries' granularity).

## What's still needed (deliberately out of this PR's scope)

- **Git tags** (`loop-engine--v0.3.0`, `ship-flow--v0.2.0`, `loop-memory--v0.2.0`) — not created by
  this PR. Tagging is a publish action; per this repo's own `gate.mjs`/`classify-risk.sh` policy
  (`reversibility=none` → always REQUIRE) that's a human call after merge, not something this
  session does unattended.
- **glucofit-partners consumption** (BAC-758 AC4: `claude plugin update`, CI tag bump in
  `.github/actions/setup-loop-engine`, `pnpm verify` green, ADR-0104 re-review-trigger) — genuinely
  blocked on the tags above existing; will be a separate PR in that repo once this merges and is
  tagged.
- **Local `~/dev/paul-loop` main ff** (AC5, optional) — trivial, will do after merge.

## Verification

`bash tools/loop-engine/test/run.sh` — 28/28 passed (27 pre-existing + the new
`dangling-doc-refs.test.sh`), including the new test at HEAD of this branch.

`claude plugin validate --strict .` / `--strict tools/loop-engine` / `--strict tools/ship-flow` /
`--strict tools/loop-memory` — all 4 pass (marketplace + 3 plugin manifests).

```
$ bash tools/loop-engine/test/dangling-doc-refs.test.sh
PASS: 33 doc(s) scanned, no unhedged dangling references

$ bash tools/loop-engine/test/run.sh 2>&1 | tail -1
loop-engine selftest: 28/28 passed
```

## Risk gate verdict

### Gate verdict — classify-risk (ADR-0061 · 3-tier)

| Field | Value |
|---|---|
| GATE | **REQUIRE** |
| TRACK | risky |
| FINAL | blast_radius=high reversibility=? cost=? |
| DEEP_GATES | (none) |
| PATHS | 18 |

**MATCHED**
- many-files (18 > 10) — broad change

**REASON**: reversibility is missing or unrecognised ("") → fail closed to human approval; cost is
missing or unrecognised ("") → fail closed to human approval; blast_radius=high

<!-- gate-verdict: GATE=REQUIRE TRACK=risky blast_radius=high reversibility=? cost=? PATHS=18 STAGE=pr BASE=91a706f39169 -->

(This is also a `main`-targeted PR, which this repo's merge/deploy policy always routes to REQUIRE
regardless of the classifier output above.)

## Linear

BAC-758 — https://linear.app/lansik/issue/BAC-758
