### PR TITLE
fix(ship-flow): wrap verifyCommand through verdict-run.sh in ship-feature/hotfix (BAC-745)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -19,7 +19,7 @@
       "name": "ship-flow",
       "source": "./tools/ship-flow",
       "description": "Delivery-loop skills — ship-feature (plan-to-PR autonomous loop), hotfix, retrospect, grill-with-docs, deps-audit, to-issues/to-prd, tdd, harness-maturity-audit, improve-codebase-architecture, resolving-merge-conflicts, plus review agents and audit/research workflows — parameterized by a consuming repo's own tracker/branch-model config instead of hardcoded to one repo. dependencies: loop-engine.",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "keywords": ["delivery", "git-flow", "hotfix", "ship", "release"]
     },
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ Explicit-version channel — see [README § Development status](README.md#develo
 not a SHA channel. Entries below `## loop-engine 0.2.0` and earlier predate the multi-plugin split
 and refer to `loop-engine` only (see the un-prefixed version numbers).
 
+## ship-flow 0.2.2
+
+- Fix: `ship-feature` step 2 and `hotfix` step 1 ran a consuming repo's raw `verifyCommand` directly
+  — `SKILL.md` never called `loop-engine`'s `verdict-run.sh`, so the `=== VERDICT ===` block,
+  `.loop/verdict-state.json`, and the `verdict.passed`/`verdict.failed` ledger events (loop-engine's
+  core contract, everything downstream — the Stop-hook fresh-PASS gate, `run-metrics`, lessons'
+  `gate_history` — depends on) never fired from the canonical entry points. Confirmed via a real
+  consuming repo's `run-metrics`: 92 runs, `with-verdict=0`. Both skills now wrap unconditionally:
+  `<however this repo invokes its installed loop-engine plugin's bin scripts> verdict-run.sh --
+  <verifyCommand>`, reading the gate off the printed `VERDICT:`/`EXIT:` lines instead of a bare shell
+  exit code. Safe even when `verifyCommand` is already a repo's own verdict-contract wrapper (e.g.
+  `pnpm verdict`) — `verdict-run.sh` detects an already-emitted `=== VERDICT ===` block and passes it
+  through unchanged rather than double-wrapping it, which is also why `setup`'s interview keeps
+  recording `verifyCommand` as the raw command rather than pointing it at `verdict-run.sh` itself.
+  New regression test `test/verdict-wrap-required.test.sh` (loop-engine test suite, since ship-flow
+  has no test harness of its own) fails if either skill's prose reverts to a raw verify-command
+  instruction.
+
 ## loop-engine 0.4.1
 
 - Fix: `plugin.json` no longer declares `"hooks": "./hooks/hooks.json"`. `hooks/hooks.json` is

--- a/tools/loop-engine/test/verdict-wrap-required.test.sh
+++ b/tools/loop-engine/test/verdict-wrap-required.test.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# BAC-745: ship-flow's ship-feature/hotfix must never instruct running a consuming repo's raw
+# verifyCommand directly — that skips loop-engine's verdict contract (=== VERDICT === block,
+# .loop/verdict-state.json, the verdict.passed/failed ledger event) entirely, which is exactly what
+# left 92 real runs (glucofit-partners, 2026-08-20) at with-verdict=0. Both skills must wrap the
+# verify step through this plugin's own verdict-run.sh instead. This is a text-level regression
+# guard on the skill prose, not a runtime check — it can't prove an agent actually follows the
+# instruction, only that the instruction itself hasn't quietly reverted to raw execution.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$HERE/../../.."
+
+fail() { echo "FAIL: $1"; exit 1; }
+
+REQUIRED_FILES=(
+  "tools/ship-flow/skills/ship-feature/SKILL.md"
+  "tools/ship-flow/skills/hotfix/SKILL.md"
+)
+
+for rel in "${REQUIRED_FILES[@]}"; do
+  f="$ROOT/$rel"
+  [ -f "$f" ] || fail "$rel not found"
+  grep -q "verdict-run\.sh -- <verifyCommand>" "$f" \
+    || fail "$rel does not wrap verifyCommand through verdict-run.sh — a raw verify-command instruction would skip the verdict contract (block/state-file/ledger event) entirely"
+  grep -q "VERDICT:.*EXIT:" "$f" \
+    || fail "$rel does not instruct reading the gate off VERDICT:/EXIT: — a bare shell exit code check would skip the verdict contract just as much as running verifyCommand raw"
+done
+
+# setup's interview must not point verifyCommand itself AT verdict-run.sh (that would double-wrap
+# and also break the field's contract as "the raw command", which ship-feature/hotfix already wrap).
+SETUP="$ROOT/tools/ship-flow/skills/setup/SKILL.md"
+[ -f "$SETUP" ] || fail "tools/ship-flow/skills/setup/SKILL.md not found"
+grep -q "Record the \*\*raw\*\*" "$SETUP" && grep -q "Don't write \`verdict-run.sh\`" "$SETUP" \
+  || fail "setup/SKILL.md's verify-command interview step no longer documents the raw-command convention (BAC-745)"
+
+echo "PASS: ship-feature/hotfix wrap verifyCommand via verdict-run.sh; setup keeps the field raw"

--- a/tools/ship-flow/.claude-plugin/plugin.json
+++ b/tools/ship-flow/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ship-flow",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Delivery-loop skills — land and release already-verified work through a repo's real gates. Tracker- and branch-model-agnostic: reads a consuming repo's own config instead of hardcoding one repo's setup.",
   "author": {
     "name": "paulkim-lansik"

--- a/tools/ship-flow/skills/hotfix/SKILL.md
+++ b/tools/ship-flow/skills/hotfix/SKILL.md
@@ -65,7 +65,11 @@ No pending changes: just `git fetch origin && git worktree add -b <branch> <path
 ### 1. Verify
 A fresh worktree has no installed dependencies — install them first. Then the project's verify
 command is the **ceiling** — don't move on until it's green (self-judgement never substitutes for
-it).
+it). Run it wrapped, always, never raw: `<however this repo invokes its installed loop-engine plugin's
+bin scripts> verdict-run.sh -- <verifyCommand>` (BAC-745) — safe even if `verifyCommand` already emits
+its own verdict-contract block, since `verdict-run.sh` passes an existing `=== VERDICT ===` block
+through unchanged instead of double-wrapping it. Read the gate off the printed `VERDICT:`/`EXIT:` lines
+— that's what feeds this repo's verdict state file and ledger, a bare exit code doesn't.
 
 ### 2. Commit → PR→`integrationBranch` (or `releaseBranch` if trunk-based)
 Commit in the repo's convention (e.g. `fix(scope): description`) → push → open the PR.

--- a/tools/ship-flow/skills/setup/SKILL.md
+++ b/tools/ship-flow/skills/setup/SKILL.md
@@ -42,7 +42,12 @@ model, changes what later questions even mean):
 2. **Package manager**: what does this repo use (`pnpm`/`npm`/`yarn`/`cargo`/`uv`/other)?
 3. **Verify command**: what single command does this repo run to check "is this change good" —
    typecheck+lint+test, or whatever this repo actually has? (If the repo has nothing yet, offer
-   `templates/turbo-verify-wiring.example.md` as a starting point — see step 4.)
+   `templates/turbo-verify-wiring.example.md` as a starting point — see step 4.) Record the **raw**
+   command as-is (e.g. `pnpm verify`), even if this repo already has its own verdict-contract wrapper
+   (e.g. `pnpm verdict`) — either way, `ship-feature`/`hotfix` always run it as
+   `verdict-run.sh -- <verifyCommand>` (BAC-745), and `verdict-run.sh` passes an already-emitted
+   `=== VERDICT ===` block through unchanged instead of double-wrapping it. Don't write `verdict-run.sh`
+   itself into this field.
 4. **Project name**: what should the `CLAUDE.md` template call this repo?
 5. **Issue tracker** (optional): does this repo use an external tracker (Linear, Jira, bare GitHub
    Issues, none)? Only asked if relevant — don't force an answer if the repo has no tracker at all.

--- a/tools/ship-flow/skills/ship-feature/SKILL.md
+++ b/tools/ship-flow/skills/ship-feature/SKILL.md
@@ -191,9 +191,15 @@ gate).
 ### 2. Implementation — `tdd` (red → green)
 Implement the plan red→green. Security/invariant paths (RLS, authorization, or whatever this repo's
 equivalent is) need **behavior-proof tests**, not just coverage. This repo's verify command is this
-loop's convergence criterion.
-→ **Gate:** verify command green + whatever `DEEP_GATES:` step 1 identified (re-checked against the
-actual diff with `--from-git`). Red loops back autonomously.
+loop's convergence criterion — run it wrapped, always, never raw: `<however this repo invokes its
+installed loop-engine plugin's bin scripts> verdict-run.sh -- <verifyCommand>` (BAC-745). This holds
+even if `verifyCommand` is itself already a verdict-contract script (e.g. a repo's own `verdict` wrapper)
+— `verdict-run.sh` detects an already-emitted `=== VERDICT ===` block and passes it through unchanged
+rather than double-wrapping, so wrapping unconditionally is always safe. Read the gate off the printed
+`VERDICT:`/`EXIT:` lines, not a bare shell exit code — the block is the actual contract (state file +
+ledger event), an exit code alone skips both.
+→ **Gate:** `VERDICT: PASS` + whatever `DEEP_GATES:` step 1 identified (re-checked against the actual
+diff with `--from-git`). `VERDICT: FAIL` loops back autonomously.
 
 ### 3. Runtime verify
 Build and run the app, drive the changed surface (CLI/API/GUI — whatever applies) through it, and


### PR DESCRIPTION
## Summary

- `ship-feature` step 2 and `hotfix` step 1 previously instructed running a consuming repo's raw
  `verifyCommand` directly — neither `SKILL.md` ever called loop-engine's `verdict-run.sh`, so the
  `=== VERDICT ===` block, `.loop/verdict-state.json`, and the `verdict.passed`/`verdict.failed` ledger
  events (the contract everything downstream — Stop-hook fresh-PASS gate, `run-metrics`, lessons'
  `gate_history` — depends on) never fired from the canonical entry points.
- Real-world confirmation (glucofit-partners, 2026-08-20): `run-metrics` reported `runs: 92
  (instrumented=67 with-verdict=0)`.
- Both skills now wrap unconditionally: `<however this repo invokes its installed loop-engine plugin's
  bin scripts> verdict-run.sh -- <verifyCommand>`, and read the gate off the printed `VERDICT:`/`EXIT:`
  lines instead of a bare shell exit code.
- Safe even when a repo's `verifyCommand` is already its own verdict-contract wrapper (e.g.
  `pnpm verdict`) — `verdict-run.sh` detects an already-emitted `=== VERDICT ===` block and passes it
  through unchanged rather than double-wrapping. `setup`'s interview keeps recording `verifyCommand` as
  the raw command accordingly (explicit "don't write verdict-run.sh itself into this field" note added).
- `ship-flow` bumped 0.2.1 → 0.2.2 (plugin.json + marketplace.json + CHANGELOG).

## AC coverage (BAC-745)

- [x] ship-feature/hotfix `SKILL.md` step 2/1 wraps via `verdict-run.sh`, gate reads the VERDICT block —
  new regression test `tools/loop-engine/test/verdict-wrap-required.test.sh` (RED if either skill's
  prose reverts to raw `verifyCommand` execution; verified by deliberately reverting hotfix's text and
  confirming the test fails, then restoring and confirming it passes again).
- [x] `setup`'s `verifyCommand` template default documented as consistent with the verdict convention,
  CHANGELOG recorded, version bumped.
- [ ] (follow-up, glucofit-partners) bump the plugin version + run `ship-flow:setup`/confirm
  `.claude/ship-flow.config.json`, add a `verify-loop-wiring` regression check.
- [ ] (follow-up, verification) a real `ship-feature`/`hotfix` run on a consuming repo showing
  `run-metrics` `with-verdict>0` and `.loop/verdict-state.json` created, numbers quoted in that repo's
  own PR.

The last two ACs are consuming-repo-side and tracked as the next step on BAC-745 once this lands and the
plugin version bump reaches glucofit-partners.

## Test plan

- [x] `bash tools/loop-engine/test/run.sh` — 30/30 passed (includes the new test)
- [x] `claude plugin validate --strict .` / `tools/loop-engine` / `tools/ship-flow` — all pass
- [x] Manually reverted the wrap text in `hotfix/SKILL.md`, confirmed the new test goes RED, restored,
  confirmed it goes back to PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)