### PR TITLE
fix(loop-memory): bump loop-engine dependency range to ^0.4.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -26,7 +26,7 @@
       "name": "loop-memory",
       "source": "./tools/loop-memory",
       "description": "pgvector semantic recall for verified dev-loop lessons (and, optionally, ADR/glossary/research knowledge). Opt-in / defaultEnabled:false — a database dependency, not core loop mechanics.",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "defaultEnabled": false,
       "keywords": ["memory", "pgvector", "recall", "semantic-search", "lessons"]
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,17 @@ and refer to `loop-engine` only (see the un-prefixed version numbers).
 - `retrospect`/`deps-audit` SKILL.md examples now disclaim that `tools/plugin-path.mjs` is a
   consuming-repo convention, not something this plugin ships (BAC-758 B7).
 
+## loop-memory 0.2.2
+
+- Fix: bump the `loop-engine` dependency range `^0.3.0` → `^0.4.0` — it had gone stale (last
+  touched when loop-engine was 0.2.x) and, being a caret range, silently *excluded* loop-engine
+  0.4.x entirely. Combined with ship-flow's now-fixed `^0.4.0` requirement (0.2.1), this produced
+  an unsatisfiable joint constraint (no version satisfies both `^0.3.0` and `^0.4.0`) the moment
+  both plugins were installed together, blocking `loop-engine` from ever updating past 0.3.0.
+  loop-engine 0.4.x is purely additive relative to what loop-memory actually uses (hooks bundling
+  + a manifest bugfix) — no compatibility reason to stay below it. Found immediately after 0.2.1,
+  while completing glucofit-partners' BAC-766 plugin reinstall.
+
 ## loop-memory 0.2.1
 
 - Fix: same `plugin.json` "hooks" field bug as loop-engine 0.4.1 — this plugin had the identical

--- a/tools/loop-memory/.claude-plugin/plugin.json
+++ b/tools/loop-memory/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "loop-memory",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "pgvector semantic recall for verified dev-loop lessons (and, optionally, ADR/glossary/research knowledge). Opt-in: installs disabled by default — this is a database dependency, not core loop mechanics.",
   "author": {
     "name": "paulkim-lansik"
@@ -10,7 +10,7 @@
   "license": "MIT",
   "keywords": ["memory", "pgvector", "recall", "semantic-search", "lessons"],
   "defaultEnabled": false,
-  "dependencies": [{ "name": "loop-engine", "version": "^0.3.0" }],
+  "dependencies": [{ "name": "loop-engine", "version": "^0.4.0" }],
   "userConfig": {
     "openai_api_key": {
       "type": "string",


### PR DESCRIPTION
## Summary
- Fourth instance of the version-hygiene bug class from #42/#43: `loop-memory`'s `loop-engine` dependency range (`^0.3.0`) was stale — last touched back at loop-engine 0.2.x — and, being a caret range, silently *excludes* loop-engine 0.4.x.
- Combined with ship-flow's now-fixed `^0.4.0` requirement (#43), installing both plugins together produced an unsatisfiable joint constraint — no version satisfies both `^0.3.0` and `^0.4.0` — permanently blocking `loop-engine` from updating past 0.3.0.
- loop-engine 0.4.x is purely additive relative to what loop-memory actually uses (hooks bundling + a manifest bugfix); no compatibility reason to stay below it.
- Found live while completing glucofit-partners' BAC-766 plugin reinstall: after #43 merged, `claude plugin update loop-engine@paul-loop` started reporting "conflicting version requirements: no version satisfies all of: ^0.3.0, ^0.4.0".

## Changes
- `tools/loop-memory/.claude-plugin/plugin.json`: version `0.2.1` → `0.2.2`, `loop-engine` dependency `^0.3.0` → `^0.4.0`.
- `.claude-plugin/marketplace.json`: matching version bump.
- CHANGELOG entry.

## Test plan
- [x] `claude plugin validate --strict .` passes
- [x] Reproduced the conflict live pre-fix; will confirm `claude plugin update loop-engine@paul-loop --scope user -y` resolves cleanly to 0.4.1 post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016y2zUZBrhEkwJyQx8nNC1Y