### PR TITLE
fix(ship-flow): bump version to force cache refresh of loop-engine dependency

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -19,7 +19,7 @@
       "name": "ship-flow",
       "source": "./tools/ship-flow",
       "description": "Delivery-loop skills — ship-feature (plan-to-PR autonomous loop), hotfix, retrospect, grill-with-docs, deps-audit, to-issues/to-prd, tdd, harness-maturity-audit, improve-codebase-architecture, resolving-merge-conflicts, plus review agents and audit/research workflows — parameterized by a consuming repo's own tracker/branch-model config instead of hardcoded to one repo. dependencies: loop-engine.",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "keywords": ["delivery", "git-flow", "hotfix", "ship", "release"]
     },
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,18 @@ and refer to `loop-engine` only (see the un-prefixed version numbers).
   guard against skill/doc examples pointing at consumer-repo-only paths (`tools/plugin-path.mjs`,
   `.claude/hooks/*`, `bin/loop-doctor.mjs`) as if this plugin ships them.
 
+## ship-flow 0.2.1
+
+- Fix: bump the plugin's own version so its `loop-engine` dependency bump (`^0.3.0` → `^0.4.0`,
+  landed earlier without a version bump alongside it) actually reaches installs. Claude Code's
+  plugin cache is keyed by `(name, version)` — with the version unchanged, every `claude plugin
+  update loop-engine@paul-loop` kept resolving against the *stale cached* `^0.3.0` constraint no
+  matter how new loop-engine's own marketplace version was, silently pinning consumers to
+  loop-engine 0.3.0 forever. No content change beyond the version number and this changelog entry —
+  found while reinstalling for glucofit-partners' BAC-766 verification (`claude plugin update
+  loop-engine@paul-loop` reported "already at latest satisfying ^0.3.0" even after loop-engine had
+  moved to 0.4.1).
+
 ## ship-flow 0.2.0
 
 - `publisher` subagent for ship-feature step 5 (#15): the Builder session — which has held

--- a/tools/ship-flow/.claude-plugin/plugin.json
+++ b/tools/ship-flow/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ship-flow",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Delivery-loop skills — land and release already-verified work through a repo's real gates. Tracker- and branch-model-agnostic: reads a consuming repo's own config instead of hardcoding one repo's setup.",
   "author": {
     "name": "paulkim-lansik"


### PR DESCRIPTION
## Summary
- ship-flow's `loop-engine` dependency was bumped `^0.3.0` → `^0.4.0` in an earlier PR without bumping ship-flow's own version alongside it.
- Claude Code's plugin cache is keyed by `(name, version)`. With ship-flow's version unchanged, every install/update kept resolving against the **stale cached** `^0.3.0` constraint no matter how new loop-engine's marketplace version actually was — this silently pinned every consumer to loop-engine 0.3.0 forever. `claude plugin update loop-engine@paul-loop` reports "already at latest satisfying ^0.3.0" indefinitely, even after loop-engine moved to 0.4.1 (#42).
- Same underlying failure mode as #42 (a real content change shipping without the version bump the cache system needs) — found immediately after, while reinstalling plugins for glucofit-partners' BAC-766 verification.

## Changes
- `tools/ship-flow/.claude-plugin/plugin.json`: `0.2.0` → `0.2.1`. No other content change.
- `.claude-plugin/marketplace.json`: matching version bump.
- CHANGELOG entry.

## Test plan
- [x] `claude plugin validate --strict .` passes
- [x] Confirmed the failure mode live: pre-fix, `claude plugin update loop-engine@paul-loop --scope user -y` reported "already at latest version satisfying ^0.3.0, ^0.3.0 (0.3.0, required by ship-flow, loop-memory)" even with loop-engine 0.4.1 available in the marketplace

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016y2zUZBrhEkwJyQx8nNC1Y