### PR TITLE
feat(loop-engine): bundle 8 generic runtime hooks via hooks.json

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "loop-engine",
       "source": "./tools/loop-engine",
       "description": "Core loop mechanics: verdict-run (machine-readable PASS/FAIL contract), loop-fix (closed verify->fix loop), lessons (verified-fix memory), classify-risk, require-tests. No framework opinions beyond \"the verifier is the ceiling, never the agent's self-report\".",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "keywords": ["verifier", "tdd", "loop", "verdict", "lessons"]
     },
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ Explicit-version channel — see [README § Development status](README.md#develo
 not a SHA channel. Entries below `## loop-engine 0.2.0` and earlier predate the multi-plugin split
 and refer to `loop-engine` only (see the un-prefixed version numbers).
 
+## loop-engine 0.4.0
+
+- Bundles 8 generic runtime-enforcement hooks via `hooks/hooks.json` (`plugin.json`'s new `hooks`
+  field), so a consuming repo gets them on a plugin-version bump instead of hand-maintaining a
+  local `.claude/hooks/` copy: `record-run-event` (run-ledger instrumentation across 7 events),
+  `gate-stop-verdict` (Stop-hook fresh-PASS gate), `loop-doctor-heartbeat` (SessionStart
+  self-diagnostic nudges), `protect-during-loop` (PreToolUse reward-hacking guard on
+  `.loop/protect.globs` + the plugin's own install path), `gate-risky-commands` (PreToolUse
+  merge/deploy REQUIRE mirror of `classify-risk`), `gate-before-merge` (PreToolUse direct-landing
+  guard on protected branches), `gate-worktree-create` (PreToolUse origin/*-only worktree-base
+  guard), and `warn-partial-checkout` (PostToolUseFailure partial-checkout data-loss warning).
+  Ported from a consuming repo's local copy with three genericizations: (1) hooks now resolve
+  their own sibling `lib/`/`bin/` files via `import.meta.url` instead of a cross-package plugin
+  resolver, since they ship colocated in the same plugin package; (2) `gate-before-merge`'s
+  protected-branch set now reads a consuming repo's `.claude/ship-flow.config.json`
+  (`releaseBranch`/`integrationBranch`) instead of a hardcoded pair, falling back to `{main,
+  master}` when that config is absent; (3) `loop-doctor-heartbeat`'s embedding-key/DB-URL check
+  now bridges `CLAUDE_PLUGIN_OPTION_*` (loop-memory's own `userConfig` injection convention)
+  instead of reading a hardcoded repo-local `.env` path. `ship-flow`'s `loop-engine` dependency
+  bumped to `^0.4.0` accordingly. New regression test `test/hooks-json-wiring.test.sh` covers
+  `plugin.json`/`hooks.json` structural wiring, an orphaned-file drift guard, an allow-path
+  end-to-end smoke test for all 8 hooks, and a deny-path + config-driven-branch-set behavioral
+  check for `gate-before-merge`.
+- `docs/verdict-contract.md` updated — it previously said this plugin doesn't ship a Stop hook;
+  now that it does, the doc points at `hooks/gate-stop-verdict.mjs`.
+
 ## loop-engine 0.3.0
 
 - AC-level success contract gate — `bin/ac-verify.sh` (ADR-0006, #23): per-AC `verify:`/

--- a/tools/loop-engine/.claude-plugin/plugin.json
+++ b/tools/loop-engine/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "loop-engine",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Core loop mechanics: verdict-run (machine-readable PASS/FAIL contract), loop-fix (closed verify->fix loop), lessons (verified-fix memory), classify-risk, require-tests. verifier=ceiling — the agent's self-judgement never substitutes for it.",
   "author": {
     "name": "paulkim-lansik"
@@ -8,5 +8,6 @@
   "homepage": "https://github.com/paulkim-lansik/paul-loop",
   "repository": "https://github.com/paulkim-lansik/paul-loop",
   "license": "MIT",
-  "keywords": ["verifier", "tdd", "loop", "verdict", "lessons"]
+  "keywords": ["verifier", "tdd", "loop", "verdict", "lessons"],
+  "hooks": "./hooks/hooks.json"
 }

--- a/tools/loop-engine/docs/verdict-contract.md
+++ b/tools/loop-engine/docs/verdict-contract.md
@@ -63,9 +63,9 @@ results — the contract is the integration point, the script is just one conven
 
 Alongside the stdout block, `verdict-run.sh` writes `.loop/verdict-state.json` on every run:
 `{verdict, exit, sha, dirty, finished_at, cmd, log}` — *what* was verified (HEAD sha at verify
-time, whether the worktree was dirty) and *when*. Consumer: a Stop-hook gate — e.g.
-`.claude/hooks/gate-stop-verdict.mjs` if this repo provides one (this plugin does not ship a
-Stop hook itself) — that refuses to let a loop-armed (`.loop/looping`) turn end unless the state
+time, whether the worktree was dirty) and *when*. Consumer: the Stop-hook gate this plugin ships
+(`hooks/gate-stop-verdict.mjs`, wired via `hooks/hooks.json`) — it refuses to let a loop-armed
+(`.loop/looping`) turn end unless the state
 is a **fresh PASS** (PASS ∧ recorded sha == current HEAD ∧ recorded clean ∧
 tree clean now) — a stale or dirty PASS (including cache replays) is treated the same as FAIL.
 The state file is listed in `.loop/protect.globs`, so the in-session guard denies an agent

--- a/tools/loop-engine/hooks/command-tokenizer.mjs
+++ b/tools/loop-engine/hooks/command-tokenizer.mjs
@@ -1,0 +1,104 @@
+// command-tokenizer.mjs — Bash 명령 문자열의 공유 근사 토크나이저 (BAC-563에서 gate-before-merge.mjs로부터
+// 추출 — 구현은 그대로, 집만 이동). 소비자: gate-before-merge.mjs(머지 방향 게이트)와
+// gate-risky-commands.mjs(머지·배포 표면 게이트). 중복 구현 금지 — 두 훅의 감지가 같은 파서 위에 서야
+// 파서 교훈이 한 곳에 산다. 계보: heredoc 처리=BAC-349, env-프리픽스 관통=초기 적대 리뷰(C-A,
+// BAC-364보다 앞선다). BAC-364의 파서 교훈(git 전역옵션·checkout 생성/값 플래그)은 여전히
+// gate-before-merge.mjs의 parseGit/checkoutTarget에 산다 — 아래 firstSubcommand는 그 계보(값-플래그
+// 스킵)를 이 파일로 가져온 gh/pnpm용 헬퍼다.
+//
+// ⚠️ 결합 주의(S-1): 이 파일(stripPrefix/tokenize/stripHeredocs/…)을 바꾸면 두 소비자 훅의 감지가
+// *함께* 바뀐다 — gate-hook.test.sh와 gate-risky-commands-hook.test.sh를 둘 다 돌려 확인할 것.
+//
+// ⚠️ 완전한 셸 파서가 아니다(coarse-net, ADR-0036) — eval/bash -c/따옴표/node -e를 못 흉내낸다. 소비자는
+// 감지 단계를 fail-open으로 다뤄야 한다(파서 하드닝은 won't-fix).
+
+// heredoc 시작 마커(`<<EOF`·`<<'EOF'`·`<<"EOF"`·`<<-EOF`, 따옴표·대시 조합 포함)부터, 그 줄과 정확히
+// 일치하는(단 `<<-`는 선행 탭 허용) 종료 줄까지(포함)를 통째로 들어낸다 — 완전한 셸 heredoc 문법이 아니라
+// 이 레포 관용구를 겨냥한 근사치. here-string(`<<<word`)은 시작으로 안 본다(음의 lookbehind로 제외 — 그
+// 자체가 heredoc이 아니고, 또한 헤어스트링이면 종료 마커가 있을 리 없어 아래 케이스로 흘러 데이터 유실
+// 위험만 남긴다). 종료 마커를 못 찾으면(비정상 입력이거나 애초에 heredoc이 아니었던 오탐) 원문을 그대로
+// 되돌린다(H-1) — 못 찾았다고 지워버리면 그 뒤에 있는 실제 명령까지 사라져 탐지가 fail-open으로 뚫린다.
+export function stripHeredocs(command) {
+  const lines = command.split('\n');
+  const startRe = /(?<!<)<<(-)?\s*(['"]?)([A-Za-z_][A-Za-z0-9_]*)\2/;
+  const out = [];
+  let i = 0;
+  while (i < lines.length) {
+    const line = lines[i];
+    out.push(line);
+    i += 1;
+    const m = startRe.exec(line);
+    if (!m) continue;
+    const [, dash, , delim] = m;
+    const bodyStart = i;
+    let closed = false;
+    while (i < lines.length) {
+      const body = dash ? lines[i].replace(/^\t+/, '') : lines[i];
+      i += 1;
+      if (body === delim) {
+        closed = true;
+        break;
+      }
+    }
+    if (!closed) {
+      // 스프레드 복원(out.push(...slice))은 ~12.5만 요소부터 V8 호출 인자 한도로 RangeError를 던진다
+      // (리뷰 실측: 20만 줄 미종결 heredoc → gate-risky-commands는 catch로 조용히 defer,
+      // gate-before-merge는 비차단 크래시 — 둘 다 fail-open). 인덱스 루프로 복원한다.
+      for (let j = bodyStart; j < i; j++) out.push(lines[j]);
+    }
+  }
+  return out.join('\n');
+}
+
+export const splitSegments = (command) =>
+  command
+    .split(/&&|\|\||[;|\n&]/)
+    .map((s) => s.trim())
+    .filter(Boolean);
+
+export const tokenize = (seg) => seg.split(/\s+/).filter(Boolean);
+
+// 선행 env 할당(FOO=bar)·env/command/nohup/nice/time/sudo 프리픽스를 벗긴다 — `GIT_SSH_COMMAND=… git
+// merge` 같은 환경변수 프리픽스나 `time pnpm deploy`·`sudo git merge` 같은 워드 프리픽스로 감지를
+// 우회하지 못하게(C-A + BAC-563 리뷰 S-1 — time/sudo 추가는 두 소비자 훅 모두를 더 보수적으로 만든다).
+export function stripPrefix(toks) {
+  let i = 0;
+  while (
+    i < toks.length &&
+    (/^[A-Za-z_][A-Za-z0-9_]*=/.test(toks[i]) ||
+      toks[i] === 'env' ||
+      toks[i] === 'command' ||
+      toks[i] === 'nohup' ||
+      toks[i] === 'nice' ||
+      toks[i] === 'time' ||
+      toks[i] === 'sudo')
+  ) {
+    i += 1;
+  }
+  return toks.slice(i);
+}
+
+// 바이너리(gh·pnpm 등) 뒤에서 플래그 토큰을 건너뛰고 첫 서브커맨드(비-플래그 토큰)의 인덱스를 돌려준다.
+// valueFlags에 든 플래그는 다음 토큰을 값으로 함께 소비한다(`--repo=x` 같은 단일 토큰 형태는 값 소비
+// 없음 — parseGit의 VALUE_GLOBAL 처리와 동일 계보, BAC-364). 목록에 없는 값-플래그는 오파싱될 수 있다
+// (coarse-net) — 소비자는 감지 단계 fail-open(defer)으로 흡수한다.
+export function firstSubcommand(toks, from, valueFlags) {
+  let i = from;
+  while (i < toks.length && toks[i].startsWith('-')) {
+    i += valueFlags.has(toks[i]) && !toks[i].includes('=') ? 2 : 1;
+  }
+  return i;
+}
+
+// git 전역옵션(다음 토큰이 값) — `git [이 옵션들...] <subcommand>`에서 subcommand 위치를 찾을 때
+// firstSubcommand와 함께 쓴다. gate-before-merge.mjs(parseGit)·gate-worktree-create.mjs·
+// worktree-remove-cleanup.mjs 공용(BAC-615 리뷰 — 각 훅이 이 집합을 따로 복제하지 않게 여기 하나로).
+export const GIT_VALUE_GLOBAL = new Set([
+  '-C',
+  '-c',
+  '--git-dir',
+  '--work-tree',
+  '--namespace',
+  '--exec-path',
+  '--super-prefix',
+]);

--- a/tools/loop-engine/hooks/gate-before-merge.mjs
+++ b/tools/loop-engine/hooks/gate-before-merge.mjs
@@ -1,0 +1,314 @@
+#!/usr/bin/env node
+// PreToolUse guardrail — detects a direct local merge/pull into a protected branch and redirects to
+// the PR flow. This hook is not a boundary. It's best-effort, local, bypassable, fail-fast guidance
+// (the filename "gate" is a historical artifact — not renamed). The real boundary is server-side
+// branch protection. Finding a bypass for this hook isn't a bug (parser hardening is a won't-fix).
+//
+// Detects `git merge`/`git pull` targeting a protected branch (see loadProtectedBranches below —
+// direction inference is cwd-based: effective branch is computed from the actual exec cwd, checkout
+// targets are tracked, and chaining/subshells/redirection keep the same structural-trust gate) and
+// denies **unconditionally**, pointing at `gh pr merge`. This hook does not enforce marker freshness,
+// --ff-only, or a specific source ref — that's the server's job now.
+//
+// Command parsing is two layers: the shared tokenizer (command-tokenizer.mjs — segment splitting,
+// heredoc stripping, env/word-prefix traversal) handles env prefixes (FOO=bar); this file's
+// parseGit/checkoutTarget handles git global options (-C/-c/...) and checkout create/value flags ->
+// together they resist `FOO=bar git merge` / `git -C . merge` / `git checkout -q/-B main`-style
+// evasion or mis-parsing. `git pull` targeting a protected branch is blocked too. Shell quoting isn't
+// fully parseable (coarse-net), so *detection* fails open (a non-merge command passes); once a merge
+// is confirmed, this fails closed.
+//
+// Heredoc bodies (a commit message via `-F -`, a PR body via `$(cat <<'EOF' ... EOF)`) are stripped
+// *before* segment splitting — otherwise splitting on newlines would misread a body's individual lines
+// as commands. Example: a doc's example code block happens to token-match `git merge --ff-only <ref>`,
+// and `<ref>` isn't a real rev -> the outer catch fails closed and denies an unrelated commit outright.
+//
+// Note: start-marker detection has no quote context — a match inside a quoted string, a grep pattern,
+// or a here-string (`<<<word`) can false-positive as a heredoc start. Such false positives almost
+// always fail to find a closing marker (because it isn't really a heredoc) -> in that case the
+// original text is restored rather than dropped (command-tokenizer.mjs's stripHeredocs). Dropping it
+// would also erase a *real* `git merge` line that follows, silently reopening detection (measured in
+// review) — a much larger blast radius than the "when in doubt, pass" philosophy this coarse-net
+// otherwise follows, so this specific case is guarded against.
+//
+// Scope: `git branch -f main` / `reset --hard` on a protected branch / `push (.|origin) HEAD:main` are
+// not merges and are out of scope — a local hook can't cover directly moving a protected branch;
+// server-side branch protection is the backstop there (this hook only watches merge/pull).
+//
+// Syncing a local protected branch to match origin is not blocked by this hook (and shouldn't be) —
+// the safe path is a ff-only merge from `origin/<branch>` (already-reviewed, already-merged server
+// truth), which doesn't route through this PreToolUse hook's merge-gate concern and doesn't bypass the
+// merge gate either.
+
+import { execFileSync } from 'node:child_process';
+import { readFileSync, realpathSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+// The tokenizer is a shared lib (shared with gate-risky-commands.mjs — same implementation, one home).
+import { splitSegments, stripHeredocs, stripPrefix, tokenize } from './command-tokenizer.mjs';
+import { logRedEvent } from './red-events-log.mjs';
+
+// biome-ignore lint/suspicious/noUndeclaredEnvVars: Claude Code injects this at hook runtime.
+const root = process.env.CLAUDE_PROJECT_DIR ?? process.cwd();
+
+// The protected branch set is repo-specific — read from the consuming repo's ship-flow.config.json
+// (releaseBranch / integrationBranch) if present. Absent that config (or a repo not using ship-flow's
+// setup skill), fall back to a conservative default that covers the two most common trunk names.
+function loadProtectedBranches(projectRoot) {
+  try {
+    const cfg = JSON.parse(
+      readFileSync(join(projectRoot, '.claude', 'ship-flow.config.json'), 'utf8'),
+    );
+    const branches = [cfg.releaseBranch, cfg.integrationBranch].filter(
+      (b) => typeof b === 'string' && b,
+    );
+    if (branches.length) return new Set(branches);
+  } catch {
+    /* missing/unreadable config -> fall through to the default */
+  }
+  return new Set(['main', 'master']);
+}
+const PROTECTED_BRANCHES = loadProtectedBranches(root);
+
+const EXEC = {
+  cwd: root,
+  encoding: 'utf8',
+  stdio: ['ignore', 'pipe', 'pipe'],
+  maxBuffer: 16 * 1024 * 1024,
+};
+
+function allow() {
+  process.exit(0);
+}
+function deny(reason, code) {
+  // Best-effort record (reason code included so a false positive, e.g. a direction mis-detection, can
+  // later be filtered out when measuring a real deny rate). Keyed to root (the worktree this hook runs
+  // in) — logRedEvent itself is fail-open, so a failure here never affects the deny verdict below.
+  logRedEvent(root, { kind: 'gate', code });
+  process.stdout.write(
+    JSON.stringify({
+      hookSpecificOutput: {
+        hookEventName: 'PreToolUse',
+        permissionDecision: 'deny',
+        permissionDecisionReason: reason,
+      },
+    }),
+  );
+  process.exit(0);
+}
+function git(args, cwd = root) {
+  return execFileSync('git', args, { ...EXEC, cwd }).trim();
+}
+
+// Flags that take a following value token — skipped along with their value.
+const VALUE_GLOBAL = new Set([
+  '-C',
+  '-c',
+  '--git-dir',
+  '--work-tree',
+  '--namespace',
+  '--exec-path',
+  '--super-prefix',
+]);
+// checkout/switch's branch-creating flags — the token right after is the *new branch name* (the
+// checkout target). Must not be skipped as a value.
+const CREATE_CHECKOUT = new Set(['-b', '-B', '-c', '-C', '--orphan']);
+// checkout/switch value-taking flags — skipped along with their value when searching for the target.
+const VALUE_CHECKOUT = new Set(['--conflict', '--pathspec-from-file', '--start-point']);
+
+// Parses a git segment -> { sub, args }. After stripping prefixes, skips git global options (with
+// their values) and returns the first non-flag token as the subcommand.
+function parseGit(rawToks) {
+  const toks = stripPrefix(rawToks);
+  if (toks[0] !== 'git') return null;
+  let i = 1;
+  while (i < toks.length) {
+    const t = toks[i];
+    if (t.startsWith('-')) {
+      i += VALUE_GLOBAL.has(t) && !t.includes('=') ? 2 : 1;
+      continue;
+    }
+    return { sub: t, args: toks.slice(i + 1) };
+  }
+  return null;
+}
+// checkout/switch's target branch. A create flag (-b/-B/-c/-C/--orphan) means the token right after it
+// is the target. A file-restore form is not a branch switch, so returns null (no switch -> effective
+// branch stays as-is, the fail-closed direction):
+//   - `checkout <tree> -- <paths>` / `checkout -- <paths>`: `--` always means a file restore.
+//   - `checkout .` / `checkout *`: a pathspec, not a valid branch ref name (git refname rules).
+function checkoutTarget(args) {
+  if (args.includes('--')) return null;
+  for (let i = 0; i < args.length; i++) {
+    const t = args[i];
+    if (CREATE_CHECKOUT.has(t)) return args[i + 1] ?? null;
+    if (t.startsWith('-')) {
+      if (VALUE_CHECKOUT.has(t) && !t.includes('=')) i += 1;
+      continue;
+    }
+    return t === '.' || t === '*' ? null : t;
+  }
+  return null;
+}
+// -- Merge detection (fails open up to here: an uncertain parse or a non-merge command passes) -------
+let payload;
+try {
+  payload = JSON.parse(readFileSync(0, 'utf8'));
+} catch {
+  allow();
+}
+if (payload?.tool_name !== 'Bash') allow();
+const cmd = payload?.tool_input?.command;
+if (typeof cmd !== 'string' || !cmd) allow();
+
+const strippedCmd = stripHeredocs(cmd);
+let gitSegs;
+try {
+  gitSegs = splitSegments(strippedCmd).map(tokenize).map(parseGit).filter(Boolean);
+} catch {
+  allow(); // a detection-stage error -> pass (a bug in this hook must not block arbitrary Bash)
+}
+
+// Trusting payload.cwd for direction inference kept producing new evasions across review rounds — -C /
+// cd / GIT_DIR= first, then a subshell `(cd ... && merge)`, brace groups, and backslash escapes next
+// (all reproduced). Blacklisting tokens one at a time keeps breaking the moment a structural character
+// glues itself onto `cd`/`git`/`-C` in a way the whitespace-only tokenizer can't see (`(git`, `\git`
+// aren't recognized as `git`). Flip it to a whitelist instead: cwd-based direction inference is only
+// trusted when the command is "structurally a single simple git merge/pull" — (1) exactly one segment
+// (no &&/;/|/newline/bare &) (2) no structural characters `(){}\\` at all (3) no -C/--git-dir/
+// --work-tree/GIT_DIR=/GIT_WORK_TREE= redirection signal. If any of the three trips,
+// direction-untrusted -> if merge/pull appears anywhere in the command (a loose scan too, spreading
+// structural characters into spaces so it also catches what the strict parser misses, like `(git` /
+// `\git`), deny regardless of reason. This is effectively reverting to the original default (treat
+// direction as always-protected-branch) — the only thing newly allowed is "a simple single command"
+// (exactly the scenario this cwd-based trust was meant to fix), so there's no new attack surface. The
+// strict tokenize/parseGit path itself is untouched — this check sits as a separate safety net on top
+// of it.
+const hasStructuralChars = (s) => /[(){}\\]/.test(s);
+const stripStructuralChars = (s) => s.replace(/[(){}\\]/g, ' ');
+const rawSegs = splitSegments(strippedCmd);
+const DIR_REDIRECT_GLOBAL = new Set(['-C', '--git-dir', '--work-tree']);
+const hasDirRedirectSignal = (rawToks) => {
+  // A GIT_DIR=/GIT_WORK_TREE= env prefix has the same redirection effect as -C/--git-dir — checked on
+  // the *raw* tokens before stripPrefix removes that evidence.
+  if (rawToks.some((t) => /^(GIT_DIR|GIT_WORK_TREE)=/.test(t))) return true;
+  const toks = stripPrefix(rawToks);
+  if (['cd', 'pushd', 'popd'].includes(toks[0])) return true;
+  return (
+    toks[0] === 'git' &&
+    toks.some(
+      (t) =>
+        DIR_REDIRECT_GLOBAL.has(t) || t.startsWith('--git-dir=') || t.startsWith('--work-tree='),
+    )
+  );
+};
+const isSimpleSingleGitCmd =
+  rawSegs.length === 1 &&
+  gitSegs.length === 1 &&
+  !hasStructuralChars(rawSegs[0]) &&
+  (gitSegs[0].sub === 'merge' || gitSegs[0].sub === 'pull') &&
+  !hasDirRedirectSignal(tokenize(rawSegs[0]));
+let looseHasMergeOrPull = false;
+try {
+  looseHasMergeOrPull = splitSegments(stripStructuralChars(strippedCmd))
+    .map(tokenize)
+    .map(parseGit)
+    .filter(Boolean)
+    .some((g) => g.sub === 'merge' || g.sub === 'pull');
+} catch {
+  looseHasMergeOrPull = false; // a scan failure is itself detection-stage -> fail-open (same philosophy)
+}
+// A non-merge/pull command (neither the strict nor the loose check found one) passes quickly.
+if (!gitSegs.some((g) => g.sub === 'merge' || g.sub === 'pull') && !looseHasMergeOrPull) allow();
+
+// Never let a single merge/pull targeting a protected branch through. An unexpected error in direction
+// inference itself fails closed (deny in the catch below).
+try {
+  if (!isSimpleSingleGitCmd) {
+    deny(
+      'This command is not a simple single `git merge`/`git pull` call (chaining, a subshell, braces, ' +
+        'backslashes, -C/cd/GIT_DIR=, etc.), so merge direction cannot be trusted. Run a single ' +
+        '`git merge`/`git pull` line directly in the target directory instead of changing directory.',
+      'not-simple-command',
+    );
+  }
+  // From here on isSimpleSingleGitCmd holds — gitSegs contains exactly that one merge/pull, so the
+  // loop below evaluates only that single op. Direction inference is based on the *actual Bash exec
+  // cwd* (payload.cwd — a field the hook receives on every call, the session cwd right before the
+  // command runs). `root` (CLAUDE_PROJECT_DIR) stays fixed at the main worktree's path, and its HEAD is
+  // typically pinned to a specific branch by convention — so measuring HEAD via `root` alone would
+  // misjudge a perfectly normal sync command run from a different worktree as targeting the protected
+  // branch.
+  //
+  // Trust boundary: payload.cwd is external input and fails far more often than root does — (a) an
+  // already-removed/nonexistent worktree (this genuinely happens when cleanup overlaps a merge), (b) a
+  // different repo than root (the session cd'd outside the repo). This hook's philosophy is
+  // "unconfirmed -> fail closed", but an early implementation let both of these cases fall through to
+  // effective=null and skip the gate for that op entirely — a real protected-branch-targeting merge
+  // could silently (with no log) pass. Falling back to `root` in both cases below restores the
+  // originally-intended safe default.
+  const execCwd = typeof payload?.cwd === 'string' && payload.cwd ? payload.cwd : root;
+  const gitCommonDir = (dir) => {
+    try {
+      // Normalize via realpath — a main vs. linked worktree can print --git-common-dir as relative or
+      // absolute depending on git version/location, and on macOS /var is a symlink to /private/var, so
+      // the same path can appear in two forms. Without normalization, a string comparison can wrongly
+      // conclude two paths point at different repos when they're the same one (measured: a linked
+      // worktree case fell through to the fallback and broke a regression test).
+      return realpathSync(resolve(dir, git(['rev-parse', '--git-common-dir'], dir)));
+    } catch {
+      return null; // doesn't exist, or not a git repo
+    }
+  };
+  const sameRepo =
+    execCwd === root ||
+    (() => {
+      const a = gitCommonDir(execCwd);
+      return a !== null && a === gitCommonDir(root);
+    })();
+  const headAt = (dir) => {
+    try {
+      return git(['rev-parse', '--abbrev-ref', 'HEAD'], dir);
+    } catch {
+      return null;
+    }
+  };
+  let effective = sameRepo ? headAt(execCwd) : null;
+  if (effective === null) effective = headAt(root); // execCwd undecidable / a different repo -> fall back to root (the fail-closed default)
+
+  for (const seg of gitSegs) {
+    if (seg.sub === 'checkout' || seg.sub === 'switch') {
+      const t = checkoutTarget(seg.args);
+      if (t) effective = t;
+      continue;
+    }
+    if (seg.sub !== 'merge' && seg.sub !== 'pull') continue;
+    if (!PROTECTED_BRANCHES.has(effective)) continue; // this op doesn't target a protected branch -> pass
+
+    // A merge-state subcommand (--abort/--continue/--quit) isn't a landing attempt -> skip this op
+    // (subsequent ops keep being evaluated).
+    if (
+      seg.sub === 'merge' &&
+      seg.args.some((a) => ['--abort', '--continue', '--quit'].includes(a))
+    )
+      continue;
+
+    // -- Direct landing attempt on a protected branch -> redirect to the PR flow (a guardrail, not a
+    // boundary). No marker freshness / --ff-only / source-ref enforcement here — the actual
+    // enforcement is the server's (branch protection + required status checks on the release branch).
+    deny(
+      `Can't land directly on ${effective} via local git ${seg.sub} — use the PR flow: push the branch ` +
+        `and merge with \`gh pr merge\` (or the GitHub UI). If you only want your local ${effective} to ` +
+        `match origin/${effective}, use \`git fetch origin && git merge --ff-only origin/${effective}\` ` +
+        `(a safe ff-only sync) instead.`,
+      `${effective}-direct-landing`,
+    );
+  }
+
+  allow(); // no merge/pull targeted a protected branch, or every op passed the check above -> allow
+} catch (e) {
+  // An unexpected error after a protected-branch merge is confirmed fails closed.
+  deny(
+    `merge gate internal error (fail-closed): ${String(e?.message ?? e).split('\n')[0]}`,
+    'internal-error',
+  );
+}

--- a/tools/loop-engine/hooks/gate-risky-commands.mjs
+++ b/tools/loop-engine/hooks/gate-risky-commands.mjs
@@ -1,0 +1,238 @@
+#!/usr/bin/env node
+// gate-risky-commands.mjs — PreToolUse(Bash) guardrail: enforces "merge and deploy always require a
+// human, regardless of risk classification" at the tool-call boundary, not just in skill prose.
+//
+// Why a hook (two structural holes in skill-level prose gates): (1) gate.mjs's exit 10 is non-blocking
+// under the Claude Code hooks contract — only exit 2, or exit 0 + JSON (permissionDecision), block.
+// (2) skill-level gates leak from subagents/bypassPermissions — a PreToolUse hook fires in both of
+// those contexts too (official docs).
+//
+// Single decision point: this hook doesn't decide AUTO vs REQUIRE itself. Its own scope filter answers
+// only "is this command a merge/deploy surface" (gh pr merge · a repo's deploy-script path · its
+// deploy/redeploy package-manager aliases). Once a surface is confirmed, it mirrors
+// bin/classify-risk.mjs --command (-> gate.mjs) and mirrors its exit code (10 = REQUIRE -> ask/deny, 0
+// = AUTO -> defer). The classification table itself is never duplicated in this hook — change the
+// rules in one place (classify-risk) and every consumer follows.
+//
+// deny vs ask: default is "ask" — REQUIRE means human approval, not prohibition. A consuming repo's
+// permissions.ask rules can already route the same surface to interactive approval and, per official
+// docs, already survive compound commands and env-var prefixes. What this hook adds on top:
+// (1) detection beyond string rules — env/nohup/nice/command/sudo/time word prefixes, whitespace
+//     variants (via the shared tokenizer), and gh/pnpm global-flag traversal (firstSubcommand)
+// (2) a single source of truth for the verdict — mirrors classify-risk, with the matched rule
+//     surfaced in the reason
+// (3) a bypassPermissions deny backstop (below) (4) red-events telemetry.
+// "ask" is a valid PreToolUse hookSpecificOutput value (official hooks doc). Headless sessions can't
+// prompt, so ask resolves to a fail-closed rejection there (intended). In bypassPermissions mode this
+// hook denies rather than asks: official docs say an *explicit* ask rule still forces a prompt even in
+// that mode, but how a hook-returned "ask" behaves there is undocumented, so this hook doesn't rely on
+// undocumented behavior and fails closed instead.
+//
+// fail-open/fail-closed (same principle as gate-before-merge): the detection stage (stdin parse,
+// non-Bash, tokenizing, "not a target surface") fails open (defer — the permissions.ask layer still
+// applies); once a surface is confirmed (including the classify-risk spawn and its verdict), it fails
+// closed.
+//
+// This hook is a guardrail, not a boundary (see the repo-wide threat-model ADR that applies to this
+// harness) — the tokenizer can't emulate eval/bash -c/quoting/node -e, and finding a bypass isn't a
+// bug (parser hardening is a won't-fix). The real boundary: server-side branch protection for merges,
+// human-approval practice for deploys. Don't read this as "merges are now blocked."
+
+import { spawnSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  firstSubcommand,
+  splitSegments,
+  stripHeredocs,
+  stripPrefix,
+  tokenize,
+} from './command-tokenizer.mjs';
+import { logRedEvent } from './red-events-log.mjs';
+
+// biome-ignore lint/suspicious/noUndeclaredEnvVars: Claude Code injects this at hook runtime.
+const root = process.env.CLAUDE_PROJECT_DIR ?? process.cwd();
+// This hook ships inside loop-engine's own package, so bin/classify-risk.mjs is a plain sibling path —
+// no cross-package plugin-install resolution needed (contrast: when this hook lived in a consuming
+// repo, it had to go find an installed plugin first).
+const pluginRoot = fileURLToPath(new URL('..', import.meta.url)).replace(/\/$/, '');
+const RULES = join(root, 'risk-rules.json');
+const CLASSIFY = join(pluginRoot, 'bin', 'classify-risk.mjs');
+
+function allow() {
+  process.exit(0); // exit 0 with no JSON = defer — the normal permission flow (incl. permissions.ask) applies.
+}
+function block(decision, reason, code) {
+  logRedEvent(root, { kind: 'gate', code }); // best-effort — a logging failure never changes the verdict
+  process.stdout.write(
+    JSON.stringify({
+      hookSpecificOutput: {
+        hookEventName: 'PreToolUse',
+        permissionDecision: decision,
+        permissionDecisionReason: reason,
+      },
+    }),
+  );
+  process.exit(0); // exit 0 + JSON is the block contract — exit 1/10 is non-blocking, exit 2 is unstructured blocking.
+}
+
+// -- Detection stage (fail-open) ----------------------------------------------------------------------
+let payload;
+try {
+  payload = JSON.parse(readFileSync(0, 'utf8'));
+} catch {
+  allow();
+}
+if (payload?.tool_name !== 'Bash') allow();
+const cmd = payload?.tool_input?.command;
+if (typeof cmd !== 'string' || !cmd) allow();
+
+// A scope filter — a subset of classify-risk's COMMAND_RULES (cmd-irreversible). Not a full mirror:
+// classify-risk fails closed (REQUIRE) on no match, so routing every Bash call through it would make
+// even `ls` REQUIRE. So this narrows to "command surfaces that are always REQUIRE" (gh pr merge · a
+// deploy-script path · the repo's canonical deploy aliases) and defers the actual verdict to
+// classify-risk below. (`git push ...:main` is deliberately out of scope — server-side branch
+// protection is the real boundary there. Other risky commands outside this filter still route through
+// classify-risk elsewhere, e.g. a ship-feature step's own classification, where an unmatched command
+// fails closed to REQUIRE.)
+// Detection style: gh/pnpm go through the tokenizer (segments, prefixes, flag traversal); a deploy
+// path is a raw substring match on the pre-tokenized command.
+const GH_VALUE_FLAGS = new Set(['-R', '--repo', '--hostname']);
+// pnpm: --filter/-F/-C/--dir take a value; -w/--workspace-root is boolean (pnpm docs) and falls
+// through the ordinary flag-skip path. A value-flag outside this list can mis-parse -> fail-open defer
+// (an accepted guardrail limit).
+const PNPM_VALUE_FLAGS = new Set(['--filter', '-F', '-C', '--dir']);
+function detectsRiskySurface(command) {
+  try {
+    const stripped = stripHeredocs(command); // heredoc bodies are data, not commands
+    if (/tools\/deploy\//.test(stripped)) return 'deploy-path'; // same substring classify-risk uses (matches read commands too — same tradeoff as the permissions.ask layer)
+    for (const rawToks of splitSegments(stripped).map(tokenize)) {
+      const toks = stripPrefix(rawToks); // strip env/word prefixes, incl. sudo/time
+      if (toks[0] === 'gh') {
+        // gh [global flags] pr [flags] merge — skip flags between subcommands with the same helper.
+        const i = firstSubcommand(toks, 1, GH_VALUE_FLAGS);
+        if (toks[i] === 'pr' && toks[firstSubcommand(toks, i + 1, GH_VALUE_FLAGS)] === 'merge')
+          return 'command';
+      }
+      if (toks[0] === 'pnpm') {
+        const i = firstSubcommand(toks, 1, PNPM_VALUE_FLAGS);
+        const sub =
+          toks[i] === 'run' ? toks[firstSubcommand(toks, i + 1, PNPM_VALUE_FLAGS)] : toks[i];
+        if (sub === 'deploy' || sub === 'redeploy') return 'command';
+      }
+    }
+    return null;
+  } catch (e) {
+    // A detection-stage error fails open (a bug in this hook must never block arbitrary Bash calls).
+    // Never fail silently — a stderr breadcrumb keeps a parser crash distinguishable from a quiet defer.
+    console.error(
+      `[gate-risky-commands] detection stage error (fail-open): ${String(e?.message ?? e).split('\n')[0]}`,
+    );
+    return null;
+  }
+}
+const surface = detectsRiskySurface(cmd);
+if (!surface) allow();
+
+// -- Surface confirmed — fail-closed from here on. classify-risk (-> gate.mjs) decides. --------------
+if (!existsSync(CLASSIFY)) {
+  block(
+    'deny',
+    '[gate-risky-commands] classify-risk.mjs is missing from this plugin install — the surface is ' +
+      'already confirmed, so this fails closed rather than deferring. Reinstall/update the loop-engine plugin and retry.',
+    'risky-cmd-classify-missing',
+  );
+}
+try {
+  // E2BIG guard: a very large command (e.g. a huge heredoc) can fail to spawn at all under the OS argv
+  // limit (measured: a 1.3MB command -> E2BIG -> a classification failure that would deny). The
+  // judgment input is capped to the first 100KB. A truncated match can only lose rule matches, which
+  // classify-risk's own unmatched-input fail-closed (REQUIRE) absorbs — the verdict can't flip toward
+  // AUTO from truncation (safe direction, monotone), and the surface itself was already confirmed
+  // against the full string. Kept as "ask" rather than "deny" to preserve REQUIRE's meaning (human
+  // approval, not prohibition).
+  const cmdForJudge = cmd.length > 100_000 ? cmd.slice(0, 100_000) : cmd;
+  const res = spawnSync(
+    process.execPath,
+    [
+      CLASSIFY,
+      '--json',
+      '--command',
+      cmdForJudge,
+      '--rules',
+      RULES,
+      '--action',
+      'PreToolUse(Bash) gate',
+    ],
+    { encoding: 'utf8', timeout: 10_000 },
+  );
+  // Mirror AUTO — this hook never gets independently stricter than classify-risk (single decision
+  // point). Defensive branch — the current scope filter is a strict subset of cmd-irreversible, so
+  // status 0 isn't reachable today; kept for when the filter widens.
+  if (res.status === 0) allow();
+  // DENY_AND_LOG — the middle tier: default-deny + evidence attached to the PR. Defensive branch — this
+  // hook's filtered surfaces (merge/deploy) are all rev=none today, so gate always returns 10 here; kept
+  // so a future filter widening doesn't mislabel status 11 as "verdict failed" below.
+  if (res.status === 11) {
+    block(
+      'deny',
+      '[gate-risky-commands] medium risk (DENY_AND_LOG) — denying by default. Attach the classification ' +
+        "evidence to the PR body via 'classify-risk --from-git --render-md'.",
+      'risky-cmd-deny-and-log',
+    );
+  }
+  // A spawn failure (res.error), a signal/timeout (status=null), or any other unexpected exit code
+  // (1, 2, ...) all mean "the verdict couldn't be determined" — fail closed (the surface is already
+  // confirmed, matching this file's own contract above).
+  if (res.error || res.status !== 10) {
+    const cause = res.error
+      ? String(res.error.message ?? res.error).split('\n')[0]
+      : `status=${res.status}`;
+    block(
+      'deny',
+      `[gate-risky-commands] classify-risk failed to produce a verdict (${cause}) — the surface is ` +
+        `already confirmed, so this fails closed. Repair the loop-engine plugin install (${CLASSIFY}) and retry.`,
+      'risky-cmd-classify-failed',
+    );
+  }
+  // status === 10 (REQUIRE) — surface the matched rule as evidence for the single decision point.
+  let matched;
+  try {
+    const arr = JSON.parse(res.stdout).matched ?? [];
+    // The reason is human-facing — cap at 2000 chars so a bloated `matched` array doesn't dump wholesale.
+    matched = arr.length ? arr.join('; ').slice(0, 2000) : 'no rule matched (unmatched fails closed)';
+  } catch (e) {
+    // A block is still valid without a parsed reason — just don't let a parse failure silently masquerade
+    // as "no rule matched"; label it distinctly and leave a stderr breadcrumb.
+    console.error(
+      `[gate-risky-commands] reason parse failed: ${String(e?.message ?? e).split('\n')[0]}`,
+    );
+    matched = '(reason parse failed)';
+  }
+  const bypass = payload?.permission_mode === 'bypassPermissions';
+  const surfaceLabel =
+    surface === 'deploy-path'
+      ? "commands touching this repo's deploy-script path (including reads — same tradeoff as the permissions.ask layer) are"
+      : 'merge/deploy commands are';
+  const base =
+    `[gate-risky-commands] ${surfaceLabel} always routed through a human-approval gate (REQUIRE, ` +
+    `verdict via classify-risk). ${matched}. ` +
+    'This hook is a guardrail, not a boundary — the real boundary is server-side branch protection.';
+  if (bypass) {
+    block(
+      'deny',
+      `${base} An explicit ask rule still forces a prompt even under bypassPermissions (per official ` +
+        `docs), but this hook's own "ask" decision has undocumented behavior in that mode, so it fails ` +
+        `closed instead — run this interactively with human approval, or run it yourself.`,
+      'risky-cmd-deny-bypass',
+    );
+  }
+  block('ask', `${base} A human approval will let this proceed.`, 'risky-cmd-ask');
+} catch (e) {
+  block(
+    'deny',
+    `[gate-risky-commands] internal error (fail-closed — surface already confirmed): ${String(e?.message ?? e).split('\n')[0]}`,
+    'risky-cmd-internal-error',
+  );
+}

--- a/tools/loop-engine/hooks/gate-stop-verdict.mjs
+++ b/tools/loop-engine/hooks/gate-stop-verdict.mjs
@@ -1,0 +1,238 @@
+#!/usr/bin/env node
+// gate-stop-verdict.mjs — Stop 훅 verdict 게이트 (BAC-564): "검증기가 천장"(CLAUDE.md §1·§8)을 턴
+// 종료 시점에 기계 강제한다. 지금까지는 에이전트가 verdict를 돌리고 결과를 자기 판단으로 해석한 뒤
+// 턴을 끝냈다(prose 규약) — 이 훅이 있으면 루프 무장 중엔 verdict가 fresh PASS가 아닌 한 턴 종료가
+// 구조적으로 차단된다. 반면교사(ECC stop-format-typecheck.js): 객관 신호를 계산해 놓고 항상 exit 0으로
+// 버린다 — 이 훅이 하는 것은 그 마지막 한 줄(차단)이다. 검증기를 여기서 *실행*하지는 않는다 — 이미
+// 기록된 verdict 상태를 읽기만 한다(실행까지 넣으면 모든 턴 종료가 비싸진다).
+//
+// 발동 조건(사용자 확정 설계, BAC-564 코멘트 2026-08-04): `.loop/looping` 센티넬이 존재할 때만.
+// 센티넬은 loop-fix.sh가 자기 루프 동안 소유하므로(ADR-0081) 일상 대화 세션·평범한 ship 세션과
+// 충돌하지 않는다 — 센티넬이 없으면 무출력 exit 0. 센티넬이 살아있는 경우 = ① 무인 드라이버가
+// 의도적으로 무장 ② loop-fix가 비정상 종료(trap 미발화)로 흘림 — 둘 다 "verdict PASS 없이 턴을
+// 끝내면 안 되는" 맥락이다.
+//
+// 판정(AC1·AC2·AC5): `.loop/verdict-state.json`(verdict-run.sh가 매 실행 기록: verdict·HEAD sha·
+// dirty·timestamp·cmd)을 읽어, verdict==PASS AND 기록 sha==현재 HEAD AND 기록 dirty=false AND 현재
+// 트리 clean일 때만 통과한다. FAIL·미기록·파싱 실패·stale sha·dirty(기록 시점/현재)는 전부 차단 —
+// exit 2, stderr가 에이전트에게 되돌아간다(공식 Stop 훅 계약, code.claude.com/docs/en/hooks).
+// 캐시 리플레이 PASS도 같은 기준이다(BAC-581 계열 stale-green 차단). 미기록을 fail-closed로 차단하는
+// 이유: 센티넬 무장 = 루프 맥락이고, 그 맥락에서 "검증기를 아직 안 돌림"은 통과 사유가 될 수 없다 —
+// 개발 편의는 킬스위치(LOOP_STOP_GATE_OFF=1, AC7 — 기본 ON)가 흡수한다.
+//
+// 무한 루프 방지(AC3·AC8): 공식 문서는 stop_hook_active=true면 즉시 exit 0을 권하지만, 그대로 따르면
+// 게이트가 1회성 알림으로 퇴화한다(재시도부터 무사통과 — AC8의 "연속 N회 deny"와 양립 불가). 이 훅의
+// 루프 상한은 탈출 밸브다: 연속 deny 카운터(`.loop/stop-gate.<session>.json` — 세션별 파일, 공유
+// 파일이면 동시 세션 핑퐁이 카운터를 무한 리셋한다, 리뷰 I4)가 MAX_CONSECUTIVE_DENIES회를 넘으면
+// 에스컬레이트 systemMessage와 함께 종료를 허용한다(verdict가 구조적으로 FAIL인 상황 — 인프라
+// 장애 등 — 에서 세션이 영구히 못 끝나는 것을 방지). 탈출은 PASS로 기록되지 않는다 — verdict 상태
+// 파일은 불변, red-events에 탈출 이벤트만 남는다. 탈출 후 같은 세션의 후속 Stop은 즉시 탈출한다
+// (카운터가 리셋되지 않는 의도된 stickiness — fresh PASS만이 리셋한다). stop_hook_active는 카운터
+// 영속화 실패의 최종 안전망: 카운터를 못 쓰면 상한을 보장할 수 없으므로 stop_hook_active=true(이미
+// 한 번 차단된 재시도)면 즉시 탈출 — 무한 루프는 "stdin 파싱과 카운터 영속화가 동시에 계속
+// 실패"하는 병리적 조합에서만 남는다(내부 크래시는 동일 원리: 첫 시도 1회 차단, 재시도 통과).
+//
+// ⚠️ 이 훅은 경계(Gate)가 아니라 가드레일이다(ADR-0036, AC9). 한계를 정직하게 적는다(AC4):
+//  - 상태 파일 직접 위조(에이전트가 스스로 PASS 기록)는 protect-during-loop 훅이 막는다 —
+//    `.loop/verdict-state.json`·`.loop/stop-gate.*.json`을 `.loop/protect.globs`에 편입했다.
+//    그러나 그 훅 자체도 로컬 가드레일이다 — 진짜 경계는 PR 리뷰 + 서버단 브랜치 보호·CI다.
+//  - 이 훅은 "어떤 명령의 PASS인지"를 검증하지 못한다 — 사소한 명령(verdict-run.sh -- true)의
+//    PASS도 fresh면 통과한다. cmd를 상태에 기록해 사후 감사만 가능하게 한다.
+//  - 킬스위치·센티넬 제거·env 우회는 전부 가능하다 — 이 훅의 목적은 "정상 에이전트가 verdict FAIL을
+//    자기 판단으로 덮고 턴을 끝내는" 사고를 구조적으로 막는 것이지, 작정한 행위자 차단이 아니다.
+// 행위 증명: tools/harness-test/gate-stop-verdict.test.sh (실제 spawn — FAIL 차단·fresh PASS
+// 통과·stale/dirty 차단·미기록 차단·센티넬 없음 통과·킬스위치·탈출 밸브·무한루프 방지·배선).
+
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+
+const MAX_CONSECUTIVE_DENIES = 3; // 연속 3회 차단 후 4번째 시도에서 탈출(AC8 — 설계 판단 3~5 중 최소값)
+
+// biome-ignore lint/suspicious/noUndeclaredEnvVars: Claude Code가 런타임에 주입하는 훅 변수.
+const root = process.env.CLAUDE_PROJECT_DIR ?? process.cwd();
+const SENTINEL = join(root, '.loop', 'looping');
+const STATE = join(root, '.loop', 'verdict-state.json');
+
+// red-events 로거는 동적 import(fire-and-forget) — 정적 import는 로거 파일 부재/문법 오류 시 이
+// 모듈 전체를 exit 1(Stop 계약상 비차단)로 즉사시켜 게이트를 조용히 무력화한다(리뷰 H1).
+// 로깅은 best-effort, 실패해도 판정 불변. exitCode는 이미 설정된 뒤라 pending import는 무해하다.
+const redEvent = (code) => {
+  import('./red-events-log.mjs')
+    .then((m) => m.logRedEvent(root, { kind: 'stop-gate', code }))
+    .catch(() => {});
+};
+
+// stdin은 최상위에서 한 번만 읽는다 — 크래시 안전망(catch)에서도 stop_hook_active가 필요하다.
+let payload = null;
+try {
+  payload = JSON.parse(readFileSync(0, 'utf8'));
+} catch {
+  /* 파싱 실패 → payload=null. 센티넬 무장 중이면 fail-closed로 계속(아래 judge가 차단). */
+}
+const stopHookActive = payload?.stop_hook_active === true;
+const sessionId = typeof payload?.session_id === 'string' ? payload.session_id : 'unknown';
+// 카운터는 세션 단위 파일(리뷰 I4): 한 파일을 공유하면 같은 워크트리의 무장 세션 2개가 번갈아
+// Stop할 때 서로의 기록을 매번 1로 리셋(핑퐁)해 탈출 밸브가 영원히 안 열린다 — 이 레포는 상시
+// 동시 병렬 작업 환경이다(CLAUDE.md §8). 세션별 파일이면 연속성이 세션 안에서만 정의되고 상한이
+// 보장된다. protect.globs 항목은 `.loop/stop-gate.*.json`.
+const COUNTER = join(
+  root,
+  '.loop',
+  `stop-gate.${sessionId.replace(/[^A-Za-z0-9_-]/g, '_').slice(0, 40) || 'unknown'}.json`,
+);
+
+function gitOut(args) {
+  return execFileSync('git', args, {
+    cwd: root,
+    encoding: 'utf8',
+    timeout: 3000,
+    stdio: ['ignore', 'pipe', 'ignore'],
+  }).trim();
+}
+
+const short = (sha) => (typeof sha === 'string' ? sha.slice(0, 7) : String(sha));
+
+// fresh PASS면 null, 아니면 {code, why, hint} — code는 red-events 텔레메트리 사유 코드.
+function judge() {
+  if (!existsSync(STATE)) {
+    return {
+      code: 'stop-verdict-missing',
+      why: 'verdict 미기록 — 이 루프에서 검증기가 아직 verdict를 남기지 않았다(fail-closed)',
+      hint: '`pnpm verdict`(또는 loop-engine@paul-loop 플러그인의 bin/verdict-run.sh -- <verify>, `node tools/plugin-path.mjs exec bin/verdict-run.sh -- <verify>`로 실행)를 실행해 fresh PASS를 기록하라',
+    };
+  }
+  let st;
+  try {
+    st = JSON.parse(readFileSync(STATE, 'utf8'));
+  } catch {
+    return {
+      code: 'stop-state-unreadable',
+      why: 'verdict 상태 파일(.loop/verdict-state.json) 파싱 실패(fail-closed)',
+      hint: '검증기(verdict-run.sh)를 재실행해 상태를 재생성하라',
+    };
+  }
+  if (st?.verdict !== 'PASS') {
+    return {
+      code: 'stop-verdict-fail',
+      why: `마지막 verdict가 ${st?.verdict ?? '(unknown)'} (exit=${st?.exit ?? '?'}, at=${st?.finished_at ?? '?'})`,
+      hint:
+        `FAIL 원인을 고친 뒤 검증기를 재실행해 PASS를 받아라 — 자기 판단이 verdict를 대체하지 ` +
+        `않는다(검증기=천장). 로그: ${st?.log ?? '.loop/last-run.log'}`,
+    };
+  }
+  // PASS — 신선도(AC5): 기록 sha==HEAD AND 기록 clean AND 현재 clean.
+  let head;
+  let dirtyNow;
+  try {
+    head = gitOut(['rev-parse', 'HEAD']);
+    dirtyNow = gitOut(['status', '--porcelain']) !== '';
+  } catch (e) {
+    return {
+      code: 'stop-freshness-failed',
+      why: `신선도 확인 실패(git: ${String(e?.message ?? e).split('\n')[0]}) — PASS를 인정할 수 없다(fail-closed)`,
+      hint: 'git 저장소 상태를 복구한 뒤 검증기를 재실행하라',
+    };
+  }
+  if (st.sha !== head) {
+    return {
+      code: 'stop-verdict-stale',
+      why: `PASS가 stale — 기록 sha ${short(st.sha)} ≠ 현재 HEAD ${short(head)}`,
+      hint: '현재 HEAD에서 검증기를 재실행해 fresh PASS를 만들라(캐시 리플레이 PASS도 같은 기준)',
+    };
+  }
+  if (st.dirty !== false) {
+    return {
+      code: 'stop-verdict-dirty-at-verify',
+      why: 'PASS가 dirty 트리에서 기록됨 — 검증된 내용이 HEAD와 다를 수 있다',
+      hint: '변경을 커밋한 뒤 검증기를 재실행해 fresh PASS를 만들라',
+    };
+  }
+  if (dirtyNow) {
+    return {
+      code: 'stop-tree-dirty-now',
+      why: 'fresh PASS 이후 작업트리에 미커밋 변경이 생겼다',
+      hint: '변경을 커밋(또는 폐기)한 뒤 검증기를 재실행해 fresh PASS를 만들라',
+    };
+  }
+  return null;
+}
+
+function block(failure) {
+  // 연속 deny 카운터(AC8) — session_id 단위. 부재·손상·다른 세션이면 0부터.
+  let denies = 0;
+  try {
+    const c = JSON.parse(readFileSync(COUNTER, 'utf8'));
+    if (c?.sessionId === sessionId && Number.isInteger(c?.denies) && c.denies >= 0)
+      denies = c.denies;
+  } catch {
+    /* 0부터 */
+  }
+  denies += 1;
+  let counterPersisted = true;
+  try {
+    mkdirSync(dirname(COUNTER), { recursive: true });
+    writeFileSync(
+      COUNTER,
+      JSON.stringify({ sessionId, denies, updatedAt: new Date().toISOString() }),
+    );
+  } catch {
+    counterPersisted = false;
+  }
+
+  const shouldEscape = denies > MAX_CONSECUTIVE_DENIES || (!counterPersisted && stopHookActive);
+  if (shouldEscape) {
+    redEvent('stop-gate-escape'); // best-effort
+    const msg =
+      `[gate-stop-verdict] 탈출 밸브: verdict 게이트가 연속 ${MAX_CONSECUTIVE_DENIES}회 차단 후 종료를 ` +
+      `허용했다${counterPersisted ? '' : ' (카운터 영속화 실패 — stop_hook_active 안전망)'}. ` +
+      `마지막 상태: ${failure.why}. 이 탈출은 PASS가 아니다 — verdict 상태는 그대로 남으며, 사람이 확인해야 한다.`;
+    process.stdout.write(JSON.stringify({ systemMessage: msg }));
+    console.error(msg); // 브레드크럼
+    return; // exit 0 — 종료 허용, PASS 기록 없음(AC8)
+  }
+
+  redEvent(failure.code); // best-effort — 판정 불변
+  console.error(
+    `[gate-stop-verdict] 턴 종료 차단 (연속 ${denies}/${MAX_CONSECUTIVE_DENIES}회): ${failure.why}. ` +
+      `다음 행동: ${failure.hint}. ` +
+      `이 게이트는 루프 무장(.loop/looping) 동안만 발동하며, 가드레일이지 경계가 아니다(ADR-0036).`,
+  );
+  process.exitCode = 2; // 공식 Stop 훅 계약: exit 2 = 차단, stderr → 에이전트. (명시적 exitCode — process.exit 금지)
+}
+
+function main() {
+  // biome-ignore lint/suspicious/noUndeclaredEnvVars: 로컬 디버깅용 킬스위치(AC7) — 기본 ON.
+  if (process.env.LOOP_STOP_GATE_OFF === '1') return; // 킬스위치 — 무출력 통과
+  if (!existsSync(SENTINEL)) return; // 센티넬 없음 = 일상 세션 무간섭(무출력 exit 0)
+
+  const failure = judge();
+  if (!failure) {
+    try {
+      unlinkSync(COUNTER); // fresh PASS 통과 → "연속" 카운터 리셋
+    } catch {
+      /* 부재·삭제 실패 무해 — 다음 deny가 세션 불일치로 0부터 세거나 이어 센다 */
+    }
+    return; // 통과(무출력 exit 0)
+  }
+  block(failure);
+}
+
+try {
+  main();
+} catch (e) {
+  // 예상 밖 내부 오류: 무장 중이면 fail-closed로 1회 차단하되, 재시도(stop_hook_active=true)는
+  // 통과시켜 크래시 반복이 무한 루프가 되지 않게 한다(AC3 안전망과 동일 원리).
+  const brief = String(e?.message ?? e).split('\n')[0];
+  if (stopHookActive) {
+    console.error(
+      `[gate-stop-verdict] 내부 오류(${brief}) — 재시도라 안전망으로 통과시킨다(사람 확인 필요).`,
+    );
+    process.exitCode = 0;
+  } else {
+    console.error(
+      `[gate-stop-verdict] 내부 오류(${brief}) — 무장 중이라 fail-closed로 1회 차단한다.`,
+    );
+    process.exitCode = 2;
+  }
+}

--- a/tools/loop-engine/hooks/gate-worktree-create.mjs
+++ b/tools/loop-engine/hooks/gate-worktree-create.mjs
@@ -1,0 +1,144 @@
+#!/usr/bin/env node
+// PreToolUse guardrail — when `git worktree add` creates a new branch (not just explicit `-b`/`-B`,
+// but also when git DWIM-creates one because the commit-ish was omitted), detects and blocks it unless
+// the base is an explicit origin/* ref. Machinery for "create new worktrees from origin/<integration
+// branch>, not local" (see this repo's own worktree-discipline convention, if it has one). Prevents
+// the recurring incident where a worktree created from a stale local branch conflicts, file-by-file,
+// with another PR that already merged.
+//
+// This hook is a guardrail, not a boundary — it's bypassable, and a coarse-net parser can't fully
+// emulate shell syntax.
+//
+// Why PreToolUse(Bash) instead of Claude Code's official WorktreeCreate hook event: per official docs
+// (code.claude.com/docs/en/hooks), WorktreeCreate only fires for Claude Code's own worktree mechanisms
+// (the EnterWorktree tool, Agent isolation:"worktree", a background session, etc.) — not for a manual
+// `git worktree add` run directly via Bash, which is how most repos following this harness actually
+// create worktrees. So this follows the repo's existing pattern instead (the same way
+// gate-before-merge.mjs intercepts `git merge`/`git pull` via a PreToolUse+Bash matcher and a
+// tokenizer).
+//
+// Unlike gate-before-merge.mjs, this hook doesn't need the "single simple command" constraint: the
+// base ref for `git worktree add` is an explicit token inside that one segment (unlike merge/pull's
+// target, which depends on cwd's implicit HEAD) — so however much chaining surrounds it, this
+// segment's own judgment is unaffected. That's why a chained idiom like
+// `git fetch origin && git worktree add -b <branch> <path> origin/main` still evaluates cleanly,
+// segment by segment.
+//
+// Scope: only calls that create a new branch. Covers not just explicit `-b`/`-B` but also
+// `git worktree add <path>` with the commit-ish omitted (git auto-creates a new branch from local HEAD
+// as if `-b $(basename <path>)` were given — the exact failure mode this hook exists to catch).
+// `--detach`/`--orphan`, or attaching an existing branch explicitly (a commit-ish is given), are out of
+// scope. Any `origin/*` ref is accepted, not just the integration branch — covering both the common
+// case and the documented exception (e.g. `git worktree add -b main <path> origin/main`, a
+// main-tracking-only worktree) with one rule.
+
+import { readFileSync } from 'node:fs';
+import {
+  firstSubcommand,
+  GIT_VALUE_GLOBAL,
+  splitSegments,
+  stripHeredocs,
+  stripPrefix,
+  tokenize,
+} from './command-tokenizer.mjs';
+import { logRedEvent } from './red-events-log.mjs';
+
+// biome-ignore lint/suspicious/noUndeclaredEnvVars: Claude Code injects this at hook runtime.
+const root = process.env.CLAUDE_PROJECT_DIR ?? process.cwd();
+
+function allow() {
+  process.exit(0);
+}
+function deny(reason, code) {
+  logRedEvent(root, { kind: 'worktree-create-guard', code });
+  process.stdout.write(
+    JSON.stringify({
+      hookSpecificOutput: {
+        hookEventName: 'PreToolUse',
+        permissionDecision: 'deny',
+        permissionDecisionReason: reason,
+      },
+    }),
+  );
+  process.exit(0);
+}
+
+// `git worktree add`'s own value flags — -b/-B are the new branch name, --reason is a --lock message.
+const VALUE_WORKTREE_ADD = new Set(['-b', '-B', '--reason']);
+
+// `git [global opts] worktree add [flags...] <path> [<ref>]` -> { newBranch, ref } | null (not a match).
+function parseWorktreeAdd(rawToks) {
+  const toks = stripPrefix(rawToks);
+  if (toks[0] !== 'git') return null;
+  const wIdx = firstSubcommand(toks, 1, GIT_VALUE_GLOBAL);
+  if (toks[wIdx] !== 'worktree' || toks[wIdx + 1] !== 'add') return null;
+  let i = wIdx + 2;
+  let explicitNewBranch = false;
+  let detachOrOrphan = false;
+  const positional = [];
+  while (i < toks.length) {
+    const t = toks[i];
+    if (t === '-b' || t === '-B') explicitNewBranch = true;
+    if (t === '--detach' || t === '-d' || t === '--orphan') detachOrOrphan = true;
+    if (t.startsWith('-')) {
+      i += VALUE_WORKTREE_ADD.has(t) && !t.includes('=') ? 2 : 1;
+      continue;
+    }
+    positional.push(t);
+    i += 1;
+  }
+  // When the commit-ish is omitted (and none of -b/-B/--detach/--orphan is given), git DWIMs a new
+  // branch from local HEAD as if -b $(basename <path>) were given (per `git worktree add` docs) — the
+  // same risk as an explicit -b/-B, so treated identically.
+  const dwimNewBranch = !explicitNewBranch && !detachOrOrphan && positional.length <= 1;
+  return { newBranch: explicitNewBranch || dwimNewBranch, ref: positional[1] ?? null };
+}
+
+// -- Detection (fail-open: an uncertain parse / a non-target command passes) -------------------------
+let payload;
+try {
+  payload = JSON.parse(readFileSync(0, 'utf8'));
+} catch {
+  allow();
+}
+if (payload?.tool_name !== 'Bash') allow();
+const cmd = payload?.tool_input?.command;
+if (typeof cmd !== 'string' || !cmd) allow();
+
+let segs;
+try {
+  segs = splitSegments(stripHeredocs(cmd)).map(tokenize).map(parseWorktreeAdd).filter(Boolean);
+} catch {
+  allow();
+}
+if (!segs.some((s) => s.newBranch)) allow();
+
+// -- Confirmed -> fails closed from here: a branch-creating worktree add without an origin/* base --
+try {
+  for (const seg of segs) {
+    if (!seg.newBranch) continue;
+    if (!seg.ref) {
+      deny(
+        "When `git worktree add` creates a new branch (-b/-B, or an omitted commit-ish), omitting the " +
+          "base ref makes local HEAD the implicit base (if local is behind origin, this conflicts with " +
+          "another already-merged PR). Specify an origin/* ref explicitly, e.g. " +
+          "`git fetch origin && git worktree add -b <branch> <path> origin/<integration-branch>`.",
+        'no-explicit-ref',
+      );
+    }
+    if (!seg.ref.startsWith('origin/')) {
+      deny(
+        `'${seg.ref}' is a local ref — since merges all happen server-side (GitHub), the server ` +
+          "(origin) is the source of truth. Specify an origin/* ref explicitly, e.g. " +
+          "`git fetch origin && git worktree add -b <branch> <path> origin/<integration-branch>`.",
+        'non-origin-ref',
+      );
+    }
+  }
+  allow();
+} catch (e) {
+  deny(
+    `worktree-create guard internal error (fail-closed): ${String(e?.message ?? e).split('\n')[0]}`,
+    'internal-error',
+  );
+}

--- a/tools/loop-engine/hooks/hooks.json
+++ b/tools/loop-engine/hooks/hooks.json
@@ -1,0 +1,85 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          { "type": "command", "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/loop-doctor-heartbeat.mjs\"", "timeout": 5 },
+          { "type": "command", "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/record-run-event.mjs\"", "timeout": 5 }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          { "type": "command", "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/record-run-event.mjs\"", "timeout": 5 }
+        ]
+      }
+    ],
+    "PermissionRequest": [
+      {
+        "hooks": [
+          { "type": "command", "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/record-run-event.mjs\"", "timeout": 5 }
+        ]
+      }
+    ],
+    "PermissionDenied": [
+      {
+        "hooks": [
+          { "type": "command", "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/record-run-event.mjs\"", "timeout": 5 }
+        ]
+      }
+    ],
+    "SubagentStart": [
+      {
+        "hooks": [
+          { "type": "command", "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/record-run-event.mjs\"", "timeout": 5 }
+        ]
+      }
+    ],
+    "SubagentStop": [
+      {
+        "hooks": [
+          { "type": "command", "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/record-run-event.mjs\"", "timeout": 5 }
+        ]
+      }
+    ],
+    "InstructionsLoaded": [
+      {
+        "hooks": [
+          { "type": "command", "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/record-run-event.mjs\"", "timeout": 5 }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          { "type": "command", "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/gate-stop-verdict.mjs\"", "timeout": 15 }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit|Bash",
+        "hooks": [
+          { "type": "command", "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/protect-during-loop.mjs\"" }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          { "type": "command", "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/gate-before-merge.mjs\"", "timeout": 30 },
+          { "type": "command", "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/gate-risky-commands.mjs\"", "timeout": 30 },
+          { "type": "command", "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/gate-worktree-create.mjs\"", "timeout": 15 }
+        ]
+      }
+    ],
+    "PostToolUseFailure": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          { "type": "command", "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/warn-partial-checkout.mjs\"", "timeout": 10 }
+        ]
+      }
+    ]
+  }
+}

--- a/tools/loop-engine/hooks/loop-doctor-heartbeat.mjs
+++ b/tools/loop-engine/hooks/loop-doctor-heartbeat.mjs
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+// SessionStart hook — a self-improvement dashboard heartbeat. Cost ceiling: 0 embedding API calls, 0
+// docker exec, 0 pnpm/CLI spawns, at most 2 git calls (check (1)'s `git status` +, if a project-local
+// `.env` isn't found, a `git rev-parse --git-common-dir` fallback probe for a main-worktree `.env` —
+// this fallback fires on essentially every call from a feature worktree), 1 localhost TCP probe (check
+// (3) below):
+//   (1) an uncommitted verified lesson (.loop/lessons/*.json) -> a reproducibility-gap nudge (won't be
+//       seen by another clone until committed)
+//   (2) `pnpm loop:doctor` (or this repo's equivalent) hasn't run in 7+ days (.loop/doctor.last) -> a
+//       full self-check nudge
+//   (3) semantic-recall layer liveness: unless `LOOP_RECALL_OFF=1`, always judged. If an embedding key
+//       is present but loop-memory's pgvector isn't reachable -> a "pgvector is down" nudge. If no key
+//       is present at all -> **also** a nudge (a worktree-isolated setup can silently be off, and
+//       "no key = intentionally off" is not a safe assumption to make silently). `LOOP_RECALL_OFF=1` is
+//       the only silent opt-out.
+// The full diagnostic (a real pgvector query, a recall smoke test) is too expensive for a SessionStart
+// hook — that's `pnpm loop:doctor`'s job. Same shape as a deps-audit heartbeat (SessionStart is the
+// right mechanism for a local-cadence reminder).
+//
+// ⚠️ FAIL-OPEN: always exit 0. Disable with LOOP_DOCTOR_HEARTBEAT_OFF=1.
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const env = process.env;
+const DAY = 86_400_000;
+const EVERY_DAYS = 7;
+
+// Bridges Claude Code's userConfig injection (CLAUDE_PLUGIN_OPTION_<KEY>) — as declared by the
+// loop-memory plugin's own userConfig schema — into the plain env var names this check reads, the
+// same way loop-memory's own hooks do. A plain shell-exported value always wins if already set.
+for (const [pluginOpt, plain] of [
+  ['CLAUDE_PLUGIN_OPTION_OPENAI_API_KEY', 'OPENAI_API_KEY'],
+  ['CLAUDE_PLUGIN_OPTION_GEMINI_API_KEY', 'GEMINI_API_KEY'],
+  ['CLAUDE_PLUGIN_OPTION_LOOP_DATABASE_URL', 'LOOP_DATABASE_URL'],
+]) {
+  if (!env[plain] && env[pluginOpt]) env[plain] = env[pluginOpt];
+}
+
+try {
+  if (env.LOOP_DOCTOR_HEARTBEAT_OFF === '1') process.exit(0);
+  const root = env.CLAUDE_PROJECT_DIR || process.cwd();
+  const nudges = [];
+
+  // (1) Uncommitted lessons — the cheapest git signal. Silently skipped on non-git / a git failure
+  // (fail-open).
+  try {
+    const st = execFileSync('git', ['-C', root, 'status', '--porcelain', '--', '.loop/lessons'], {
+      encoding: 'utf8',
+      timeout: 3000,
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+    const untracked = st
+      .split('\n')
+      .filter((l) => l.startsWith('??') && l.trim().endsWith('.json')).length;
+    if (untracked > 0) nudges.push(`${untracked} uncommitted verified lesson(s) — commit so other clones see them`);
+  } catch {
+    /* fail-open */
+  }
+
+  // (2) Self-diagnostic is stale or has never run.
+  try {
+    const stamp = join(root, '.loop', 'doctor.last');
+    const last = existsSync(stamp) ? parseInt(readFileSync(stamp, 'utf8').trim(), 10) || 0 : 0;
+    const days = last ? Math.floor((Date.now() - last) / DAY) : null;
+    if (days === null || days >= EVERY_DAYS)
+      nudges.push('loop self-diagnostic is stale — run `pnpm loop:doctor` (or this repo\'s equivalent)');
+  } catch {
+    /* fail-open */
+  }
+
+  // (3) Semantic-recall layer liveness. If `LOOP_RECALL_OFF=1` is set, that's an intentional opt-out —
+  // pass silently (don't re-flag an intentional off-switch as noise). Otherwise it splits on key
+  // presence:
+  //   - key present but the DB isn't reachable -> a "pgvector is down" nudge.
+  //   - no key at all -> **still nudge** (a worktree-isolated setup can be silently dead, and "no key =
+  //     intentional off" is not something this heartbeat can safely assume without evidence).
+  try {
+    if (env.LOOP_RECALL_OFF !== '1') {
+      const hasKey = !!(env.OPENAI_API_KEY || env.GEMINI_API_KEY);
+      if (!hasKey) {
+        nudges.push(
+          'semantic recall is fully off — no embedding key (can be silently dead due to worktree isolation) — ' +
+            'run `pnpm loop:doctor` to check, or set `LOOP_RECALL_OFF=1` if this is intentional',
+        );
+      } else {
+        const { tcpReachable } = await import('../lib/tcp-reachable.mjs');
+        const dbUrl = env.LOOP_DATABASE_URL || 'postgresql://postgres:postgres@localhost:5434/loop_memory';
+        const db = await tcpReachable(dbUrl, 2000);
+        if (!db.ok) {
+          nudges.push(
+            `semantic recall is off — an embedding key is set but pgvector isn't reachable (${db.label}) — ` +
+              'start loop-memory\'s database (see its docker-compose.yml / README)',
+          );
+        }
+      }
+    }
+  } catch (e) {
+    // fail-open — this hook missing one nudge matters less than wedging the session. Still, total
+    // silence regardless of cause would make "plugin not resolved" indistinguishable from "a transient
+    // git/DB error", so a breadcrumb only.
+    console.error(
+      `[loop-doctor-heartbeat] semantic-recall check failed (fail-open): ${String(e?.message ?? e)}`,
+    );
+  }
+
+  if (nudges.length) console.log(`🩺 loop-doctor: ${nudges.join(' · ')}`);
+} catch {
+  /* fail-open */
+}
+process.exit(0);

--- a/tools/loop-engine/hooks/protect-during-loop.mjs
+++ b/tools/loop-engine/hooks/protect-during-loop.mjs
@@ -1,0 +1,157 @@
+#!/usr/bin/env node
+// PreToolUse guard — reward-hacking defense: blocks **Edit/Write/MultiEdit (file paths) and Bash
+// (shell mutation)** against files that decide the verifier's outcome (a consuming repo's
+// `.loop/protect.globs`), at the harness level.
+//
+// Arming is structural, not prose: relying only on a `.loop/looping` sentinel (touched by the loop
+// being watched, i.e. by the very agent it's meant to constrain) leaves the guard silently off
+// whenever context gets compacted and the agent forgets to arm it. Armed state is decided by a shared
+// judge (lib/protect-globs.mjs `guardState`):
+//   armed = `.loop/looping` present (owned by loop-fix.sh — takes priority over guard-off)
+//        OR (on a working branch, outside the consuming repo's protected-branch set, AND no valid
+//            `.loop/guard-off`)
+// Legitimate edits to protected files (writing a failing TDD test, touching package.json/turbo.json)
+// escape via: `echo '<reason>' > .loop/guard-off` (empty file is invalid; TTL 30 min — prevents a
+// permanent off-switch) -> edit -> `rm -f .loop/guard-off`, with the reason recorded in the PR body.
+//
+// Bash channel: what a shell touches is undecidable in general -> a conservative coarse net. Blocks
+// only when a command (a) looks mutating (rm/mv/cp/sed -i/redirection/etc.) AND (b) contains a token
+// that hits a protected glob. Pure reads (cat/grep/pnpm test/etc.) pass through. The real boundary is
+// PR review, not this hook.
+//
+// fail-open: internal error / non-git / detached -> allow (never wedge the session).
+
+import { existsSync, readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { join, relative } from 'node:path';
+
+// biome-ignore lint/suspicious/noUndeclaredEnvVars: Claude Code injects this at hook runtime (not a
+// turbo task var).
+const root = process.env.CLAUDE_PROJECT_DIR ?? process.cwd();
+// This hook ships inside loop-engine's own package (hooks/ is a sibling of lib/), so "where is the
+// plugin I need to protect" is just "the directory one level above this file" — no cross-package
+// resolution needed.
+const pluginPath = fileURLToPath(new URL('..', import.meta.url)).replace(/\/$/, '');
+
+let GUARD_OFF_TTL_MS;
+let globToRegExp;
+let guardState;
+let loadPatterns;
+let state;
+try {
+  ({ GUARD_OFF_TTL_MS, globToRegExp, guardState, loadPatterns } = await import(
+    '../lib/protect-globs.mjs'
+  ));
+  state = guardState(root);
+} catch (e) {
+  console.error(`[protect-during-loop] judge module load failed (fail-open): ${String(e?.message ?? e)}`);
+  process.exit(0);
+}
+if (!state.armed) process.exit(0);
+
+let payload;
+try {
+  payload = JSON.parse(readFileSync(0, 'utf8'));
+} catch {
+  process.exit(0); // stdin parse failure -> fail-open
+}
+const tool = payload?.tool_name;
+const input = payload?.tool_input ?? {};
+
+const globFile = join(root, '.loop', 'protect.globs');
+if (!existsSync(globFile)) process.exit(0);
+
+const patterns = loadPatterns(globFile);
+const matchesGlob = (tok) => patterns.some((p) => globToRegExp(p).test(tok));
+
+const TTL_MIN = Math.round(GUARD_OFF_TTL_MS / 60000);
+function escapeHint() {
+  if (state.mode === 'sentinel') {
+    return 'A loop-fix loop is armed (.loop/looping, owned by loop-fix.sh) — retry after the loop ends.';
+  }
+  const why =
+    state.mode === 'guard-off-empty'
+      ? ' (.loop/guard-off is empty and invalid — a reason string is required)'
+      : state.mode === 'guard-off-expired'
+        ? ` (.loop/guard-off window expired — TTL ${TTL_MIN}min)`
+        : '';
+  return (
+    `On a working branch (${state.branch}) the guard is always armed${why}. ` +
+    `For a legitimate change: echo '<reason>' > .loop/guard-off (${TTL_MIN}min window) -> edit -> ` +
+    `rm -f .loop/guard-off, and record the reason in the PR body.`
+  );
+}
+
+function deny(reason) {
+  process.stdout.write(
+    JSON.stringify({
+      hookSpecificOutput: {
+        hookEventName: 'PreToolUse',
+        permissionDecision: 'deny',
+        permissionDecisionReason: reason,
+      },
+    }),
+  );
+  process.exit(0);
+}
+
+// -- Bash channel: a fixer changing verifier-deciding files via shell (reward-hacking) --------------
+if (tool === 'Bash') {
+  const cmd = input?.command;
+  if (typeof cmd !== 'string' || !cmd) process.exit(0);
+  // (a) does it look mutating — conservative; the real gate is the token match below, so
+  // over-matching here is harmless (it only lets more commands through the mutation check).
+  const mutates =
+    /(^|[\s;&|(])(rm|unlink|mv|cp|dd|truncate|tee|install)\b/.test(cmd) ||
+    /\bsed\b[^|;&]*\s-[a-z]*i/.test(cmd) ||
+    /\bgit\s+(checkout|restore|reset|stash)\b/.test(cmd) ||
+    />>?/.test(cmd);
+  if (!mutates) process.exit(0);
+  // (b) does it carry a token that hits a protected glob — or a token pointing at this plugin's own
+  // install path. The latter matters because .loop/protect.globs is a repo-relative glob set and can
+  // never, in principle, cover a path outside the repo (the plugin cache) — and if only the Edit/Write
+  // channel below blocked that, a single `sed -i` would bypass it.
+  const inPlugin = (t) => t === pluginPath || t.startsWith(`${pluginPath}/`);
+  const tokens = cmd
+    .split(/[\s>|<;&()'"`]+/)
+    .filter(Boolean)
+    .map((t) => t.replace(/^\.\//, ''));
+  const hitTok = tokens.find((t) => matchesGlob(t) || inPlugin(t));
+  if (!hitTok) process.exit(0);
+  deny(
+    `Bash blocked while the guard is armed: '${hitTok}' matches ${inPlugin(hitTok) ? `this project's verifier itself (loop-engine, ${pluginPath})` : '.loop/protect.globs'}. ` +
+      `Don't modify files that decide the verifier's outcome (tests, snapshots, config, migrations, the guard itself) via shell — verifier=ceiling (reward-hacking defense). ` +
+      `Make the source code pass the verifier instead. ${escapeHint()}`,
+  );
+}
+
+// -- Edit/Write/MultiEdit channel: file paths ---------------------------------------------------------
+const filePath = input?.file_path;
+if (typeof filePath !== 'string' || !filePath) process.exit(0);
+
+// The verifier itself (classify-risk, gate, verdict-run, protect-globs, etc.) now lives outside the
+// repo, in the installed plugin cache. .loop/protect.globs is a repo-relative glob set and can't cover
+// that path in principle. Before falling through to the repo-relative match below (which would treat
+// "outside the repo" as "pass"), block the plugin's own install path directly by absolute-path prefix
+// — code, not a glob, because this path is outside the repo. Still part of the verifier=ceiling
+// invariant.
+if (filePath === pluginPath || filePath.startsWith(`${pluginPath}/`)) {
+  deny(
+    `loop-engine plugin file blocked while the guard is armed: '${filePath}' is this project's verifier itself (loop-engine, ${pluginPath}). ` +
+      `It lives outside the repo but still decides verdicts, so it's protected for the same reason as .loop/protect.globs. ` +
+      `Make the source code pass the verifier instead. ${escapeHint()}`,
+  );
+}
+
+const rel = relative(root, filePath).split('\\').join('/');
+// Paths outside the repo (another repo, /tmp, $HOME, etc. — the plugin path is already handled above)
+// aren't protected -> allow (`../` and absolute paths are excluded from matching).
+if (rel === '..' || rel.startsWith('../') || rel.startsWith('/')) process.exit(0);
+const hit = patterns.find((p) => globToRegExp(p).test(rel));
+if (!hit) process.exit(0);
+
+deny(
+  `Protected-file write blocked while the guard is armed: '${rel}' matches .loop/protect.globs ('${hit}'). ` +
+    `Don't modify files that decide the verifier's outcome (tests, snapshots, config, migrations, the guard itself) — verifier=ceiling (reward-hacking defense). ` +
+    `Make the source code pass the verifier instead. ${escapeHint()}`,
+);

--- a/tools/loop-engine/hooks/record-run-event.mjs
+++ b/tools/loop-engine/hooks/record-run-event.mjs
@@ -1,0 +1,113 @@
+#!/usr/bin/env node
+// record-run-event.mjs — run-event instrumentation hook. Never judges, never blocks — every error is
+// a no-op (exit 0).
+//
+// If this hook exits 2 on PermissionRequest, that permission gets denied (official hooks doc: "Exit
+// Code 2 Behavior: Denies the permission") — instrumentation must never change permission flow, so
+// this file never exits non-zero (main().finally(exit 0)). No stdout either — SessionStart's stdout is
+// the additionalContext injection channel, and an instrumentation hook must not pollute context.
+//
+// Writes via lib/run-ledger.mjs -> <consuming-repo>/.loop/runs/<run-id>.jsonl (append-only, gitignored
+// local telemetry). run-id = a sanitized stdin session_id (a run's boundary = the session's boundary).
+// verdict.* events are appended by loop-engine's own bin/verdict-run.sh directly, not by this hook —
+// consistent with "the agent can't write its own verdict state" (verifier=ceiling).
+//
+// Best-effort dependencies are dynamically imported — a static import would let a broken dependency
+// silently disable the whole hook.
+import { readFileSync } from 'node:fs';
+
+const TYPE = {
+  SessionStart: 'run.started',
+  SessionEnd: 'run.ended',
+  PermissionRequest: 'permission.requested',
+  PermissionDenied: 'permission.denied',
+  SubagentStart: 'subagent.started',
+  SubagentStop: 'subagent.stopped',
+  InstructionsLoaded: 'instructions.loaded',
+};
+
+// Common stdin fields (official hooks doc) — noise to drop from instructions.loaded's "everything
+// else" payload.
+const COMMON_FIELDS = new Set([
+  'session_id',
+  'prompt_id',
+  'transcript_path',
+  'cwd',
+  'permission_mode',
+  'hook_event_name',
+  'agent_id',
+  'agent_type',
+]);
+
+// sanitize() scans the full string *before* the 256-char storage cap — an unbounded command (e.g. a
+// base64 blob with no whitespace) makes the greedy-star regex backtrack O(n^2) and can blow the hook's
+// timeout (measured: a 64k-char command took ~3.4s). Storage truncates to 256 chars anyway, so
+// pre-truncate before sanitize. Surface classification alone still runs on the full string (a boundary
+// command sitting past the truncation point must not be missed).
+const PRE_SANITIZE_CAP = 2048;
+const capStr = (v) =>
+  typeof v === 'string' && v.length > PRE_SANITIZE_CAP ? v.slice(0, PRE_SANITIZE_CAP) : v;
+
+function pickPayload(type, input, surfaceOf) {
+  if (type === 'permission.requested' || type === 'permission.denied') {
+    return {
+      tool_name: input.tool_name,
+      command: capStr(input.tool_input?.command),
+      file_path: capStr(input.tool_input?.file_path),
+      tool_use_id: input.tool_use_id,
+      // bypassPermissions runs never fire this event at all, so an aggregator can't tell "no
+      // intervention needed" apart from "this event never fires here" without the mode on the event.
+      permission_mode: input.permission_mode,
+      // Surface tagging happens at record time — a long-command preview cap upstream can make surface
+      // classification impossible for very long commands. Aggregation should only count
+      // surface==null interventions.
+      surface: surfaceOf(input.tool_name, input.tool_input?.command),
+    };
+  }
+  if (type === 'subagent.started' || type === 'subagent.stopped') {
+    return { agent_id: input.agent_id, agent_type: input.agent_type };
+  }
+  if (type === 'run.started' || type === 'run.ended') {
+    return { cwd: input.cwd, reason: input.reason, permission_mode: input.permission_mode };
+  }
+  // instructions.loaded — the event-specific fields aren't documented: carry everything except the
+  // common fields, still pre-truncating unknown long strings (sanitize's blocklist/cap defends the
+  // content).
+  const rest = {};
+  for (const [k, v] of Object.entries(input)) {
+    if (!COMMON_FIELDS.has(k)) rest[k] = capStr(v);
+  }
+  return rest;
+}
+
+async function main() {
+  let input;
+  try {
+    input = JSON.parse(readFileSync(0, 'utf8'));
+  } catch {
+    return; // stdin parse failure = no-op
+  }
+  const type = TYPE[input?.hook_event_name];
+  if (!type) return;
+  // biome-ignore lint/suspicious/noUndeclaredEnvVars: Claude Code injects this at hook runtime.
+  const root = process.env.CLAUDE_PROJECT_DIR ?? process.cwd();
+  try {
+    const [ledger, surfaces] = await Promise.all([
+      import('../lib/run-ledger.mjs'),
+      import('../lib/boundary-surfaces.mjs'),
+    ]);
+    ledger.appendRunEvent(root, {
+      type,
+      sessionId: input.session_id,
+      payload: pickPayload(type, input, surfaces.boundarySurface),
+      writeCurrentPointer: type === 'run.started',
+      // A stale pointer left after session end would attribute a later terminal verdict to a dead
+      // run — clear only on our own run (run-ledger cross-checks); after that, verdicts honestly fall
+      // into the unknown bucket instead of misattributing.
+      clearCurrentPointer: type === 'run.ended',
+    });
+  } catch {
+    /* best-effort — instrumentation failure must never affect session/permission flow */
+  }
+}
+main().finally(() => process.exit(0));

--- a/tools/loop-engine/hooks/red-events-log.mjs
+++ b/tools/loop-engine/hooks/red-events-log.mjs
@@ -1,0 +1,47 @@
+// RED(차단) 이벤트 계측(BAC-366) — gate-before-merge.mjs(게이트 deny)가 쓰는 append-only 로거.
+// "차단율 단조감소" 성장 시계열(GNOSIS 리서치) 실측을 위해 PASS/allow가 아니라 실패/거부만 기록한다.
+// 소비(리포트/대시보드)는 범위 밖 — 포착만 먼저.
+//
+// best-effort: 로그 쓰기 실패가 호출자의 판정(게이트 allow/deny)을 절대 바꾸지 않는다 — 모든 예외를
+// 삼킨다. 위치는 `<git-common-dir>/loop-markers/red-events.log`라 모든 워크트리가 공유(cp 브리지 불필요).
+import { execFileSync } from 'node:child_process';
+import { appendFileSync, mkdirSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+/**
+ * @param {string} root - 이벤트가 발생한 워크트리(CLAUDE_PROJECT_DIR).
+ * @param {{kind: string, code?: string}} event - kind: 'gate'(머지 게이트 deny). code: deny의 사유 코드
+ *   (오탐 필터용 — 예: BAC-364 방향-오판 deny를 나중에 골라내기 위함).
+ */
+export function logRedEvent(root, event) {
+  try {
+    // 스프레드는 event가 undefined/null/문자열이어도 던지지 않는다 — 그래서 조용히 kind 없는(=이 지표의
+    // 목적 자체를 무의미하게 만드는) 로그 줄을 남길 수 있다. 이건 "계측 실패"가 아니라 "조용히 틀린
+    // 텔레메트리"라 별도로 막는다(멀티에이전트 리뷰 실측). 그래도 절대 throw는 안 함 — 여전히 no-op.
+    if (!event || typeof event.kind !== 'string') {
+      console.error('[red-events] logRedEvent에 잘못된 event가 들어와 기록을 건너뜀:', event);
+      return;
+    }
+    // stdio를 억제 — 이 로거가 실패하는 경로(root가 git repo가 아닌 등)는 fail-open으로 조용히 삼켜야
+    // 하는데, execFileSync 기본값은 부모 stdio를 상속해 git의 stderr(예: "fatal: not a git repository")가
+    // 호출자(gate-before-merge.mjs) 콘솔로 새어나간다 — 계측 실패가 눈에 띄면 안 된다(BAC-366).
+    // timeout — deny()의 6개 호출부 전부(내부 오류 fail-closed catch-all 포함)가 이 함수를 거치므로,
+    // git이 어떤 이유로든 멈추면 이 훅 전체가 hang한다 — 이 파일 자신의 헤더가 경고하는 바로 그 실패
+    // 모드(훅 timeout → fail-open)를 계측 코드가 다시 열면 안 된다. SIGTERM은 여전히 throw → 여전히 catch.
+    const git = (args) =>
+      execFileSync('git', args, {
+        cwd: root,
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'ignore'],
+        timeout: 2000,
+      }).trim();
+    const sha = git(['rev-parse', 'HEAD']);
+    const branch = git(['rev-parse', '--abbrev-ref', 'HEAD']);
+    const markerDir = resolve(root, git(['rev-parse', '--git-common-dir']), 'loop-markers');
+    mkdirSync(markerDir, { recursive: true });
+    const line = JSON.stringify({ ts: new Date().toISOString(), sha, branch, ...event });
+    appendFileSync(join(markerDir, 'red-events.log'), `${line}\n`);
+  } catch {
+    /* best-effort — 계측 실패가 게이트 판정에 영향을 주면 안 된다(BAC-366) */
+  }
+}

--- a/tools/loop-engine/hooks/warn-partial-checkout.mjs
+++ b/tools/loop-engine/hooks/warn-partial-checkout.mjs
@@ -1,0 +1,143 @@
+#!/usr/bin/env node
+// warn-partial-checkout.mjs — PostToolUseFailure(Bash) hook: when `git checkout`/`git rebase` fails
+// partway through, the working tree can be left with a subset of files partially reflecting the
+// target branch's content while HEAD never moved (measured reproduction: an unlink failure aborting
+// mid-checkout left unrelated files rewritten to the target branch's content, while the user's own
+// working files were deleted). To reduce the risk of this quiet data loss going unnoticed until
+// someone happens to run `git status`, this hook warns via systemMessage right after a failure if the
+// working tree is dirty, pointing at a recovery procedure.
+//
+// PostToolUseFailure can't block a command that already ran (official contract — this hook is a
+// guardrail, not a boundary) — it's purely informational. Observed behavior (headless `claude -p`
+// probes): this event fires when a Bash command exits non-zero (a success instead fires
+// PostToolUse), and the `error` field carries "Exit code N\n<stderr>" — but repeated measurement
+// (5 reproductions of the same failure scenario) found this event simply didn't fire at all on 1 of 5
+// runs, even though the Bash call had failed (unrelated to this file's own logic — it happens in
+// Claude Code's own hook-dispatch layer, outside what this hook can fix). So "always fires on a
+// non-zero exit" is an observed tendency, not a guarantee — this hook already sits on the "guardrail,
+// not a boundary" premise above, so this non-determinism is absorbed by the same premise (a human
+// still has to confirm with `git status` in the end — that's exactly the limit this warning names).
+// This hook doesn't parse the exit code at all — PostToolUseFailure firing is itself already the
+// "it failed" signal, so it only reads tool_input.command (detection) and cwd (for the status check) —
+// deliberately the smallest surface, so a schema change elsewhere doesn't break it.
+//
+// False-positive avoidance (measured): a successful checkout/rebase leaves the working tree clean
+// (and this hook doesn't even fire on success, so it's doubly safe) — a single dirty check catches
+// "command failed + something silently changed." A normal merge conflict also leaves the tree dirty,
+// and in that case the same advice ("check with git status, and restore your own files with
+// --source=HEAD") still applies, so this hook doesn't try to distinguish the two.
+//
+// cwd tracking: a `cd <dir> && git rebase ...` means the real target isn't payload.cwd — this is the
+// same evasion family gate-before-merge.mjs already documents (cd/-C/GIT_DIR=). This hook isn't a deny
+// gate, it's advisory, so it leans toward "follow along as best as possible so the warning isn't
+// missed" rather than "block if untrustworthy" — it walks segments in order and updates a running cwd
+// on every literal `cd`/`pushd <path>` (a variable expansion or `cd -`, which can't be resolved
+// statically, doesn't update it — the previous cwd is kept; a coarse net, not a full shell parser).
+
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import {
+  firstSubcommand,
+  GIT_VALUE_GLOBAL,
+  splitSegments,
+  stripHeredocs,
+  stripPrefix,
+  tokenize,
+} from './command-tokenizer.mjs';
+
+function allow() {
+  process.exit(0);
+}
+
+function warn(message) {
+  process.stdout.write(JSON.stringify({ systemMessage: message }));
+  process.exit(0);
+}
+
+// `git [global opts] (checkout|rebase) ...` -> { cflag } | null (not a match). toks arrives already
+// stripPrefix'd (reusing the same stripPrefix result the cd/pushd check uses). cflag: the value of
+// `-C <dir>` if present (git resolves subsequent paths relative to it).
+function parseCheckoutOrRebase(toks) {
+  if (toks[0] !== 'git') return null;
+  const idx = firstSubcommand(toks, 1, GIT_VALUE_GLOBAL);
+  if (toks[idx] !== 'checkout' && toks[idx] !== 'rebase') return null;
+  let cflag = null;
+  for (let i = 1; i < idx; i++) {
+    if (toks[i] === '-C' && !toks[i].includes('=')) cflag = toks[i + 1] ?? cflag;
+  }
+  return { cflag };
+}
+
+// `cd <literal-path>` | `pushd <literal-path>` -> that path string, else null (a variable expansion
+// (`$...`), `cd -`, or a bare `cd` can't be resolved statically -> null, keeping the previous cwd).
+function literalDirChange(toks) {
+  if (toks[0] !== 'cd' && toks[0] !== 'pushd') return null;
+  const dir = toks[1];
+  if (!dir || dir.startsWith('-') || dir.includes('$')) return null;
+  return dir;
+}
+
+// Walks the command's segments in order, deriving "the actual cwd at that point" for each
+// checkout/rebase segment — an earlier `cd`/`pushd <dir>` accumulates.
+function resolveTargetDirs(cmd, baseCwd) {
+  const segs = splitSegments(stripHeredocs(cmd)).map(tokenize).map(stripPrefix);
+  const targets = [];
+  let cwd = baseCwd;
+  for (const toks of segs) {
+    const dir = literalDirChange(toks);
+    if (dir) {
+      cwd = resolve(cwd, dir);
+      continue;
+    }
+    const m = parseCheckoutOrRebase(toks);
+    if (m) targets.push(m.cflag ? resolve(cwd, m.cflag) : cwd);
+  }
+  return targets;
+}
+
+function isDirty(cwd) {
+  try {
+    return (
+      execFileSync('git', ['status', '--porcelain'], {
+        cwd,
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'ignore'],
+        timeout: 5000,
+      }).trim().length > 0
+    );
+  } catch {
+    return false; // not a git repo, or undecidable -> don't warn (fail-open — this hook never makes noise it isn't sure about)
+  }
+}
+
+// -- Detection (fail-open: an uncertain parse / a non-target command passes) --------------------
+let payload;
+try {
+  payload = JSON.parse(readFileSync(0, 'utf8'));
+} catch {
+  allow();
+}
+if (payload?.tool_name !== 'Bash') allow();
+const cmd = payload?.tool_input?.command;
+if (typeof cmd !== 'string' || !cmd) allow();
+
+const baseCwd = typeof payload?.cwd === 'string' && payload.cwd ? payload.cwd : process.cwd();
+let targetDirs;
+try {
+  targetDirs = resolveTargetDirs(cmd, baseCwd);
+} catch {
+  allow();
+}
+if (targetDirs.length === 0) allow();
+
+const dirty = targetDirs.some((dir) => isDirty(dir));
+if (!dirty) allow();
+
+warn(
+  '⚠️ A git checkout/rebase failed and the working tree has uncommitted changes — some files may have ' +
+    'been silently, partially rewritten to the target branch\'s content, or your own working files may ' +
+    'have been deleted (HEAD did not move). Check `git status` now: restore anything that isn\'t your ' +
+    'own work with `git restore <path>`, and restore your own work specifically with ' +
+    '`git restore --source=HEAD -- <path>`.',
+);

--- a/tools/loop-engine/test/hooks-json-wiring.test.sh
+++ b/tools/loop-engine/test/hooks-json-wiring.test.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# Regression test for hooks/hooks.json (BAC-765/BAC-752 — loop-engine bundles its own hooks so a
+# consuming repo gets them via plugin-version bump instead of a hand-maintained local copy).
+#
+# Verifies the bundle actually wires up, not just that each file parses: every command in
+# hooks.json resolves to a real file under hooks/, every hook is valid JS, plugin.json points at
+# hooks.json, and each PreToolUse/Stop/SessionStart hook actually runs end-to-end against a benign
+# non-matching input (allow path) plus one deny-path behavioral check for gate-before-merge.mjs
+# (the one hook whose logic changed during the port — protected branches now come from a consuming
+# repo's ship-flow.config.json instead of being hardcoded).
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$HERE/../../.."
+ENGINE="$ROOT/tools/loop-engine"
+HOOKS="$ENGINE/hooks"
+
+fail() { echo "FAIL: $1"; exit 1; }
+
+[ -f "$ENGINE/.claude-plugin/plugin.json" ] || fail "plugin.json not found"
+[ -f "$HOOKS/hooks.json" ] || fail "hooks/hooks.json not found"
+
+node -e '
+  const fs = require("fs");
+  const path = require("path");
+  const engine = process.argv[1];
+
+  const plugin = JSON.parse(fs.readFileSync(path.join(engine, ".claude-plugin/plugin.json"), "utf8"));
+  if (plugin.hooks !== "./hooks/hooks.json") {
+    console.error(`FAIL: plugin.json "hooks" field must be "./hooks/hooks.json", got ${JSON.stringify(plugin.hooks)}`);
+    process.exit(1);
+  }
+
+  const hooksJson = JSON.parse(fs.readFileSync(path.join(engine, "hooks/hooks.json"), "utf8"));
+  const seen = new Set();
+  let count = 0;
+  for (const [event, entries] of Object.entries(hooksJson.hooks ?? {})) {
+    for (const entry of entries) {
+      for (const h of entry.hooks ?? []) {
+        count += 1;
+        const m = /\$\{CLAUDE_PLUGIN_ROOT\}\/(hooks\/[\w.-]+\.mjs)/.exec(h.command ?? "");
+        if (!m) {
+          console.error(`FAIL: ${event} hook command does not reference \${CLAUDE_PLUGIN_ROOT}/hooks/*.mjs: ${h.command}`);
+          process.exit(1);
+        }
+        const rel = m[1];
+        seen.add(rel);
+        if (!fs.existsSync(path.join(engine, rel))) {
+          console.error(`FAIL: ${event} hook references missing file: ${rel}`);
+          process.exit(1);
+        }
+      }
+    }
+  }
+  if (count < 8) {
+    console.error(`FAIL: expected at least 8 wired hook commands, found ${count}`);
+    process.exit(1);
+  }
+
+  // Every .mjs directly under hooks/ must be reachable from hooks.json, either as a top-level
+  // command or as a shared dependency (command-tokenizer.mjs / red-events-log.mjs are imported by
+  // other hooks, not registered directly) — this is a drift guard against an orphaned file.
+  const SHARED_DEPS = new Set(["hooks/command-tokenizer.mjs", "hooks/red-events-log.mjs"]);
+  for (const f of fs.readdirSync(path.join(engine, "hooks"))) {
+    if (!f.endsWith(".mjs")) continue;
+    const rel = `hooks/${f}`;
+    if (!seen.has(rel) && !SHARED_DEPS.has(rel)) {
+      console.error(`FAIL: hooks/${f} exists but is neither registered in hooks.json nor a known shared dependency`);
+      process.exit(1);
+    }
+  }
+  console.log(`hooks.json wiring OK — ${count} hook command(s), ${seen.size} distinct file(s)`);
+' "$ENGINE" || fail "hooks.json structural check failed"
+
+# Every hook file must be valid JS.
+for f in "$HOOKS"/*.mjs; do
+  node --check "$f" || fail "syntax error in $f"
+done
+
+DIR="$(mktemp -d "${TMPDIR:-/tmp}/tmp.XXXXXXXX")" || fail "mktemp -d failed"
+trap 'rm -rf "$DIR"' EXIT
+
+# -- Allow-path smoke test: every PreToolUse/Stop hook must run end-to-end (real relative imports
+# resolving, not just parsing) against a benign, non-matching input and exit 0 with no stdout. This
+# is the actual regression this port could break — a wrong `../lib/...` import path parses fine
+# under `node --check` but throws at runtime the first time the module is touched.
+run_allow() {
+  local name="$1" stdin="$2"
+  local out rc
+  out="$(printf '%s' "$stdin" | node "$HOOKS/$name" 2>"$DIR/stderr.$name")"
+  rc=$?
+  [ "$rc" -eq 0 ] || fail "$name: expected exit 0 on a benign input, got $rc (stderr: $(cat "$DIR/stderr.$name"))"
+  [ -z "$out" ] || fail "$name: expected no stdout on a benign (allow) input, got: $out"
+}
+run_allow "gate-before-merge.mjs" '{"tool_name":"Bash","tool_input":{"command":"ls -la"}}'
+run_allow "gate-risky-commands.mjs" '{"tool_name":"Bash","tool_input":{"command":"ls -la"}}'
+run_allow "gate-worktree-create.mjs" '{"tool_name":"Bash","tool_input":{"command":"ls -la"}}'
+run_allow "warn-partial-checkout.mjs" '{"tool_name":"Bash","tool_input":{"command":"ls -la"}}'
+run_allow "protect-during-loop.mjs" '{"tool_name":"Write","tool_input":{"file_path":"/tmp/not-protected.txt"}}'
+run_allow "gate-stop-verdict.mjs" '{"session_id":"hooks-json-wiring-test"}'
+
+# record-run-event.mjs and loop-doctor-heartbeat.mjs are always-exit-0/no-deny by design (pure
+# instrumentation / advisory nudges) — just confirm they run without throwing.
+printf '{"session_id":"hooks-json-wiring-test","hook_event_name":"SessionStart"}' \
+  | node "$HOOKS/record-run-event.mjs" >/dev/null 2>"$DIR/stderr.record" \
+  || fail "record-run-event.mjs threw on a valid SessionStart input (stderr: $(cat "$DIR/stderr.record"))"
+LOOP_DOCTOR_HEARTBEAT_OFF=1 node "$HOOKS/loop-doctor-heartbeat.mjs" </dev/null >/dev/null 2>"$DIR/stderr.doctor" \
+  || fail "loop-doctor-heartbeat.mjs threw with the kill switch on (stderr: $(cat "$DIR/stderr.doctor"))"
+rm -f "$DIR/.loop/runs" 2>/dev/null
+
+# -- Deny-path behavioral check: gate-before-merge.mjs on a protected branch, no ship-flow.config.json
+# present (the fallback-default path — protected = {main, master}) must deny a merge into main.
+REPO="$DIR/repo"
+mkdir -p "$REPO"
+git -C "$REPO" init -q -b main
+git -C "$REPO" config user.email test@example.com
+git -C "$REPO" config user.name test
+git -C "$REPO" commit -q --allow-empty -m init
+
+OUT="$(printf '{"tool_name":"Bash","tool_input":{"command":"git merge origin/develop"},"cwd":"%s"}' "$REPO" \
+  | CLAUDE_PROJECT_DIR="$REPO" node "$HOOKS/gate-before-merge.mjs")"
+printf '%s' "$OUT" | grep -q '"permissionDecision":"deny"' \
+  || fail "gate-before-merge.mjs: expected a deny decision merging into main with no ship-flow.config.json, got: $OUT"
+printf '%s' "$OUT" | grep -q "Can't land directly on main" \
+  || fail "gate-before-merge.mjs: deny reason must name the protected branch, got: $OUT"
+
+# -- Config-driven path: an explicit ship-flow.config.json narrows the protected set to what it says.
+mkdir -p "$REPO/.claude"
+printf '{"releaseBranch":"release","integrationBranch":"trunk"}' > "$REPO/.claude/ship-flow.config.json"
+OUT="$(printf '{"tool_name":"Bash","tool_input":{"command":"git merge origin/develop"},"cwd":"%s"}' "$REPO" \
+  | CLAUDE_PROJECT_DIR="$REPO" node "$HOOKS/gate-before-merge.mjs")"
+[ -z "$OUT" ] || fail "gate-before-merge.mjs: with ship-flow.config.json declaring release/trunk, a merge on 'main' must be allowed (main is no longer in the protected set), got: $OUT"
+
+echo "PASS: hooks/hooks.json — plugin.json wiring, file resolution, allow-path smoke test (8 hooks), gate-before-merge deny + config-driven protected-branch behavior"

--- a/tools/ship-flow/.claude-plugin/plugin.json
+++ b/tools/ship-flow/.claude-plugin/plugin.json
@@ -10,6 +10,6 @@
   "license": "MIT",
   "keywords": ["delivery", "git-flow", "hotfix", "ship", "release"],
   "dependencies": [
-    { "name": "loop-engine", "version": "^0.3.0" }
+    { "name": "loop-engine", "version": "^0.4.0" }
   ]
 }


### PR DESCRIPTION
## Summary
- loop-engine (and ship-flow) declared no hooks in `plugin.json` — only loop-memory did — so a consuming repo had to hand-maintain its own local `.claude/hooks/` copy of 8 hooks, and a plugin-version bump never reached them. Traced in a consuming repo's grill session (BAC-752, ADR-0078 addendum).
- Ports all 8 into `tools/loop-engine/hooks/`, wired via a new `hooks/hooks.json` (`plugin.json`'s new `hooks` field): `record-run-event`, `gate-stop-verdict`, `loop-doctor-heartbeat`, `protect-during-loop`, `gate-risky-commands`, `gate-before-merge`, `gate-worktree-create`, `warn-partial-checkout`.
- Three genericizations made during the port:
  1. Hooks resolve sibling `lib/`/`bin/` files via `import.meta.url` instead of a cross-package plugin-path resolver (they ship colocated now).
  2. `gate-before-merge`'s protected-branch set reads a consuming repo's `.claude/ship-flow.config.json` (`releaseBranch`/`integrationBranch`) instead of a hardcoded pair, falling back to `{main, master}`.
  3. `loop-doctor-heartbeat`'s embedding-key/DB-URL check bridges `CLAUDE_PLUGIN_OPTION_*` (loop-memory's own `userConfig` convention) instead of a hardcoded `.env` path.
- `ship-flow`'s `loop-engine` dependency bumped `^0.3.0` -> `^0.4.0`. `loop-engine` bumped `0.3.0` -> `0.4.0`.
- `docs/verdict-contract.md` updated (it previously said this plugin doesn't ship a Stop hook — now it does).

## Test plan
- [x] New `test/hooks-json-wiring.test.sh`: `plugin.json`/`hooks.json` structural wiring, orphaned-file drift guard, allow-path end-to-end smoke test for all 8 hooks, deny-path + config-driven-branch-set behavioral check for `gate-before-merge`.
- [x] Full `test/run.sh` self-test suite: 29/29 passing.
- [x] `claude plugin validate --strict .`: passes.

https://claude.ai/code/session_016y2zUZBrhEkwJyQx8nNC1Y