### PR TITLE
fix(loop-memory): bump loop-engine dependency range to ^0.5.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -26,7 +26,7 @@
       "name": "loop-memory",
       "source": "./tools/loop-memory",
       "description": "pgvector semantic recall for verified dev-loop lessons (and, optionally, ADR/glossary/research knowledge). Opt-in / defaultEnabled:false — a database dependency, not core loop mechanics.",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "defaultEnabled": false,
       "keywords": ["memory", "pgvector", "recall", "semantic-search", "lessons"]
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ Explicit-version channel — see [README § Development status](README.md#develo
 not a SHA channel. Entries below `## loop-engine 0.2.0` and earlier predate the multi-plugin split
 and refer to `loop-engine` only (see the un-prefixed version numbers).
 
+## loop-memory 0.2.3
+
+- Fix: `loop-engine` dependency range was left at `^0.4.0` when loop-engine bumped to 0.5.0 in the
+  same train (PR #46, BAC-753) — the exact joint-constraint bug class fixed twice before (PR #43/#44):
+  with ship-flow now requiring `^0.5.0` and loop-memory still at `^0.4.0`, no version satisfied both,
+  and `claude plugin update loop-engine@paul-loop` reported "conflicting version requirements" instead
+  of updating. Bumped to `^0.5.0` to match. No other content change beyond the version number and this
+  changelog entry — caught immediately while reinstalling for glucofit-partners' BAC-753 follow-up.
+
 ## loop-engine 0.5.0
 
 - New `bin/plugin-path.mjs` (BAC-753) — resolves the on-disk root of loop-engine/ship-flow/loop-memory

--- a/tools/loop-memory/.claude-plugin/plugin.json
+++ b/tools/loop-memory/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "loop-memory",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "pgvector semantic recall for verified dev-loop lessons (and, optionally, ADR/glossary/research knowledge). Opt-in: installs disabled by default — this is a database dependency, not core loop mechanics.",
   "author": {
     "name": "paulkim-lansik"
@@ -10,7 +10,7 @@
   "license": "MIT",
   "keywords": ["memory", "pgvector", "recall", "semantic-search", "lessons"],
   "defaultEnabled": false,
-  "dependencies": [{ "name": "loop-engine", "version": "^0.4.0" }],
+  "dependencies": [{ "name": "loop-engine", "version": "^0.5.0" }],
   "userConfig": {
     "openai_api_key": {
       "type": "string",


### PR DESCRIPTION
## Summary

PR #46 (BAC-753) bumped `loop-engine` to 0.5.0 and updated `ship-flow`'s dependency alongside it, but
missed `loop-memory`'s own `loop-engine` dependency (left at `^0.4.0`) — the exact joint-constraint
bug class fixed twice before this week (PR #43/#44): with `ship-flow` now requiring `^0.5.0` and
`loop-memory` still at `^0.4.0`, no version satisfies both, and
`claude plugin update loop-engine@paul-loop --scope user -y` reports "conflicting version
requirements (no version satisfies all of: ^0.5.0, ^0.4.0)" instead of updating — verified live while
reinstalling for glucofit-partners' BAC-753 follow-up.

`loop-memory` bumped 0.2.2 → 0.2.3 to force the plugin cache to re-pull the changed dependency
declaration (same reasoning as PR #43/#44 — the cache is keyed by `(name, version)`).

## Test plan

- [x] `bash tools/loop-engine/test/run.sh` — 31/31 passed
- [x] `claude plugin validate --strict .` / `tools/loop-memory` — pass
- [x] Reproduced live: `claude plugin update loop-engine@paul-loop --scope user -y` failed with the
  conflicting-requirements message before this fix; will re-verify it succeeds after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)