### PR TITLE
feat(loop-engine,ship-flow): bundle plugin-path resolver + CI composite action templates (BAC-753)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,15 +11,15 @@
     {
       "name": "loop-engine",
       "source": "./tools/loop-engine",
-      "description": "Core loop mechanics: verdict-run (machine-readable PASS/FAIL contract), loop-fix (closed verify->fix loop), lessons (verified-fix memory), classify-risk, require-tests. No framework opinions beyond \"the verifier is the ceiling, never the agent's self-report\".",
-      "version": "0.4.1",
+      "description": "Core loop mechanics: verdict-run (machine-readable PASS/FAIL contract), loop-fix (closed verify->fix loop), lessons (verified-fix memory), classify-risk, require-tests, plugin-path (resolve sibling plugin install paths). No framework opinions beyond \"the verifier is the ceiling, never the agent's self-report\".",
+      "version": "0.5.0",
       "keywords": ["verifier", "tdd", "loop", "verdict", "lessons"]
     },
     {
       "name": "ship-flow",
       "source": "./tools/ship-flow",
       "description": "Delivery-loop skills — ship-feature (plan-to-PR autonomous loop), hotfix, retrospect, grill-with-docs, deps-audit, to-issues/to-prd, tdd, harness-maturity-audit, improve-codebase-architecture, resolving-merge-conflicts, plus review agents and audit/research workflows — parameterized by a consuming repo's own tracker/branch-model config instead of hardcoded to one repo. dependencies: loop-engine.",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "keywords": ["delivery", "git-flow", "hotfix", "ship", "release"]
     },
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,34 @@ Explicit-version channel — see [README § Development status](README.md#develo
 not a SHA channel. Entries below `## loop-engine 0.2.0` and earlier predate the multi-plugin split
 and refer to `loop-engine` only (see the un-prefixed version numbers).
 
+## loop-engine 0.5.0
+
+- New `bin/plugin-path.mjs` (BAC-753) — resolves the on-disk root of loop-engine/ship-flow/loop-memory
+  for a consuming repo, ported from glucofit-partners' repo-local `tools/plugin-path.mjs`
+  (BAC-699/706/766). A repo with ONLY these plugins installed (no local copy of its own) now has a
+  working resolver, closing the dangling reference that upstream `ship-feature`/`retrospect`/
+  `deps-audit` skills used to have when they hardcoded a consuming repo's own `tools/plugin-path.mjs`
+  path. Env-var overrides (`LOOP_ENGINE_PATH`/`SHIP_FLOW_PATH`/`LOOP_MEMORY_PATH`) let CI (a plain
+  shell process outside the live plugin cache) point at a pinned `git clone`. New
+  `test/plugin-path.test.sh`, including the hermetic plugin-unresolved idiom (`LOOP_ENGINE_PATH=`
+  empty + `HOME=$WORK/no-home`).
+
+## ship-flow 0.2.3
+
+- Fix (BAC-753): `retrospect`, `deps-audit`, and `ship-feature`'s `classify-risk` step hardcoded a
+  consuming repo's own `tools/plugin-path.mjs` as the way to invoke loop-engine bin scripts — a
+  dangling reference for any repo with only the plugins installed and no such file of its own. Now
+  point at loop-engine's bundled `bin/plugin-path.mjs` (0.5.0+) instead, and note that in a live
+  session this is usually just the bare script name (a plugin's `bin/` is already on PATH once
+  loaded) — the resolver only matters for CI or resolving a *different* plugin's path.
+- New CI templates (BAC-753): `templates/setup-loop-engine.action.yml.template` (a composite action
+  that pins loop-engine/ship-flow via tagged `git clone` and exports `LOOP_ENGINE_PATH`/
+  `SHIP_FLOW_PATH`, ported from glucofit-partners' `.github/actions/setup-loop-engine`) and
+  `templates/loop-selftest.yml.template` (a git-flow integration-branch-PR backstop for
+  harness/policy changes `ci.yml` never sees, adapt-by-hand like `turbo-verify-wiring.example.md`).
+  `setup` skill's step 4 now offers wiring both.
+- `loop-engine` dependency bumped to `^0.5.0` (0.5.0 is the first version with `bin/plugin-path.mjs`).
+
 ## ship-flow 0.2.2
 
 - Fix: `ship-feature` step 2 and `hotfix` step 1 ran a consuming repo's raw `verifyCommand` directly

--- a/tools/loop-engine/.claude-plugin/plugin.json
+++ b/tools/loop-engine/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "loop-engine",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "Core loop mechanics: verdict-run (machine-readable PASS/FAIL contract), loop-fix (closed verify->fix loop), lessons (verified-fix memory), classify-risk, require-tests. verifier=ceiling — the agent's self-judgement never substitutes for it.",
   "author": {
     "name": "paulkim-lansik"

--- a/tools/loop-engine/bin/plugin-path.mjs
+++ b/tools/loop-engine/bin/plugin-path.mjs
@@ -1,0 +1,127 @@
+#!/usr/bin/env node
+// plugin-path.mjs — resolves the on-disk root of a paul-loop plugin (loop-engine, ship-flow,
+// loop-memory) for a consuming repo (BAC-753 — ported from glucofit-partners' repo-local
+// tools/plugin-path.mjs, originally BAC-699/706/766). Bundled here so a repo with ONLY these
+// plugins installed (no repo-local copy of its own) still has a working resolver, closing the
+// dangling reference that upstream ship-feature/retrospect/deps-audit skills used to have when
+// they hardcoded a consuming repo's own `tools/plugin-path.mjs` path.
+//
+// Two real jobs this script does that bare PATH resolution (a live session's plugin `bin/`,
+// auto-registered on load) can't:
+//   1. CI / any headless invocation outside a live Claude Code session — nothing is on PATH there,
+//      so a caller needs a literal path. A consuming repo's CI clones the tagged plugin release
+//      (this repo's own setup-loop-engine/setup-ship-flow composite actions, BAC-753) and sets the
+//      env var below; this script picks it up.
+//   2. Resolving a *different* installed plugin's path from within one plugin's own skill/hook —
+//      e.g. a ship-flow skill needing loop-engine's install path, or anything needing ship-flow's
+//      or loop-memory's path for a read (version check), since only loop-engine ships bin/ scripts
+//      that land on PATH at all.
+//
+// Resolution order (per plugin):
+//   1. An explicit env var override — LOOP_ENGINE_PATH / SHIP_FLOW_PATH / LOOP_MEMORY_PATH. CI sets
+//      these after a pinned `git clone` (GitHub Actions is a plain shell process, outside the Claude
+//      Code plugin-cache mechanism entirely — see docs/adr/0078 addendum in glucofit-partners). A
+//      human can also point one at a local paul-loop checkout when working on a plugin itself.
+//   2. ~/.claude/plugins/installed_plugins.json — the live Claude Code plugin cache, matched by
+//      `projectPath === this repo's root` (via `git rev-parse --show-toplevel`), not blindly the
+//      first array entry — a machine can have a plugin installed for several projects/worktrees at
+//      different versions, and taking entries[0] could silently resolve a stale or wrong-project
+//      install.
+//
+// No match anywhere is a loud failure (exit 1), not a silent fallback — a caller that swallowed this
+// and proceeded without the harness would be worse than one that stops.
+//
+// Usage:
+//   node plugin-path.mjs resolve [plugin]                     # print the resolved plugin root, or exit 1
+//   node plugin-path.mjs exec <relative-bin> [args]            # resolve loop-engine, run <root>/<relative-bin>
+// [plugin] defaults to loop-engine. `exec` only ever targets loop-engine: it's the only one of the
+// three that ships bin/ scripts to run — ship-flow is skills/agents/workflows and loop-memory is
+// hooks/a CLI of its own, both resolved by path only (`resolve <plugin>`, not `exec`).
+
+import { execFileSync, spawnSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const PLUGINS = {
+  'loop-engine': { key: 'loop-engine@paul-loop', envVar: 'LOOP_ENGINE_PATH' },
+  'ship-flow': { key: 'ship-flow@paul-loop', envVar: 'SHIP_FLOW_PATH' },
+  'loop-memory': { key: 'loop-memory@paul-loop', envVar: 'LOOP_MEMORY_PATH' },
+};
+const DEFAULT_PLUGIN = 'loop-engine';
+
+function repoRoot() {
+  return execFileSync('git', ['rev-parse', '--show-toplevel'], { encoding: 'utf8' }).trim();
+}
+
+export function resolvePluginPath({ pluginsFile, root, plugin = DEFAULT_PLUGIN } = {}) {
+  const cfg = PLUGINS[plugin];
+  if (!cfg) throw new Error(`[plugin-path] unknown plugin shorthand: ${plugin}`);
+  // biome-ignore lint/suspicious/noUndeclaredEnvVars: CI(setup-loop-engine/setup-ship-flow action)·로컬 모두가 명시적으로 세팅하는 리졸버 오버라이드(플러그인별로 이름이 다르다).
+  if (process.env[cfg.envVar]) return process.env[cfg.envVar];
+  const file = pluginsFile || join(homedir(), '.claude', 'plugins', 'installed_plugins.json');
+  if (!existsSync(file)) return null;
+  let parsed;
+  try {
+    parsed = JSON.parse(readFileSync(file, 'utf8'));
+  } catch {
+    return null;
+  }
+  const entries = parsed?.plugins?.[cfg.key];
+  if (!Array.isArray(entries) || entries.length === 0) return null;
+  const projectRoot = root || repoRoot();
+  const match =
+    entries.find((e) => e.projectPath === projectRoot) ?? entries.find((e) => e.scope === 'user');
+  return match?.installPath ?? null;
+}
+
+function usage() {
+  process.stderr.write(
+    'Usage: plugin-path.mjs resolve [loop-engine|ship-flow|loop-memory] | exec <relative-bin-path> [args...]\n',
+  );
+  process.exit(2);
+}
+
+function fail(plugin) {
+  const cfg = PLUGINS[plugin];
+  process.stderr.write(
+    `[plugin-path] ${cfg.key}을 이 프로젝트에서 찾지 못했습니다. ` +
+      `'claude plugin install ${cfg.key} --scope user -y'를 실행하거나(세션 재시작 필요), ` +
+      `${cfg.envVar}를 로컬 paul-loop 체크아웃 경로로 설정하세요.\n`,
+  );
+  process.exit(1);
+}
+
+// import.meta.url is percent-encoded (spaces/non-ASCII → %XX); process.argv[1] is a raw OS path.
+// Comparing them as strings silently mismatches on a checkout path containing either — the CLI
+// block below then never runs, and this script exits 0 having done nothing (a caller like
+// `pnpm verdict`/require-tests.sh would read that as success). pathToFileURL() normalizes argv[1]
+// the same way before comparing (BAC-699 review, ported).
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const [cmd, ...rest] = process.argv.slice(2);
+  if (cmd === 'resolve') {
+    const plugin = rest[0] || DEFAULT_PLUGIN;
+    if (!PLUGINS[plugin]) usage();
+    const installPath = resolvePluginPath({ plugin });
+    if (!installPath) fail(plugin);
+    process.stdout.write(`${installPath}\n`);
+  } else if (cmd === 'exec') {
+    const [relBin, ...args] = rest;
+    if (!relBin) usage();
+    const installPath = resolvePluginPath({ plugin: DEFAULT_PLUGIN });
+    if (!installPath) fail(DEFAULT_PLUGIN);
+    const target = join(installPath, relBin);
+    const interpreter = target.endsWith('.mjs')
+      ? process.execPath
+      : target.endsWith('.sh')
+        ? 'bash'
+        : null;
+    const res = interpreter
+      ? spawnSync(interpreter, [target, ...args], { stdio: 'inherit' })
+      : spawnSync(target, args, { stdio: 'inherit' });
+    process.exit(res.status === null ? 1 : res.status);
+  } else {
+    usage();
+  }
+}

--- a/tools/loop-engine/test/plugin-path.test.sh
+++ b/tools/loop-engine/test/plugin-path.test.sh
@@ -1,0 +1,240 @@
+#!/usr/bin/env bash
+# BAC-753 — bin/plugin-path.mjs is the resolver a consuming repo (or another of this repo's own
+# skills) uses to find an installed paul-loop plugin's on-disk root when bare PATH resolution
+# doesn't apply (CI, or resolving a *different* plugin's path). Ported from glucofit-partners'
+# repo-local tools/plugin-path.mjs + its harness-test/plugin-path.test.sh (BAC-699/706/766), which
+# this plugin now makes redundant for a repo with no copy of its own. Its own doc comment documents
+# a real bug class observed on that machine during BAC-699 (two different install versions
+# resolvable across worktrees on the same machine) — this test locks the disambiguation logic that
+# fixes it, plus the malformed/missing-file and CLI dispatch paths.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+MOD="$HERE/../bin/plugin-path.mjs"
+
+fail() { echo "FAIL: $1"; exit 1; }
+[ -f "$MOD" ] || fail "plugin-path.mjs not found at $MOD"
+
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/tmp.XXXXXXXX")" || fail "mktemp -d failed"
+trap 'rm -rf "$WORK"' EXIT
+
+# helper: call resolvePluginPath({pluginsFile, root}) programmatically and print the result (or "null").
+# LOOP_ENGINE_PATH= (empty, not unset) explicitly clears any value the parent shell exported — the
+# resolver checks this env var FIRST and highest-priority, so a global override (e.g. CI's
+# setup-loop-engine action exporting it job-wide via $GITHUB_ENV) would otherwise leak into every one
+# of these pluginsFile-targeted assertions and make them pass for the wrong reason. Reproduced locally
+# by running this suite with LOOP_ENGINE_PATH set, matching what a real CI job does (BAC-699 review).
+resolve() { # $1=pluginsFile $2=root
+  LOOP_ENGINE_PATH= node --input-type=module -e '
+    const { resolvePluginPath } = await import(process.argv[1]);
+    const pluginsFile = process.argv[2] || undefined;
+    const root = process.argv[3] || undefined;
+    const r = resolvePluginPath({ pluginsFile, root });
+    process.stdout.write(String(r));
+  ' "$(node -e "console.log(require('url').pathToFileURL(process.argv[1]).href)" "$MOD")" "$1" "${2:-}"
+}
+
+write_plugins() { # $1=file $2=json-body(the array under plugins["loop-engine@paul-loop"])
+  node -e '
+    const fs = require("fs");
+    const [, file, body] = process.argv;
+    fs.writeFileSync(file, JSON.stringify({ plugins: { "loop-engine@paul-loop": JSON.parse(body) } }));
+  ' "$1" "$2"
+}
+
+# ── missing installed_plugins.json file → null, not a throw ────────────────────────────────────
+OUT="$(resolve "$WORK/does-not-exist.json" "$WORK/proj")"
+[ "$OUT" = "null" ] || fail "missing plugins file must resolve to null, got: $OUT"
+
+# ── malformed JSON → null (fail-closed-to-caller, not a crash) ─────────────────────────────────
+printf 'not-json{{{' > "$WORK/malformed.json"
+OUT="$(resolve "$WORK/malformed.json" "$WORK/proj")"
+[ "$OUT" = "null" ] || fail "malformed plugins file must resolve to null, got: $OUT"
+
+# ── plugin key absent / empty entries array → null ──────────────────────────────────────────────
+printf '{"plugins":{}}' > "$WORK/no-key.json"
+OUT="$(resolve "$WORK/no-key.json" "$WORK/proj")"
+[ "$OUT" = "null" ] || fail "plugins file with no loop-engine@paul-loop key must resolve to null, got: $OUT"
+write_plugins "$WORK/empty.json" '[]'
+OUT="$(resolve "$WORK/empty.json" "$WORK/proj")"
+[ "$OUT" = "null" ] || fail "empty entries array must resolve to null, got: $OUT"
+
+# ── single entry, exact projectPath match → that entry's installPath ───────────────────────────
+write_plugins "$WORK/single.json" "$(node -e '
+  console.log(JSON.stringify([{ scope: "project", projectPath: process.argv[1], installPath: "/cache/v1" }]));
+' "$WORK/proj")"
+OUT="$(resolve "$WORK/single.json" "$WORK/proj")"
+[ "$OUT" = "/cache/v1" ] || fail "exact projectPath match must win, got: $OUT"
+
+# ── multi-entry disambiguation (the documented bug class — two worktrees, two versions on the
+# same machine): entries[0] is a DIFFERENT project at v1, entries[1] is THIS project at v2 — the
+# match must be by projectPath, never by array position. ──────────────────────────────────────
+write_plugins "$WORK/multi.json" "$(node -e '
+  const [, other, mine] = process.argv;
+  console.log(JSON.stringify([
+    { scope: "project", projectPath: other, installPath: "/cache/wrong-project-v1" },
+    { scope: "project", projectPath: mine, installPath: "/cache/right-project-v2" },
+  ]));
+' "$WORK/other-worktree" "$WORK/proj")"
+OUT="$(resolve "$WORK/multi.json" "$WORK/proj")"
+[ "$OUT" = "/cache/right-project-v2" ] || fail "multi-entry resolution must match by projectPath, not array position (entries[0] would give the wrong project's install) — got: $OUT"
+
+# ── no exact projectPath match, but a scope:user entry exists → user-scope fallback wins ───────
+write_plugins "$WORK/user-fallback.json" "$(node -e '
+  const [, other] = process.argv;
+  console.log(JSON.stringify([
+    { scope: "project", projectPath: other, installPath: "/cache/other-project" },
+    { scope: "user", installPath: "/cache/user-scope" },
+  ]));
+' "$WORK/some-other-project")"
+OUT="$(resolve "$WORK/user-fallback.json" "$WORK/proj")"
+[ "$OUT" = "/cache/user-scope" ] || fail "no projectPath match must fall back to the scope:user entry, got: $OUT"
+
+# ── no exact match, no user-scope entry either → null (no blind entries[0] fallback) ───────────
+write_plugins "$WORK/no-fallback.json" "$(node -e '
+  const [, other] = process.argv;
+  console.log(JSON.stringify([{ scope: "project", projectPath: other, installPath: "/cache/other" }]));
+' "$WORK/some-other-project")"
+OUT="$(resolve "$WORK/no-fallback.json" "$WORK/proj")"
+[ "$OUT" = "null" ] || fail "no projectPath match and no user-scope entry must resolve to null (not silently grab entries[0]), got: $OUT"
+
+echo "PASS: resolvePluginPath — missing/malformed file, empty/no-key entries, exact-match, multi-entry disambiguation (not array position), user-scope fallback, no-fallback-to-entries[0] all correct"
+
+# ── LOOP_ENGINE_PATH env var wins over everything (highest priority, per module's own doc) ─────
+write_plugins "$WORK/ignored.json" "$(node -e '
+  const [, mine] = process.argv;
+  console.log(JSON.stringify([{ scope: "project", projectPath: mine, installPath: "/cache/should-be-ignored" }]));
+' "$WORK/proj")"
+OUT="$(LOOP_ENGINE_PATH=/env/override node --input-type=module -e '
+  const { resolvePluginPath } = await import(process.argv[1]);
+  process.stdout.write(String(resolvePluginPath({ pluginsFile: process.argv[2], root: process.argv[3] })));
+' "$(node -e "console.log(require('url').pathToFileURL(process.argv[1]).href)" "$MOD")" "$WORK/ignored.json" "$WORK/proj")"
+[ "$OUT" = "/env/override" ] || fail "LOOP_ENGINE_PATH must win over installed_plugins.json entirely, got: $OUT"
+
+echo "PASS: LOOP_ENGINE_PATH env override takes precedence over installed_plugins.json"
+
+# ── CLI: exec subcommand dispatch by extension (.mjs → node, .sh → bash, else → direct exec) ───
+FAKE_PLUGIN="$WORK/fake-plugin"
+mkdir -p "$FAKE_PLUGIN/bin"
+printf '#!/usr/bin/env node\nconsole.log("mjs:" + process.argv.slice(2).join(","));\n' > "$FAKE_PLUGIN/bin/hello.mjs"
+printf '#!/usr/bin/env bash\necho "sh:$*"\n' > "$FAKE_PLUGIN/bin/hello.sh"
+printf '#!/bin/sh\necho "bin:$*"\n' > "$FAKE_PLUGIN/bin/hello.bin"
+chmod +x "$FAKE_PLUGIN/bin/hello.sh" "$FAKE_PLUGIN/bin/hello.bin"
+
+OUT="$(LOOP_ENGINE_PATH="$FAKE_PLUGIN" node "$MOD" exec bin/hello.mjs a b)"
+[ "$OUT" = "mjs:a,b" ] || fail ".mjs target must dispatch via node, got: $OUT"
+OUT="$(LOOP_ENGINE_PATH="$FAKE_PLUGIN" node "$MOD" exec bin/hello.sh a b)"
+[ "$OUT" = "sh:a b" ] || fail ".sh target must dispatch via bash, got: $OUT"
+OUT="$(LOOP_ENGINE_PATH="$FAKE_PLUGIN" node "$MOD" exec bin/hello.bin a b)"
+[ "$OUT" = "bin:a b" ] || fail "extensionless (executable) target must dispatch via direct exec, got: $OUT"
+
+echo "PASS: exec subcommand dispatches by extension — .mjs via node, .sh via bash, else direct exec"
+
+# ── CLI: resolve/exec with no plugin resolvable → exit 1 with a clear stderr message ────────────
+RC="$(LOOP_ENGINE_PATH= HOME="$WORK/no-home" node "$MOD" resolve >/dev/null 2>"$WORK/err"; echo $?)"
+[ "$RC" = "1" ] || fail "resolve with nothing resolvable must exit 1, got rc=$RC"
+grep -q 'loop-engine@paul-loop' "$WORK/err" || fail "unresolvable failure must name the plugin in stderr: $(cat "$WORK/err")"
+
+# ── CLI: exec with no relative bin path → usage error (exit 2) ─────────────────────────────────
+RC="$(LOOP_ENGINE_PATH="$FAKE_PLUGIN" node "$MOD" exec >/dev/null 2>/dev/null; echo $?)"
+[ "$RC" = "2" ] || fail "exec with no relative-bin argument must be a usage error (exit 2), got rc=$RC"
+
+echo "PASS: CLI dispatch — unresolvable plugin exits 1 with a named error, exec with no bin path exits 2 (usage)"
+
+# ── ship-flow@paul-loop resolves independently of loop-engine@paul-loop — same disambiguation
+# logic, a different plugins-file key and a different env var (SHIP_FLOW_PATH, not LOOP_ENGINE_PATH). ──
+write_ship_flow_plugins() { # $1=file $2=json-body(entries array under plugins["ship-flow@paul-loop"])
+  node -e '
+    const fs = require("fs");
+    const [, file, body] = process.argv;
+    fs.writeFileSync(file, JSON.stringify({ plugins: { "ship-flow@paul-loop": JSON.parse(body) } }));
+  ' "$1" "$2"
+}
+resolve_ship_flow() { # $1=pluginsFile $2=root
+  LOOP_ENGINE_PATH= SHIP_FLOW_PATH= node --input-type=module -e '
+    const { resolvePluginPath } = await import(process.argv[1]);
+    const pluginsFile = process.argv[2] || undefined;
+    const root = process.argv[3] || undefined;
+    const r = resolvePluginPath({ pluginsFile, root, plugin: "ship-flow" });
+    process.stdout.write(String(r));
+  ' "$(node -e "console.log(require('url').pathToFileURL(process.argv[1]).href)" "$MOD")" "$1" "${2:-}"
+}
+
+write_ship_flow_plugins "$WORK/ship-flow.json" "$(node -e '
+  console.log(JSON.stringify([{ scope: "project", projectPath: process.argv[1], installPath: "/cache/ship-flow-v1" }]));
+' "$WORK/proj")"
+OUT="$(resolve_ship_flow "$WORK/ship-flow.json" "$WORK/proj")"
+[ "$OUT" = "/cache/ship-flow-v1" ] || fail "plugin:ship-flow must resolve from the ship-flow@paul-loop key, got: $OUT"
+
+# a loop-engine-only plugins file must NOT satisfy a ship-flow lookup (distinct keys, no cross-talk)
+OUT="$(resolve_ship_flow "$WORK/single.json" "$WORK/proj")"
+[ "$OUT" = "null" ] || fail "plugin:ship-flow must not resolve from a loop-engine@paul-loop-only plugins file, got: $OUT"
+
+echo "PASS: ship-flow@paul-loop resolves independently by its own key, no cross-talk with loop-engine@paul-loop"
+
+# SHIP_FLOW_PATH env override wins for ship-flow; LOOP_ENGINE_PATH must NOT leak into a ship-flow lookup
+OUT="$(SHIP_FLOW_PATH=/env/ship-flow-override LOOP_ENGINE_PATH= node --input-type=module -e '
+  const { resolvePluginPath } = await import(process.argv[1]);
+  process.stdout.write(String(resolvePluginPath({ pluginsFile: process.argv[2], root: process.argv[3], plugin: "ship-flow" })));
+' "$(node -e "console.log(require('url').pathToFileURL(process.argv[1]).href)" "$MOD")" "$WORK/ship-flow.json" "$WORK/proj")"
+[ "$OUT" = "/env/ship-flow-override" ] || fail "SHIP_FLOW_PATH must win over installed_plugins.json for plugin:ship-flow, got: $OUT"
+
+OUT="$(LOOP_ENGINE_PATH=/env/wrong-plugin SHIP_FLOW_PATH= node --input-type=module -e '
+  const { resolvePluginPath } = await import(process.argv[1]);
+  process.stdout.write(String(resolvePluginPath({ pluginsFile: process.argv[2], root: process.argv[3], plugin: "ship-flow" })));
+' "$(node -e "console.log(require('url').pathToFileURL(process.argv[1]).href)" "$MOD")" "$WORK/ship-flow.json" "$WORK/proj")"
+[ "$OUT" = "/cache/ship-flow-v1" ] || fail "LOOP_ENGINE_PATH must not leak into a plugin:ship-flow lookup, got: $OUT"
+
+echo "PASS: SHIP_FLOW_PATH env override is independent of LOOP_ENGINE_PATH (no cross-plugin env leakage)"
+
+# ── loop-memory@paul-loop resolves independently too (BAC-753) — same key/env-var isolation ────
+OUT="$(LOOP_MEMORY_PATH=/env/loop-memory-override node --input-type=module -e '
+  const { resolvePluginPath } = await import(process.argv[1]);
+  process.stdout.write(String(resolvePluginPath({ pluginsFile: process.argv[2], root: process.argv[3], plugin: "loop-memory" })));
+' "$(node -e "console.log(require('url').pathToFileURL(process.argv[1]).href)" "$MOD")" "$WORK/does-not-exist.json" "$WORK/proj")"
+[ "$OUT" = "/env/loop-memory-override" ] || fail "LOOP_MEMORY_PATH must resolve plugin:loop-memory, got: $OUT"
+
+echo "PASS: loop-memory@paul-loop resolves via its own LOOP_MEMORY_PATH env var"
+
+# CLI: `resolve` with no argument still defaults to loop-engine (every pre-BAC-706 caller omits it)
+OUT="$(LOOP_ENGINE_PATH=/env/default-loop-engine node "$MOD" resolve)"
+[ "$OUT" = "/env/default-loop-engine" ] || fail "CLI 'resolve' with no plugin argument must default to loop-engine, got: $OUT"
+OUT="$(SHIP_FLOW_PATH=/env/cli-ship-flow node "$MOD" resolve ship-flow)"
+[ "$OUT" = "/env/cli-ship-flow" ] || fail "CLI 'resolve ship-flow' must resolve the ship-flow plugin, got: $OUT"
+
+echo "PASS: CLI 'resolve' defaults to loop-engine, 'resolve ship-flow' targets ship-flow explicitly"
+
+# CLI: unknown plugin shorthand is a usage error (exit 2), same class as a missing exec bin path
+RC="$(node "$MOD" resolve nonexistent-plugin >/dev/null 2>/dev/null; echo $?)"
+[ "$RC" = "2" ] || fail "CLI 'resolve <unknown>' must be a usage error (exit 2), got rc=$RC"
+
+echo "PASS: CLI rejects an unknown plugin shorthand as a usage error"
+
+# ── BAC-699 review regression: import.meta.url (percent-encoded) vs process.argv[1] (raw OS path)
+# must not silently mismatch when the checkout path has a space — that mismatch made the whole CLI
+# block never run, exiting 0 having done nothing (a caller like `pnpm verdict` reads that as
+# success). Copy the module into a space-containing directory and confirm it still dispatches. ────
+SPACE_DIR="$WORK/has space"
+mkdir -p "$SPACE_DIR"
+cp "$MOD" "$SPACE_DIR/plugin-path.mjs"
+(
+  cd "$SPACE_DIR" &&
+  git init -q &&
+  git -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
+) || fail "could not init the hermetic space-path fixture repo"
+SPACE_ERR="$WORK/space-err"
+RC="$(cd "$SPACE_DIR" && LOOP_ENGINE_PATH= HOME="$WORK/no-home" node ./plugin-path.mjs resolve >/dev/null 2>"$SPACE_ERR"; echo $?)"
+[ "$RC" = "1" ] || fail "resolver in a space-containing path must still reach the unresolvable-plugin exit 1, got rc=$RC (import.meta.url percent-encoding mismatch would silently exit 0 instead)"
+grep -q 'loop-engine@paul-loop' "$SPACE_ERR" || fail "space-path resolver must still emit the named error, got: $(cat "$SPACE_ERR")"
+
+echo "PASS: CLI entrypoint check survives a space in the module's own path (import.meta.url vs argv[1] encoding)"
+
+# ── hermetic idiom (BAC-753 issue text): plugin-unresolved simulation = LOOP_ENGINE_PATH= (empty,
+# not unset) + HOME=$WORK/no-home, so installed_plugins.json under the real $HOME is never
+# consulted even by accident. Confirms this idiom actually produces the documented exit 1 + named
+# stderr, so other tests/CI adopting it can trust it. ───────────────────────────────────────────
+RC="$(LOOP_ENGINE_PATH= HOME="$WORK/no-home" node "$MOD" resolve loop-memory >/dev/null 2>"$WORK/hermetic-err"; echo $?)"
+[ "$RC" = "1" ] || fail "hermetic no-plugin idiom (LOOP_ENGINE_PATH= + HOME=\$WORK/no-home) must exit 1 for loop-memory too, got rc=$RC"
+grep -q 'loop-memory@paul-loop' "$WORK/hermetic-err" || fail "hermetic idiom's failure must name the plugin: $(cat "$WORK/hermetic-err")"
+
+echo "PASS: hermetic plugin-unresolved idiom (LOOP_ENGINE_PATH= + HOME=\$WORK/no-home) behaves as documented"
+exit 0

--- a/tools/ship-flow/.claude-plugin/plugin.json
+++ b/tools/ship-flow/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ship-flow",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Delivery-loop skills — land and release already-verified work through a repo's real gates. Tracker- and branch-model-agnostic: reads a consuming repo's own config instead of hardcoding one repo's setup.",
   "author": {
     "name": "paulkim-lansik"
@@ -10,6 +10,6 @@
   "license": "MIT",
   "keywords": ["delivery", "git-flow", "hotfix", "ship", "release"],
   "dependencies": [
-    { "name": "loop-engine", "version": "^0.4.0" }
+    { "name": "loop-engine", "version": "^0.5.0" }
   ]
 }

--- a/tools/ship-flow/skills/deps-audit/SKILL.md
+++ b/tools/ship-flow/skills/deps-audit/SKILL.md
@@ -9,13 +9,19 @@ Answers whether each installed extension **(1) is maintained upstream, (2) is yo
 
 ## Run
 
-Run this repo's installed loop-engine plugin's `deps-audit` script — invoked however this repo resolves plugin bin scripts. The example below uses the `tools/plugin-path.mjs exec` wrapper convention some consuming repos provide (this plugin does not ship `plugin-path.mjs` itself); a repo that installs loop-engine a different way may invoke it differently:
+Run this repo's installed loop-engine plugin's `deps-audit` script — invoked however this repo
+resolves plugin bin scripts (BAC-753). In a live session this is usually just the bare script name —
+a plugin's `bin/` is already on PATH once it's loaded. The example below uses loop-engine's own
+bundled resolver, `bin/plugin-path.mjs` (`exec <relative-bin> [args...]`, env-var overrides
+`LOOP_ENGINE_PATH`/`SHIP_FLOW_PATH`/`LOOP_MEMORY_PATH`), for contexts bare-PATH doesn't cover — CI (no
+live plugin load) or resolving a *different* installed plugin's path; a repo that installs loop-engine
+a different way may invoke it differently:
 
 ```bash
-node tools/plugin-path.mjs exec bin/deps-audit.mjs                      # fast — local manifests + usage + gh freshness (no clone)
-node tools/plugin-path.mjs exec bin/deps-audit.mjs --deep                # + skills.sh merge-base divergence (your edits vs staleness)
-node tools/plugin-path.mjs exec bin/deps-audit.mjs --json                # machine-readable
-node tools/plugin-path.mjs exec bin/deps-audit.mjs --refresh-provenance  # regenerate the sidecar (run after `npx skills update`)
+<however this repo invokes its installed loop-engine plugin's bin scripts> deps-audit.mjs                      # fast — local manifests + usage + gh freshness (no clone)
+<however this repo invokes its installed loop-engine plugin's bin scripts> deps-audit.mjs --deep                # + skills.sh merge-base divergence (your edits vs staleness)
+<however this repo invokes its installed loop-engine plugin's bin scripts> deps-audit.mjs --json                # machine-readable
+<however this repo invokes its installed loop-engine plugin's bin scripts> deps-audit.mjs --refresh-provenance  # regenerate the sidecar (run after `npx skills update`)
 ```
 
 If `CLAUDE_PROJECT_DIR` isn't set, it treats CWD as the project (run from the repo root). Each run (including `--json`) stamps `.loop/deps-audit.last` with a timestamp so a weekly heartbeat, if this repo has one, can throttle re-runs.

--- a/tools/ship-flow/skills/retrospect/SKILL.md
+++ b/tools/ship-flow/skills/retrospect/SKILL.md
@@ -9,10 +9,14 @@ Make runs get smarter over time. A failure becomes a lesson (Reflexion); a *recu
 lesson becomes a skill/guideline candidate (Voyager). Full reference: loop-engine@paul-loop's
 docs/lessons.md (in the plugin, not this repo).
 
-> Commands below invoke `bin/<name>.sh` via `node tools/plugin-path.mjs exec bin/<name>.sh` — a
-> resolver/wrapper convention some consuming repos provide (this plugin does not ship
-> `plugin-path.mjs` itself). If this repo doesn't have one, invoke the plugin's installed bin path
-> directly instead.
+> Commands below invoke `bin/<name>.sh` as `<however this repo invokes its installed loop-engine
+> plugin's bin scripts> <name>.sh` (BAC-753). In a live session this is usually just the bare script
+> name — a plugin's `bin/` is already on PATH once it's loaded. loop-engine also bundles its own
+> resolver at `bin/plugin-path.mjs` (`resolve [plugin]` / `exec <relative-bin> [args...]`, env-var
+> overrides `LOOP_ENGINE_PATH`/`SHIP_FLOW_PATH`/`LOOP_MEMORY_PATH`) for the cases bare-PATH doesn't
+> cover — CI (no live plugin load, nothing on PATH) or resolving a *different* installed plugin's
+> path. A consuming repo may still provide its own equivalent wrapper instead; either way, invoke it
+> however this repo actually resolves plugin bin scripts.
 
 ## The one rule
 
@@ -24,17 +28,17 @@ lessons are recalled as authoritative; only recurring ones get promoted. This ke
 ## In a fix loop (automatic)
 
 ```bash
-node tools/plugin-path.mjs exec bin/loop-fix.sh --verify "npm test" --fix '<agent>' --protect "**/*.test.*" --guard-mutation --lessons .loop/lessons
+<however this repo invokes its installed loop-engine plugin's bin scripts> loop-fix.sh --verify "npm test" --fix '<agent>' --protect "**/*.test.*" --guard-mutation --lessons .loop/lessons
 ```
 `loop-fix` recalls past verified fixes for the current failure into your prompt, and records a
 verified lesson when it converges. Nothing else to do — just point `--lessons` at a (committed) dir.
 
 ## By hand (in-session)
 
-- **Recall before you fix:** `node tools/plugin-path.mjs exec bin/lessons.sh recall --signature-file .loop/last-verdict.txt --lessons <dir>`.
+- **Recall before you fix:** `<however this repo invokes its installed loop-engine plugin's bin scripts> lessons.sh recall --signature-file .loop/last-verdict.txt --lessons <dir>`.
   If a past run solved this exact failure, start from that, then re-verify (don't trust the memory —
   the verifier still decides).
-- **Record after green:** once the verifier passes, `node tools/plugin-path.mjs exec bin/lessons.sh record --signature-file <first-failure>
+- **Record after green:** once the verifier passes, `<however this repo invokes its installed loop-engine plugin's bin scripts> lessons.sh record --signature-file <first-failure>
   --fix "<what worked>" --source <loop-fix|diagnose|review> --iterations <N> --verified --gate "<verify cmd>" --lessons <dir>`.
   `--gate` (e.g. this repo's verify command) attributes the recurrence to that verify gate so
   `promote --runs` can annotate the candidate when the gate regresses — without it, regressions only
@@ -80,7 +84,7 @@ example) where product/domain insights surface during other work. A durable one 
 into `.loop/lessons` by hand, using the same recording flow as any other domain lesson:
 
 ```bash
-node tools/plugin-path.mjs exec bin/lessons.sh record --signature-file <...> --fix "<what worked>" \
+<however this repo invokes its installed loop-engine plugin's bin scripts> lessons.sh record --signature-file <...> --fix "<what worked>" \
   --source <tool-name> --category domain --lessons <dir>
 ```
 
@@ -91,25 +95,25 @@ plugin-standard tooling for it, and a repo without such a tool can skip this sec
 
 ## Retro & promotion (where self-improvement compounds)
 
-- `node tools/plugin-path.mjs exec bin/lessons.sh stats --lessons <dir>` — avg iterations-to-green, recurrence counts, top recurring blockers.
+- `<however this repo invokes its installed loop-engine plugin's bin scripts> lessons.sh stats --lessons <dir>` — avg iterations-to-green, recurrence counts, top recurring blockers.
   Use it to see whether the loop is actually getting faster.
-- `node tools/plugin-path.mjs exec bin/lessons.sh promote --min-count 3 --lessons <dir>` — recurring verified lessons worth codifying. For
+- `<however this repo invokes its installed loop-engine plugin's bin scripts> lessons.sh promote --min-count 3 --lessons <dir>` — recurring verified lessons worth codifying. For
   each candidate, pick its destination with the checklist below, then hand it to `write-a-skill` (make
   the fix a reusable skill) or fold it into `CLAUDE.md` (a guideline) accordingly — then the loop stops
   re-solving it from scratch. Add `--runs .loop/runs` to fold in deterministic gate-regression
   signals: a `[REGRESSION: <gate> PASS→FAIL]` line — distinct from the `[N×]` recurrence count — marks
   candidates whose gate regressed in the runs ledger, and unattributed regressions list in their own section. The
   ledger is forgeable (trust boundary), so a regression is candidate INPUT only — the skeptical challenge gate stands.
-- `node tools/plugin-path.mjs exec bin/lessons.sh retire --id <id> --ref "<where>" --lessons <dir>` — **after** you've codified an accepted
+- `<however this repo invokes its installed loop-engine plugin's bin scripts> lessons.sh retire --id <id> --ref "<where>" --lessons <dir>` — **after** you've codified an accepted
   candidate into a skill/`CLAUDE.md`, retire it so it stops re-surfacing (the promote listing, `--codify`,
   or a heartbeat-style "promotion candidate" nudge if this repo has one). This is the terminal gate that
   keeps the candidate pool from growing monotonically. Fail closed: only a verified + `challenge
   --verdict accept`ed lesson can retire; a content change later re-opens it for fresh review.
-- `node tools/plugin-path.mjs exec bin/lessons.sh invalidate --id <id> --reason "<why>" [--superseded-by <id2>] --lessons <dir>`
+- `<however this repo invokes its installed loop-engine plugin's bin scripts> lessons.sh invalidate --id <id> --reason "<why>" [--superseded-by <id2>] --lessons <dir>`
   (if this repo's lessons tooling has it) — mark a lesson WRONG (the lesson itself was mistaken), distinct
   from `retire` (the lesson was right but is now codified). An invalidated lesson is excluded, fail
   closed, from recall and from the promote listing/`--codify` going forward.
-- `node tools/plugin-path.mjs exec bin/lessons.sh mark-clean --gate "<verify cmd>" --lessons <dir>` (if
+- `<however this repo invokes its installed loop-engine plugin's bin scripts> lessons.sh mark-clean --gate "<verify cmd>" --lessons <dir>` (if
   available) — bump a clean-pass counter on lessons attributed to that gate; a fresh recurrence resets it
   to 0. `promote`'s listing flags a lesson crossing the clean-pass threshold as a `RETIREMENT CANDIDATE`
   comment — informational only, never an auto-retire/invalidate.

--- a/tools/ship-flow/skills/setup/SKILL.md
+++ b/tools/ship-flow/skills/setup/SKILL.md
@@ -90,6 +90,22 @@ If the repo is (or will be) a turbo monorepo with no verify wiring yet, point at
 reference material to adapt by hand, not something this skill copies verbatim (task names vary too
 much repo to repo to template safely).
 
+If any CI job in this repo needs to invoke a loop-engine or ship-flow bin script directly (a PR gate
+running `classify-risk.sh`/`ac-verify.sh`, or a repo-local harness self-test) — ask whether to
+install `${CLAUDE_PLUGIN_ROOT}/templates/setup-loop-engine.action.yml.template` at
+`.github/actions/setup-loop-engine/action.yml` (BAC-753), substituting `{{LOOP_ENGINE_TAG}}`/
+`{{SHIP_FLOW_TAG}}` with the plugin versions this repo currently targets (match `minPluginVersions`
+if this repo has one — see verify-loop-wiring's floor check pattern). GitHub Actions is a plain shell
+process outside the live-session plugin cache, so any such job needs this action's
+`LOOP_ENGINE_PATH`/`SHIP_FLOW_PATH` exports before loop-engine's bundled `bin/plugin-path.mjs`
+resolver (or a bin script invoked directly) can find anything.
+
+For `git-flow` repos, also offer `${CLAUDE_PLUGIN_ROOT}/templates/loop-selftest.yml.template` as a
+`{integrationBranch}`-PR backstop for harness/policy changes that `ci.yml` never sees (git-flow's
+feature→integration PRs skip `ci.yml`'s trigger entirely — see `ci.yml.template`'s own comments).
+Like `turbo-verify-wiring.example.md`, this one is reference material to adapt by hand — the actual
+policy paths and selftest command are this repo's own, not something to copy verbatim.
+
 ### 5. Offer branch protection — human stop point, always
 **Never run `templates/branch-protect.sh` without an explicit `AskUserQuestion` confirmation first,
 every time** — this changes a real GitHub repo setting, and a past "yes" to a different question isn't

--- a/tools/ship-flow/skills/ship-feature/SKILL.md
+++ b/tools/ship-flow/skills/ship-feature/SKILL.md
@@ -108,10 +108,12 @@ never lower it:
 #                          the command instead — the two channels intentionally mean different things
 ```
 
-(`<however this repo invokes its installed loop-engine plugin's bin scripts>` — a repo-local
-resolver/wrapper if this repo has one, e.g. `node tools/plugin-path.mjs exec bin/<name>`; otherwise
-invoke the plugin's installed bin path directly. If this repo layers its own `risk-rules.json` on top of
-loop-engine's defaults, `classify-risk.sh` picks it up automatically.)
+(`<however this repo invokes its installed loop-engine plugin's bin scripts>` — usually just the bare
+script name in a live session, since a plugin's `bin/` is already on PATH once it's loaded; for CI or
+resolving a *different* installed plugin's path, loop-engine bundles its own resolver at
+`bin/plugin-path.mjs` (`exec <relative-bin> [args...]`, BAC-753), or this repo may provide its own
+equivalent wrapper. If this repo layers its own `risk-rules.json` on top of loop-engine's defaults,
+`classify-risk.sh` picks it up automatically.)
 
 - **Surface the rules typically cover**: schema migrations (`reversibility=none`) · row-level-security or
   equivalent tenant-isolation schema · auth/guards · outbound send/call · the harness/constitution layer

--- a/tools/ship-flow/templates/loop-selftest.yml.template
+++ b/tools/ship-flow/templates/loop-selftest.yml.template
@@ -1,0 +1,46 @@
+# Server-side backstop for this repo's harness/policy paths (git-flow only — trunk-based repos
+# don't need this, ci.yml already covers the single shared branch on every PR).
+#
+# Why a separate workflow: in git-flow (ADR-0053-style), a feature→{{INTEGRATION_BRANCH}} PR doesn't
+# trigger ci.yml at all (ci.yml's `pull_request.branches` is scoped to the release branch only —
+# that trigger-level skip is the actual cost saving). But the loop's riskiest output — a
+# harness-improvement PR touching CLAUDE.md/skills/hooks/risk rules — lands on exactly that path,
+# unverified, unless something else catches it. Adding {{INTEGRATION_BRANCH}} to ci.yml's own
+# trigger with a `paths:` filter doesn't work either: `on.pull_request.paths` applies to the whole
+# workflow, so it would also path-filter the release PR's real verify/integration jobs. Hence this
+# separate, narrowly-triggered file.
+#
+# ADAPT BY HAND — this is a reference template, not something to copy verbatim (like
+# turbo-verify-wiring.example.md): the paths list below is THIS repo's own policy surface
+# (.claude/**, CLAUDE.md, docs/adr/**, wherever this repo's risk-classification rules and harness
+# wiring actually live) and the selftest command is whatever repo-local harness self-check this repo
+# has (if none, a minimal check is just confirming the plugins resolve — see setup-loop-engine).
+name: Loop selftest ({{INTEGRATION_BRANCH}} PR)
+
+on:
+  pull_request:
+    branches: [{{INTEGRATION_BRANCH}}]
+    paths:
+      - '.claude/**'
+      - 'CLAUDE.md'
+      - 'docs/adr/**'
+      # Add this repo's own policy-relevant paths here — anywhere its risk-classification rules,
+      # verify-loop wiring, or harness-local tooling live.
+      - '.github/workflows/loop-selftest.yml'
+      - '.github/actions/setup-loop-engine/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  loop-engine-selftest:
+    name: loop-engine selftest ({{INTEGRATION_BRANCH}}, verifier machine)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: ./.github/actions/setup-loop-engine
+      - run: {{POLICY_SELFTEST_COMMAND}}

--- a/tools/ship-flow/templates/setup-loop-engine.action.yml.template
+++ b/tools/ship-flow/templates/setup-loop-engine.action.yml.template
@@ -1,0 +1,24 @@
+name: Setup loop-engine
+description: >
+  GitHub Actions is a plain shell process, outside the Claude Code plugin-cache mechanism entirely
+  (plugin bin/ PATH registration and installed-path lookup assume a live Claude Code session). This
+  action fills loop-engine@paul-loop and ship-flow@paul-loop in via a pinned-tag `git clone` and
+  exports LOOP_ENGINE_PATH/SHIP_FLOW_PATH, so `plugin-path.mjs` (loop-engine's own bundled resolver,
+  BAC-753) resolves them the same way it would a local env-var override. Any job that runs a verify
+  command, a loop-engine bin script, or this repo's own selftest should call this action first.
+
+  The two plugins can be pinned to different tags (they version independently) — a shared clone
+  would make one implicitly depend on the other's version, so they're cloned separately. Bump the
+  tags below deliberately when you want a newer plugin version — this is an explicit semver pin, not
+  a SHA channel that auto-follows (see paul-loop's ADR-0078 addendum for why).
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: |
+        git clone --depth 1 --branch loop-engine--{{LOOP_ENGINE_TAG}} \
+          https://github.com/paulkim-lansik/paul-loop.git /tmp/paul-loop-loop-engine
+        echo "LOOP_ENGINE_PATH=/tmp/paul-loop-loop-engine/tools/loop-engine" >> "$GITHUB_ENV"
+        git clone --depth 1 --branch ship-flow--{{SHIP_FLOW_TAG}} \
+          https://github.com/paulkim-lansik/paul-loop.git /tmp/paul-loop-ship-flow
+        echo "SHIP_FLOW_PATH=/tmp/paul-loop-ship-flow/tools/ship-flow" >> "$GITHUB_ENV"


### PR DESCRIPTION
## Summary

Backport from a reverse-backport audit (2026-08-20, glucofit-partners → paul-loop). Upstream
`ship-feature`/`retrospect`/`deps-audit` skills hardcoded a consuming repo's own
`tools/plugin-path.mjs` as the way to invoke loop-engine bin scripts — a dangling reference for any
repo with only the plugins installed and no such file of its own (`retrospect`/`deps-audit` used to
explicitly disclaim "this plugin does not ship plugin-path.mjs itself").

- **loop-engine 0.4.1 → 0.5.0**: new `bin/plugin-path.mjs`, ported from glucofit-partners'
  repo-local resolver (originally BAC-699, extended BAC-706/766) — resolves loop-engine/ship-flow/
  loop-memory's on-disk install path via env-var override (`LOOP_ENGINE_PATH`/`SHIP_FLOW_PATH`/
  `LOOP_MEMORY_PATH`, for CI/headless contexts) or the live `installed_plugins.json` cache
  (multi-worktree-version-skew-safe — matches by `projectPath`, never blind `entries[0]`). New
  `test/plugin-path.test.sh` (ported + one new case for `loop-memory`'s env var + the issue's
  hermetic idiom: `LOOP_ENGINE_PATH=` empty + `HOME=$WORK/no-home`).
- **ship-flow 0.2.2 → 0.2.3**: `retrospect`/`deps-audit`/`ship-feature`'s `classify-risk` step now
  point at the bundled resolver (or, in a live session, just the bare script name — a plugin's
  `bin/` is already on PATH once loaded — that's the more common case in practice). `loop-engine`
  dependency bumped to `^0.5.0` (0.5.0 is the first version with `bin/plugin-path.mjs`). New
  templates: `setup-loop-engine.action.yml.template` (pinned-tag `git clone` composite action, ported
  from glucofit-partners' real `.github/actions/setup-loop-engine`) and `loop-selftest.yml.template`
  (git-flow integration-branch-PR harness/policy backstop, adapt-by-hand like
  `turbo-verify-wiring.example.md` — the policy paths and selftest command are genuinely per-repo).
  `setup` skill's step 4 now offers wiring both.

## AC coverage (BAC-753)

- [x] loop-engine resolver bin + test (hermetic idiom included); 3 upstream skill references
  (`retrospect`, `deps-audit`, `ship-feature`) replaced with the bundled-resolver / bare-PATH
  guidance — no more hardcoded consumer-repo-only path.
- [x] ship-flow `templates/` CI composite action + selftest workflow templates; `setup` skill offers
  wiring both.
- [x] CHANGELOG + version bumps (loop-engine 0.5.0, ship-flow 0.2.3, dependency range bumped
  together so the two never drift into an unsatisfiable joint constraint — the exact bug class fixed
  twice earlier this week in PR #43/#44).
- [ ] (glucofit-partners, after this merges) replace/shim `tools/plugin-path.mjs`, update
  `verify-loop-wiring.mjs` — tracked as BAC-753's consumer-repo follow-up, same two-PR pattern as
  BAC-745/PR#809.

## Test plan

- [x] `bash tools/loop-engine/test/run.sh` — 31/31 passed (includes the new `plugin-path.test.sh`)
- [x] `claude plugin validate --strict .` / `tools/loop-engine` / `tools/ship-flow` — all pass
- [x] `dangling-doc-refs.test.sh` confirms no unhedged dangling reference remains across the 3 fixed
  skill files (existence check now succeeds against the newly-created `bin/plugin-path.mjs`, no hedge
  needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)