### PR TITLE
test(loop-engine): port generic coverage upstream from glucofit-partners' harness-test (BAC-755)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "loop-engine",
       "source": "./tools/loop-engine",
       "description": "Core loop mechanics: verdict-run (machine-readable PASS/FAIL contract), loop-fix (closed verify->fix loop), lessons (verified-fix memory), classify-risk, require-tests, plugin-path (resolve sibling plugin install paths). No framework opinions beyond \"the verifier is the ceiling, never the agent's self-report\".",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "keywords": ["verifier", "tdd", "loop", "verdict", "lessons"]
     },
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,36 @@ Explicit-version channel — see [README § Development status](README.md#develo
 not a SHA channel. Entries below `## loop-engine 0.2.0` and earlier predate the multi-plugin split
 and refer to `loop-engine` only (see the un-prefixed version numbers).
 
+## loop-engine 0.5.1
+
+- New generic test coverage for pieces of the ADR-0078 "split principle" (a consuming repo's own
+  `tools/harness-test/` should only wire-check that repo's use of the plugin; the plugin's own
+  GENERIC behavior belongs here) that were still only tested via glucofit-partners' consumer suite
+  (BAC-755):
+  - `test/check-rules-always-on.test.sh` — 8 synthetic-fixture cases for `bin/check-rules-always-on.mjs`
+    (missing-dir, scoped-vs-leaking frontmatter shapes, `--report-only`, text output, nested scan,
+    mixed accounting, byte-vs-count exit semantics). Consumer keeps only its own real-repo assertion.
+  - `test/verdict-state-producer.test.sh` — `.loop/verdict-state.json` producer correctness
+    (`bin/verdict-run.sh`'s sha/dirty/`finished_at` fields on clean/dirty trees, FAIL runs, non-git
+    dirs, control-char-injected commands, a PATH-spoofed `git status` failure — none of which were
+    covered by the existing `ac-verify.test.sh`/`verdict-mutation-guard.test.sh`, which only consume
+    this state as a side channel for their own features) and `bin/loop-fix.sh`'s `LOOP_STOP_GATE_OFF=1`
+    propagation to the fixer subprocess.
+  - `test/skill-guard-prose-wiring.test.sh` — ship-flow's `tdd`/`ship-feature` SKILL.md still name the
+    reward-hack guard's `.loop/guard-off` escape hatch and never reintroduce the BAC-583 prose-arming
+    failure mode (`touch .loop/looping`).
+  - `test/protect-globs-matcher.test.sh` — first direct unit coverage of `lib/protect-globs.mjs`'s
+    `globToRegExp`/`loadPatterns` (`*`/`**`/`**/`/`?` semantics, comment/blank-line filtering), which
+    had zero coverage anywhere before this (only indirectly exercised against one consumer's real
+    `protect.globs` file).
+  - `test/mktemp-fail-closed.test.sh` — ported the BAC-720 meta-lint (every `mktemp` call in this
+    directory's own `*.test.sh` files must be guarded with `|| fail`) to scan `test/` itself; fixed
+    the comment-line false positives the port surfaced (the sweep now skips `#`-prefixed lines) and one
+    real unguarded pair it caught in `lessons-hygiene.test.sh`.
+  - Fixed `test/eval-gate-tier0.test.sh`'s bare `mktemp -d` (missing the `${TMPDIR:-/tmp}/tmp.XXXXXXXX`
+    template — the actual BAC-718/720 root-cause pattern, present here despite already having the
+    `|| fail` guard).
+
 ## loop-memory 0.2.3
 
 - Fix: `loop-engine` dependency range was left at `^0.4.0` when loop-engine bumped to 0.5.0 in the

--- a/tools/loop-engine/.claude-plugin/plugin.json
+++ b/tools/loop-engine/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "loop-engine",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Core loop mechanics: verdict-run (machine-readable PASS/FAIL contract), loop-fix (closed verify->fix loop), lessons (verified-fix memory), classify-risk, require-tests. verifier=ceiling — the agent's self-judgement never substitutes for it.",
   "author": {
     "name": "paulkim-lansik"

--- a/tools/loop-engine/test/check-rules-always-on.test.sh
+++ b/tools/loop-engine/test/check-rules-always-on.test.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# BAC-755 (ported from glucofit-partners' check-rules-always-on.test.sh cases 1-8 — synthetic-fixture
+# coverage of check-rules-always-on.mjs's own leak-detection logic, which had been living in a
+# consuming repo even though none of it reads that repo's actual state). The consuming repo keeps
+# only a real-repo assertion ("this repo's own .claude/rules has zero leakage") — that one stays
+# local since it's a wiring/state check, not plugin behavior.
+#
+# 계약: `.claude/rules/**/*.md` 중 (a) frontmatter/paths: 키 없음, (b) paths: 빈 배열, (c) paths:
+# 정확히 ["**"]인 파일을 "always-on 잔류"로 집계해 바이트 합계를 리포트한다. 광역 glob("apps/web/**")은
+# 해당 안 됨. 리크가 있으면 기본 exit 1(게이트), --report-only는 항상 exit 0.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+CHECK="$HERE/../bin/check-rules-always-on.mjs"
+
+fail() { echo "FAIL: $1"; exit 1; }
+[ -f "$CHECK" ] || fail "check-rules-always-on.mjs not found at $CHECK"
+
+DIR="$(mktemp -d "${TMPDIR:-/tmp}/tmp.XXXXXXXX")" || fail "mktemp -d failed"
+trap 'rm -rf "$DIR"' EXIT
+
+# ── 1) .claude/rules 디렉터리 자체가 없음 → 0개, exit 0 ─────────────────────────────────────
+EMPTY="$DIR/empty-root"
+mkdir -p "$EMPTY"
+JSON_NONE="$(node "$CHECK" --root "$EMPTY" --json)"; rc=$?
+[ "$rc" = "0" ] || fail "missing .claude/rules dir must exit 0, got $rc"
+node -e '
+  const m = JSON.parse(process.argv[1]);
+  if (m.total_files !== 0) throw new Error("no rules dir must report 0 files, got " + m.total_files);
+' "$JSON_NONE" || fail "missing dir report wrong"
+echo "PASS: missing .claude/rules directory reports 0 files, exit 0"
+
+# ── 2) 정상 scoped 규칙(광역 glob "apps/web/**" 포함)은 leak 아님 → exit 0 ──────────────────
+R="$DIR/root"
+mkdir -p "$R/.claude/rules"
+printf -- '---\npaths: ["apps/web/**", "apps/admin-web/**"]\n---\n\n# ok\ncontent\n' > "$R/.claude/rules/ok-flow.md"
+printf -- '---\npaths:\n  - "apps/api/**"\n---\n\n# ok block style\n' > "$R/.claude/rules/ok-block.md"
+JSON_OK="$(node "$CHECK" --root "$R" --json)"; rc=$?
+[ "$rc" = "0" ] || fail "fully-scoped rules must exit 0, got $rc"
+node -e '
+  const m = JSON.parse(process.argv[1]);
+  if (m.total_files !== 2) throw new Error("expected 2 files, got " + m.total_files);
+  if (m.leaking_files !== 0) throw new Error("apps/web/** and block-style paths must not leak, got " + m.leaking_files);
+  if (m.scoped_files !== 2) throw new Error("both files must count as scoped, got " + m.scoped_files);
+' "$JSON_OK" || fail "flow-style and block-style paths: parsing wrong"
+echo "PASS: flow-style and block-style paths: (including a apps/web/** double-star glob) are not flagged"
+
+# ── 3) paths: 없음 / 빈 배열 / ["**"] 는 전부 leak → exit 1, 바이트 합계 정확 ─────────────────
+L="$DIR/leaky"
+mkdir -p "$L/.claude/rules"
+printf 'no frontmatter at all\n' > "$L/.claude/rules/no-frontmatter.md"
+printf -- '---\nname: has-frontmatter-no-paths\n---\nbody\n' > "$L/.claude/rules/no-paths-key.md"
+printf -- '---\npaths: []\n---\nbody\n' > "$L/.claude/rules/empty-paths.md"
+printf -- '---\npaths: ["**"]\n---\nbody\n' > "$L/.claude/rules/match-all.md"
+EXPECT_BYTES=$(( $(wc -c < "$L/.claude/rules/no-frontmatter.md") + $(wc -c < "$L/.claude/rules/no-paths-key.md") + $(wc -c < "$L/.claude/rules/empty-paths.md") + $(wc -c < "$L/.claude/rules/match-all.md") ))
+JSON_LEAK="$(node "$CHECK" --root "$L" --json)"; rc=$?
+[ "$rc" = "1" ] || fail "leaking rules must exit 1 by default, got $rc"
+node -e '
+  const m = JSON.parse(process.argv[1]);
+  if (m.leaking_files !== 4) throw new Error("expected 4 leaking files, got " + m.leaking_files);
+  if (m.leaking_bytes !== Number(process.argv[2])) throw new Error("leaking_bytes mismatch: got " + m.leaking_bytes + " want " + process.argv[2]);
+  const reasons = m.leaking.map(f => f.reason).sort();
+  const want = ["empty-paths", "match-all", "no-frontmatter", "no-paths-key"].sort();
+  if (JSON.stringify(reasons) !== JSON.stringify(want)) throw new Error("reason tags wrong: " + JSON.stringify(reasons));
+' "$JSON_LEAK" "$EXPECT_BYTES" || fail "leak detection/byte accounting wrong"
+echo "PASS: missing frontmatter, missing paths: key, empty array, and [\"**\"] are all flagged with correct byte sum, exit 1"
+
+# ── 4) --report-only는 리크가 있어도 exit 0 (리포트만) ──────────────────────────────────────
+node "$CHECK" --root "$L" --report-only --json >/dev/null; rc=$?
+[ "$rc" = "0" ] || fail "--report-only must force exit 0 even with leaks, got $rc"
+echo "PASS: --report-only reports leaks without failing the gate"
+
+# ── 5) 사람용 텍스트 출력에 LEAK 라인과 바이트 합계가 보인다 ────────────────────────────────
+OUT_TXT="$(node "$CHECK" --root "$L" --report-only)"
+printf '%s' "$OUT_TXT" | grep -q "LEAK: .claude/rules/no-frontmatter.md" || fail "text output must list leaking files by relative path"
+printf '%s' "$OUT_TXT" | grep -q "always-on 잔류" || fail "text output must report the always-on-leftover summary line"
+echo "PASS: human-readable output lists leaking files and the summary line"
+
+# ── 6) 중첩 서브디렉터리도 재귀적으로 스캔한다 ──────────────────────────────────────────────
+N="$DIR/nested"
+mkdir -p "$N/.claude/rules/backend"
+printf -- '---\npaths: ["apps/api/**"]\n---\nok\n' > "$N/.claude/rules/backend/scoped.md"
+printf 'no frontmatter, nested\n' > "$N/.claude/rules/backend/leaky.md"
+JSON_NESTED="$(node "$CHECK" --root "$N" --json)"; rc=$?
+[ "$rc" = "1" ] || fail "nested leak must still exit 1, got $rc"
+node -e '
+  const m = JSON.parse(process.argv[1]);
+  if (m.total_files !== 2) throw new Error("nested scan must find 2 files, got " + m.total_files);
+  if (m.leaking_files !== 1) throw new Error("nested leak must be found, got " + m.leaking_files);
+  if (!m.leaking[0].file.includes("backend/leaky.md")) throw new Error("leak path must include the subdirectory, got " + m.leaking[0].file);
+' "$JSON_NESTED" || fail "nested subdirectory scanning wrong"
+echo "PASS: .claude/rules subdirectories are scanned recursively"
+
+# ── 7) 한 번의 실행에서 scoped와 leaking이 섞여도 양쪽 합계가 독립적으로 정확하다 ─────────────
+M="$DIR/mixed"
+mkdir -p "$M/.claude/rules"
+printf -- '---\npaths: ["apps/web/**"]\n---\nok one\n' > "$M/.claude/rules/scoped-a.md"
+printf -- '---\npaths: ["apps/api/**"]\n---\nok two\n' > "$M/.claude/rules/scoped-b.md"
+printf -- '---\npaths: ["**"]\n---\nleak\n' > "$M/.claude/rules/leak-a.md"
+EXPECT_SCOPED=$(( $(wc -c < "$M/.claude/rules/scoped-a.md") + $(wc -c < "$M/.claude/rules/scoped-b.md") ))
+EXPECT_LEAK=$(wc -c < "$M/.claude/rules/leak-a.md")
+JSON_MIXED="$(node "$CHECK" --root "$M" --json)"; rc=$?
+[ "$rc" = "1" ] || fail "mixed run with any leak must exit 1, got $rc"
+node -e '
+  const m = JSON.parse(process.argv[1]);
+  if (m.total_files !== 3) throw new Error("mixed run must see 3 files, got " + m.total_files);
+  if (m.scoped_files !== 2) throw new Error("mixed run must count 2 scoped files, got " + m.scoped_files);
+  if (m.leaking_files !== 1) throw new Error("mixed run must count 1 leaking file, got " + m.leaking_files);
+  if (m.scoped_bytes !== Number(process.argv[2])) throw new Error("scoped_bytes wrong: got " + m.scoped_bytes + " want " + process.argv[2]);
+  if (m.leaking_bytes !== Number(process.argv[3])) throw new Error("leaking_bytes wrong: got " + m.leaking_bytes + " want " + process.argv[3]);
+' "$JSON_MIXED" "$EXPECT_SCOPED" "$EXPECT_LEAK" || fail "mixed scoped+leaking accounting wrong"
+echo "PASS: scoped and leaking files are accounted independently within the same run"
+
+# ── 8) exit code follows leak COUNT, not bytes — a 0-byte leaking file must still fail ───────
+Z="$DIR/zero-byte"
+mkdir -p "$Z/.claude/rules"
+: > "$Z/.claude/rules/empty.md"
+node "$CHECK" --root "$Z" --json >/dev/null; rc=$?
+[ "$rc" = "1" ] || fail "a 0-byte leaking file must still exit 1 (count-based, not bytes-based), got $rc"
+echo "PASS: exit code is driven by leak count, not leak byte total (0-byte leaks still fail)"
+
+exit 0

--- a/tools/loop-engine/test/eval-gate-tier0.test.sh
+++ b/tools/loop-engine/test/eval-gate-tier0.test.sh
@@ -14,7 +14,7 @@ fail() { echo "FAIL: $1"; exit 1; }
 [ -x "$TIER0RUN" ] || fail "tier0-run.sh not executable at $TIER0RUN"
 [ -d "$DATASET" ] || fail "tier0 golden dataset dir not found at $DATASET"
 
-WORK="$(mktemp -d)" || fail "mktemp -d failed"
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/tmp.XXXXXXXX")" || fail "mktemp -d failed"
 trap 'rm -rf "$WORK"' EXIT
 
 # ── case 1: 전체 골든셋이 PASS로 채점되어야 한다(결정론적 — k=1 기본값으로 충분, LLM 없음) ─────

--- a/tools/loop-engine/test/lessons-hygiene.test.sh
+++ b/tools/loop-engine/test/lessons-hygiene.test.sh
@@ -112,7 +112,7 @@ RSUP="$(id_for "$DIR" "hygiene lesson recall superseder")"
 [ -n "$RSUP" ] || fail "could not extract recall superseder id"
 L record --signature-file <(printf '%s\n' "FAIL: hygiene recall probe") --verified --title "hygiene lesson recall probe" >/dev/null || fail "record recall probe failed"
 L invalidate --id "$(id_for "$DIR" "hygiene lesson recall probe")" --reason "stale" --superseded-by "$RSUP" >/dev/null || fail "invalidate recall probe failed"
-OUT7="$(mktemp "${TMPDIR:-/tmp}/tmp.XXXXXXXX")"; ERR7="$(mktemp "${TMPDIR:-/tmp}/tmp.XXXXXXXX")"
+OUT7="$(mktemp "${TMPDIR:-/tmp}/tmp.XXXXXXXX")" || fail "mktemp failed"; ERR7="$(mktemp "${TMPDIR:-/tmp}/tmp.XXXXXXXX")" || fail "mktemp failed"
 L recall --signature "FAIL: hygiene recall probe" >"$OUT7" 2>"$ERR7"
 rc=$?
 [ "$rc" = "0" ] || fail "recall of an invalidated lesson must still exit 0; got rc=$rc"

--- a/tools/loop-engine/test/mktemp-fail-closed.test.sh
+++ b/tools/loop-engine/test/mktemp-fail-closed.test.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# BAC-755 (ported near-verbatim from glucofit-partners' mktemp-fail-closed.test.sh, BAC-720 — the
+# meta-lint is entirely generic and belongs wherever *.test.sh files with mktemp calls live, which is
+# now also here).
+#
+# 배경: bare mktemp가 $TMPDIR를 무시해 샌드박스가 거부하는 기본 임시 디렉토리를 고르면 EPERM으로
+# 실패하고(BAC-718), 실패를 아무도 체크하지 않으면 변수가 빈 문자열이 되어 후속 `git -C "$WORK" init`
+# 같은 호출이 `-C` 무시로 실제 cwd에서 실행된다(실측 피해: 빈 커밋 4개 생성). 고정:
+# tools/loop-engine/test/*.test.sh의 모든 mktemp 호출 지점에 `|| fail "..."`를 붙여 mktemp가 어떤
+# 이유로든 실패하면 그 즉시 스크립트가 죽고 이후 명령이 전혀 실행되지 않게 한다.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+SELF="$HERE/$(basename "$0")"
+
+fail() { echo "FAIL: $1"; exit 1; }
+
+# ── 1) wiring sweep: every mktemp call in this directory's other *.test.sh files must be guarded
+#      with a trailing `|| fail`/`|| exit`/`|| {`. ───────────────────────────────────────────────
+unguarded=""
+for f in "$HERE"/*.test.sh; do
+  [ "$f" = "$SELF" ] && continue
+  while IFS= read -r line; do
+    trimmed="${line#"${line%%[! ]*}"}"
+    case "$trimmed" in
+      '#'*) continue ;;
+    esac
+    case "$line" in
+      *'mktemp'*'|| fail'*|*'mktemp'*'|| exit'*|*'mktemp'*'|| {'*) ;;
+      *) unguarded="$unguarded  $(basename "$f"): $line"$'\n' ;;
+    esac
+  done < <(grep 'mktemp' "$f")
+done
+[ -z "$unguarded" ] || fail "unguarded mktemp call(s) — must end with '|| fail ...' on the same line:
+$unguarded"
+echo "PASS: every mktemp call in tools/loop-engine/test/*.test.sh is guarded against silent failure"
+
+# ── 2) behavioral proof: reproduce a real mktemp -d failure (chmod 000 parent) and confirm the
+#      GUARDED idiom aborts before any subsequent command runs — no fake-repo side effect leaks. ───
+DENIEDPARENT="$(mktemp -d "${TMPDIR:-/tmp}/tmp.XXXXXXXX")" || fail "setup: mktemp -d for the denied-parent fixture failed"
+MARKER="$HERE/.mktemp-fail-closed-leak-marker.$$"
+trap 'chmod u+rwx "$DENIEDPARENT" 2>/dev/null; rm -rf "$DENIEDPARENT"; rm -f "$MARKER"' EXIT
+chmod 000 "$DENIEDPARENT"
+
+rm -f "$MARKER"
+
+(
+  set -uo pipefail
+  WORK="$(mktemp -d "$DENIEDPARENT/tmp.XXXXXXXX")" || { echo "FAIL: mktemp -d failed"; exit 1; }
+  touch "$MARKER"
+  git -C "$WORK" init -q -b main
+)
+RC=$?
+
+[ "$RC" -ne 0 ] || fail "guarded idiom must exit non-zero when mktemp -d fails, got $RC"
+[ ! -e "$MARKER" ] || { rm -f "$MARKER"; fail "guard did not stop execution — a side effect ran after the failed mktemp"; }
+echo "PASS: mktemp -d failure aborts immediately — no fake-repo side effect leaks into the real cwd"
+
+# ── 3) sanity: the SAME idiom minus the guard DOES leak — proves this test can actually detect the
+#      regression it exists to catch, not vacuously green. ─────────────────────────────────────────
+rm -f "$MARKER"
+(
+  set -uo pipefail
+  WORK="$(mktemp -d "$DENIEDPARENT/tmp.XXXXXXXX")"
+  touch "$MARKER"
+)
+
+if [ ! -e "$MARKER" ]; then
+  fail "sanity check failed: expected the UNGUARDED idiom to leak (proves this test can detect the original bug) — got no marker, this test may be vacuous"
+fi
+rm -f "$MARKER"
+echo "PASS: sanity — the unguarded (pre-BAC-720) idiom does leak, confirming this test would have caught the original bug"
+
+exit 0

--- a/tools/loop-engine/test/protect-globs-matcher.test.sh
+++ b/tools/loop-engine/test/protect-globs-matcher.test.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# BAC-755 — generic unit coverage for lib/protect-globs.mjs's globToRegExp/loadPatterns, which had
+# zero direct test coverage anywhere (only exercised indirectly, and only against one consuming
+# repo's real file list, via that repo's protect-globs-coverage.test.sh — which is itself entirely
+# repo-policy and not portable, see BAC-755's investigation). This locks the matcher's own contract
+# with synthetic patterns, independent of any consumer's protect.globs content.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+LIB="$HERE/../lib/protect-globs.mjs"
+
+fail() { echo "FAIL: $1"; exit 1; }
+[ -f "$LIB" ] || fail "protect-globs.mjs not found at $LIB"
+
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/tmp.XXXXXXXX")" || fail "mktemp -d failed"
+trap 'rm -rf "$WORK"' EXIT
+
+OUT="$(node --input-type=module -e '
+  import { globToRegExp, loadPatterns } from "'"$LIB"'";
+  import { writeFileSync, mkdirSync } from "node:fs";
+  import { join } from "node:path";
+
+  const cases = [];
+  const check = (label, cond) => cases.push({ label, cond });
+
+  // globToRegExp: * (single segment), ** (any depth incl. zero), **/ (0+ leading segments), ?
+  check("* matches within one segment", globToRegExp("*.test.ts").test("foo.test.ts"));
+  check("* does not cross a slash", !globToRegExp("*.test.ts").test("a/foo.test.ts"));
+  check("** matches across slashes", globToRegExp("apps/**").test("apps/api/src/x.ts"));
+  check("** matches zero segments too", globToRegExp("apps/**").test("apps/"));
+  check("**/ matches zero leading segments", globToRegExp("**/*.test.ts").test("foo.test.ts"));
+  check("**/ matches nested leading segments", globToRegExp("**/*.test.ts").test("a/b/foo.test.ts"));
+  check("? matches exactly one char", globToRegExp("a?c").test("abc"));
+  check("? does not match zero chars", !globToRegExp("a?c").test("ac"));
+  check("? does not match a slash", !globToRegExp("a?c").test("a/c"));
+  check("literal dot is escaped, not a wildcard", !globToRegExp("a.ts").test("aXts"));
+  check("non-matching path is rejected", !globToRegExp("apps/web/**").test("apps/api/x.ts"));
+  check("full match required, not substring", !globToRegExp("foo.ts").test("foo.ts.bak"));
+
+  // loadPatterns: comments/blank lines filtered, missing file -> []
+  const dir = join(process.argv[1], "patterns");
+  mkdirSync(dir, { recursive: true });
+  const globFile = join(dir, "protect.globs");
+  writeFileSync(globFile, "# comment\n\n  \napps/web/**\n*.test.ts\n  # indented comment\napps/api/**\n");
+  const patterns = loadPatterns(globFile);
+  check("loadPatterns drops comments/blank lines", JSON.stringify(patterns) === JSON.stringify(["apps/web/**", "*.test.ts", "apps/api/**"]));
+  check("loadPatterns on missing file returns []", JSON.stringify(loadPatterns(join(dir, "nope.globs"))) === "[]");
+
+  const failed = cases.filter(c => !c.cond);
+  if (failed.length) {
+    for (const f of failed) console.error("FAIL: " + f.label);
+    process.exit(1);
+  }
+  console.log("PASS: all " + cases.length + " globToRegExp/loadPatterns cases");
+' "$WORK" 2>&1)"
+rc=$?
+echo "$OUT"
+[ "$rc" = "0" ] || fail "protect-globs.mjs matcher unit cases failed"
+
+exit 0

--- a/tools/loop-engine/test/skill-guard-prose-wiring.test.sh
+++ b/tools/loop-engine/test/skill-guard-prose-wiring.test.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# BAC-755 (ported from glucofit-partners' skill-sentinel-wiring.test.sh §③/④ — the ship-flow-specific
+# portions only). Checks that ship-flow's own SKILL.md prose stays consistent with loop-engine's
+# reward-hack guard: tdd names the .loop/guard-off escape hatch, ship-feature names the guard concept
+# generically (it's repo-agnostic post-BAC-706, so it can't hardcode the literal path), and neither
+# ever reintroduces the BAC-583 failure mode (agent-owned prose "arming" via `touch .loop/looping` —
+# the guard's actual armed/unarmed state must come from lib/protect-globs.mjs's guardState(), never
+# from a skill telling an agent to touch a sentinel file itself).
+#
+# The consuming repo's local-only loop-fix/SKILL.md (never ported to any plugin) keeps its own
+# equivalent checks — that file doesn't exist here to check.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+TDD="$HERE/../../ship-flow/skills/tdd/SKILL.md"
+SHIP="$HERE/../../ship-flow/skills/ship-feature/SKILL.md"
+
+fail() { echo "FAIL: $1"; exit 1; }
+[ -f "$TDD" ] || fail "ship-flow tdd SKILL.md not found at $TDD"
+[ -f "$SHIP" ] || fail "ship-flow ship-feature SKILL.md not found at $SHIP"
+
+grep -q '\.loop/guard-off' "$TDD" || fail "tdd SKILL.md must mention .loop/guard-off"
+echo "PASS: tdd SKILL.md mentions .loop/guard-off"
+
+grep -qi 'reward-hack guard' "$SHIP" || fail "ship-feature SKILL.md must mention the reward-hack guard concept"
+grep -qi 'window' "$SHIP" || fail "ship-feature SKILL.md must mention the guard-off window concept"
+echo "PASS: ship-feature SKILL.md mentions the reward-hack guard and its window concept"
+
+for f in "$TDD" "$SHIP"; do
+  if grep -q 'touch \.loop/looping' "$f"; then
+    fail "$f must not reintroduce prose-arming via 'touch .loop/looping' (BAC-583 failure mode)"
+  fi
+done
+echo "PASS: neither SKILL.md reintroduces touch .loop/looping prose-arming"
+
+exit 0

--- a/tools/loop-engine/test/verdict-state-producer.test.sh
+++ b/tools/loop-engine/test/verdict-state-producer.test.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# BAC-755 (ported from glucofit-partners' gate-stop-verdict.test.sh "AC5 producer" section, which
+# lived in a consuming repo even though it tests verdict-run.sh's own behavior — a Stop-hook
+# consumer running its own gate-stop-verdict.mjs against this repo's verdict-run.sh, but the
+# producer half (does verdict-run.sh itself write correct freshness state?) has zero generic
+# coverage anywhere upstream). Locks the shape of `.loop/verdict-state.json` — the freshness record
+# a consumer-repo Stop-hook gate reads to refuse stale/dirty PASS replays.
+#
+# AC1-AC4/AC7/AC8 (the Stop-hook's own block/allow/kill-switch/escape-valve behavior) stay in the
+# consuming repo — that's testing a Stop hook, a repo-local wiring concern (BAC-752's hook-bundling
+# decision governs whether/how that moves upstream, not this issue).
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+VERDICT_RUN="$HERE/../bin/verdict-run.sh"
+LOOP_FIX="$HERE/../bin/loop-fix.sh"
+
+fail() { echo "FAIL: $1"; exit 1; }
+[ -x "$VERDICT_RUN" ] || fail "verdict-run.sh not found/executable at $VERDICT_RUN"
+[ -x "$LOOP_FIX" ] || fail "loop-fix.sh not found/executable at $LOOP_FIX"
+
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/tmp.XXXXXXXX")" || fail "mktemp -d failed"
+cleanup() { chmod -R u+w "$WORK" 2>/dev/null || true; rm -rf "$WORK"; }
+trap cleanup EXIT
+
+REPO2="$WORK/repo2"
+mkdir -p "$REPO2"
+git -C "$REPO2" init -q
+printf '.loop/\n' > "$REPO2/.gitignore"
+echo hi > "$REPO2/a.txt"
+git -C "$REPO2" add .
+git -C "$REPO2" -c user.email=t@t -c user.name=t commit -qm init
+HEAD2="$(git -C "$REPO2" rev-parse HEAD)"
+state_field() { # $1=field → prints value (validates JSON while at it)
+  node -e '
+    const st = JSON.parse(require("fs").readFileSync(process.argv[1], "utf8"));
+    process.stdout.write(String(st[process.argv[2]]));
+  ' "$REPO2/.loop/verdict-state.json" "$1"
+}
+(cd "$REPO2" && "$VERDICT_RUN" -- true >/dev/null 2>&1)
+[ "$?" = "0" ] || fail "verdict-run -- true must exit 0"
+[ -f "$REPO2/.loop/verdict-state.json" ] || fail "verdict-run must write .loop/verdict-state.json"
+[ "$(state_field verdict)" = "PASS" ] || fail "state verdict must be PASS after a passing run"
+[ "$(state_field sha)" = "$HEAD2" ] || fail "state sha must be the verified HEAD ($HEAD2), got $(state_field sha)"
+[ "$(state_field dirty)" = "false" ] || fail "state dirty must be false on a clean tree"
+case "$(state_field finished_at)" in
+  *T*Z) : ;;
+  *) fail "state finished_at must be an ISO-8601 UTC timestamp, got $(state_field finished_at)" ;;
+esac
+echo wip > "$REPO2/untracked.txt"
+(cd "$REPO2" && "$VERDICT_RUN" -- true >/dev/null 2>&1)
+[ "$(state_field dirty)" = "true" ] || fail "state dirty must be true when the tree has uncommitted changes"
+rm -f "$REPO2/untracked.txt"
+(cd "$REPO2" && "$VERDICT_RUN" -- false >/dev/null 2>&1)
+rc=$?
+[ "$rc" = "1" ] || fail "verdict-run -- false must exit 1, got rc=$rc"
+[ "$(state_field verdict)" = "FAIL" ] || fail "state verdict must be FAIL after a failing run"
+# non-git directory: sha=unknown + dirty=true (freshness can't be judged → fail-closed value a
+# consumer gate should treat as stale/untrusted).
+NOGIT="$WORK/nogit"
+mkdir -p "$NOGIT"
+(cd "$NOGIT" && "$VERDICT_RUN" -- true >/dev/null 2>&1)
+node -e '
+  const st = JSON.parse(require("fs").readFileSync(process.argv[1], "utf8"));
+  if (st.sha !== "unknown" || st.dirty !== true) { console.error(st); process.exit(1); }
+' "$NOGIT/.loop/verdict-state.json" || fail "non-git verdict state must record sha=unknown dirty=true (fail-closed input)"
+# control chars in cmd must not corrupt the state JSON (review M5).
+rm -f "$REPO2/untracked.txt"
+(cd "$REPO2" && "$VERDICT_RUN" -- sh -c "$(printf 'true #\rCR')" >/dev/null 2>&1)
+[ "$(state_field verdict)" = "PASS" ] || fail "control chars in cmd must not corrupt the state JSON"
+# git status failure → dirty=true (fail-closed, symmetric with rev-parse failure — review M3).
+REALGIT="$(command -v git)"
+FAKEBIN="$WORK/fakebin"
+mkdir -p "$FAKEBIN"
+printf '#!/bin/sh\n[ "$1" = status ] && exit 1\nexec "%s" "$@"\n' "$REALGIT" > "$FAKEBIN/git"
+chmod +x "$FAKEBIN/git"
+(cd "$REPO2" && PATH="$FAKEBIN:$PATH" "$VERDICT_RUN" -- true >/dev/null 2>&1)
+[ "$(state_field dirty)" = "true" ] || fail "git status failure must record dirty=true (fail-closed), got $(state_field dirty)"
+
+echo "PASS: verdict-run.sh freshness state — sha/dirty/timestamp recorded, FAIL/non-git/control-char/status-fail shapes correct"
+
+# ── loop-fix → fixer env: LOOP_STOP_GATE_OFF=1 propagated (a consumer-repo Stop-hook gate, if
+# wired, must not fight the fixer on every cycle while a loop is actively converging). ────────────
+REPO3="$WORK/repo3"
+mkdir -p "$REPO3"
+git -C "$REPO3" init -q
+printf '.loop/\n' > "$REPO3/.gitignore"
+echo x > "$REPO3/f.txt"
+git -C "$REPO3" add .
+git -C "$REPO3" -c user.email=t@t -c user.name=t commit -qm init
+(cd "$REPO3" && "$LOOP_FIX" --verify "false" --max-iter 1 \
+  --fix 'printf "%s" "${LOOP_STOP_GATE_OFF:-unset}" > gate-off-env.out' >/dev/null 2>&1) || true
+[ "$(cat "$REPO3/gate-off-env.out" 2>/dev/null)" = "1" ] \
+  || fail "loop-fix must pass LOOP_STOP_GATE_OFF=1 to the fixer, got '$(cat "$REPO3/gate-off-env.out" 2>/dev/null)'"
+
+echo "PASS: loop-fix propagates LOOP_STOP_GATE_OFF=1 to the fixer"
+exit 0


### PR DESCRIPTION
## Summary

ADR-0078's split principle: a consuming repo's `tools/harness-test/` should only wire-check that
repo's specific use of the plugin — generic behavior of the plugin itself belongs in the plugin's
own CI. BAC-755 audits glucofit-partners' `tools/harness-test/*.test.sh` for pieces that were
actually testing loop-engine's own logic with synthetic fixtures (no repo-specific state) and
ports them here.

- `test/check-rules-always-on.test.sh` — 8 of the 9 cases from the consumer's version (dropped the
  9th, which asserts the real repo's own `.claude/rules` has zero leakage — a repo-state check,
  stays local).
- `test/verdict-state-producer.test.sh` — ported from a deleted consumer test
  (`gate-stop-verdict.test.sh`'s AC5 section, removed in glucofit-partners' BAC-766) since grepping
  `ac-verify.test.sh`/`verdict-mutation-guard.test.sh` confirmed neither actually exercises
  `verdict-run.sh`'s own state-producer correctness (sha/dirty/`finished_at` on clean/dirty trees,
  non-git dirs, control-char-injected commands, a PATH-spoofed `git status` failure) — they only
  consume `.loop/verdict-state.json` as a side channel for their own features.
- `test/skill-guard-prose-wiring.test.sh` — ported the ship-flow-specific portions of
  `skill-sentinel-wiring.test.sh` (the local-only `loop-fix/SKILL.md` checks stay in the consumer,
  that file isn't in any plugin).
- `test/protect-globs-matcher.test.sh` — new, first direct unit coverage for
  `lib/protect-globs.mjs`'s `globToRegExp`/`loadPatterns` (confirmed via grep there was none
  anywhere before this).
- `test/mktemp-fail-closed.test.sh` — ported the BAC-720 meta-lint verbatim, scanning this repo's
  own `test/*.test.sh`. Running it here surfaced two real issues fixed in this PR: a comment-line
  false-positive in the sweep itself (fixed by skipping `#`-prefixed lines) and a genuine unguarded
  `mktemp` pair in `lessons-hygiene.test.sh:115`.
- Fixed `eval-gate-tier0.test.sh`'s bare `mktemp -d` (had the `|| fail` guard but was missing the
  `${TMPDIR:-/tmp}/tmp.XXXXXXXX` template — the actual BAC-718/720 root-cause pattern).
- `protect-globs-coverage.test.sh` in the consumer was investigated and found to be entirely
  repo-specific policy (real `git ls-files`, real `.loop/protect.globs`, an inline
  consumer-defined `isSurface()` classifier) — nothing removable from it, left untouched.

loop-engine 0.5.0 → 0.5.1 (patch — test-only, no public API/behavior change; ship-flow/loop-memory's
`^0.5.0` dependency ranges already satisfy it, no joint-constraint bump needed this time).

## Test plan

- [x] `bash tools/loop-engine/test/run.sh` — 36/36 passed
- [x] `claude plugin validate --strict .` — Validation passed
- [x] Each new/modified test file run in isolation during authoring

🤖 Generated with [Claude Code](https://claude.com/claude-code)