### PR TITLE
feat(loop-engine): port docs-hygiene/pr-hygiene/module-size gates upstream (BAC-754)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,22 +11,22 @@
     {
       "name": "loop-engine",
       "source": "./tools/loop-engine",
-      "description": "Core loop mechanics: verdict-run (machine-readable PASS/FAIL contract), loop-fix (closed verify->fix loop), lessons (verified-fix memory), classify-risk, require-tests, plugin-path (resolve sibling plugin install paths). No framework opinions beyond \"the verifier is the ceiling, never the agent's self-report\".",
-      "version": "0.5.1",
+      "description": "Core loop mechanics: verdict-run (machine-readable PASS/FAIL contract), loop-fix (closed verify->fix loop), lessons (verified-fix memory), classify-risk, require-tests, plugin-path (resolve sibling plugin install paths), check-docs-hygiene/check-pr-hygiene/check-module-size (repo hygiene gates). No framework opinions beyond \"the verifier is the ceiling, never the agent's self-report\".",
+      "version": "0.6.0",
       "keywords": ["verifier", "tdd", "loop", "verdict", "lessons"]
     },
     {
       "name": "ship-flow",
       "source": "./tools/ship-flow",
       "description": "Delivery-loop skills — ship-feature (plan-to-PR autonomous loop), hotfix, retrospect, grill-with-docs, deps-audit, to-issues/to-prd, tdd, harness-maturity-audit, improve-codebase-architecture, resolving-merge-conflicts, plus review agents and audit/research workflows — parameterized by a consuming repo's own tracker/branch-model config instead of hardcoded to one repo. dependencies: loop-engine.",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "keywords": ["delivery", "git-flow", "hotfix", "ship", "release"]
     },
     {
       "name": "loop-memory",
       "source": "./tools/loop-memory",
       "description": "pgvector semantic recall for verified dev-loop lessons (and, optionally, ADR/glossary/research knowledge). Opt-in / defaultEnabled:false — a database dependency, not core loop mechanics.",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "defaultEnabled": false,
       "keywords": ["memory", "pgvector", "recall", "semantic-search", "lessons"]
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,49 @@ Explicit-version channel — see [README § Development status](README.md#develo
 not a SHA channel. Entries below `## loop-engine 0.2.0` and earlier predate the multi-plugin split
 and refer to `loop-engine` only (see the un-prefixed version numbers).
 
+## loop-memory 0.2.4
+
+- `loop-engine` dependency range bumped `^0.5.0` → `^0.6.0` to match loop-engine's minor bump below
+  (same-PR joint-constraint bump — the exact bug class fixed three times before, this time caught
+  proactively via `grep -rn '"loop-engine"' --include=plugin.json` before publishing). No other
+  content change.
+
+## ship-flow 0.2.4
+
+- `templates/ci.yml.template`: new commented-out `hygiene` job showing how to wire loop-engine's three
+  new repo-hygiene gates (below) via the existing `setup-loop-engine` action.
+- `skills/setup/SKILL.md` step 4: proposes the `hygiene` job when offering CI wiring, and notes that a
+  consuming repo whose tracker id format isn't caught by `check-pr-hygiene.mjs`'s default pattern
+  should record a `--pattern` override (e.g. via a `trackerIdPattern` field in
+  `.claude/ship-flow.config.json`) rather than editing the plugin.
+- `loop-engine` dependency range bumped `^0.5.0` → `^0.6.0` (same-PR joint-constraint bump, see above).
+
+## loop-engine 0.6.0
+
+- New `bin/check-docs-hygiene.mjs`, `bin/check-pr-hygiene.mjs`, `bin/check-module-size.mjs` (BAC-754,
+  ported from glucofit-partners' `tools/check-*.mjs` — upstream harness-maturity audit finding #15:
+  "no machine docs-hygiene gate; the original monorepo built exactly this"). All three were already
+  fully generic (root/baseline/base-ref/json flags, no repo-specific hardcoding) except
+  `check-pr-hygiene.mjs`'s tracker-id regex, which was hardcoded to `BAC-*`/`PRO-*` — replaced with a
+  `--pattern` CLI override, defaulting to a generic "LETTERS-digits" shape that still matches both of
+  those plus common conventions like JIRA-style `PROJ-123`.
+  - `check-docs-hygiene.mjs`: ADR number uniqueness/gaps, bidirectional README index completeness,
+    dangling markdown-link/backtick-path references (CLAUDE.md + docs/adr/**), SKILL.md word-count
+    WARN tiers (2,000 target / 5,000 max). Also fixes a malformed cross-repo markdown link in this
+    repo's own `docs/adr/0006-ac-level-success-contract.md` that the new gate caught immediately when
+    run against this repo's own docs.
+  - `check-pr-hygiene.mjs`: PR body must reference at least one tracker id (no closing-keyword
+    requirement — see the bin's own header for why).
+  - `check-module-size.mjs`: module-size ratchet with a self-modification guard (a PR can't relax its
+    own baseline/threshold vs. base-ref in the same commit).
+  - New `test/check-docs-hygiene.test.sh` (24 cases, ported from glucofit-partners' 23 synthetic-fixture
+    cases + a new case 14 asserting paul-loop's own `docs/adr/` stays clean — the plugin repo is now
+    also a real user of its own gate), `test/check-pr-hygiene.test.sh` (9 cases: the 7 ported +
+    2 new covering `--pattern`), `test/check-module-size.test.sh` (12 cases, ported verbatim — already
+    entirely synthetic-fixture).
+- `ship-flow/templates/ci.yml.template` and `skills/setup/SKILL.md` updated to offer wiring these three
+  gates (see ship-flow's own changelog entry below).
+
 ## loop-engine 0.5.1
 
 - New generic test coverage for pieces of the ADR-0078 "split principle" (a consuming repo's own

--- a/docs/adr/0006-ac-level-success-contract.md
+++ b/docs/adr/0006-ac-level-success-contract.md
@@ -61,4 +61,4 @@ ouroboros가 실물로 증명한 함정("선택적 계약 필드는 아무도 �
 
 - 원본: glucofit-partners `docs/adr/0104-ac-level-success-contract-plan-file-is-source-paul-loop-owns-implementation.md`
 - 구현: `bin/ac-verify.sh`, `test/ac-verify.test.sh`
-- BAC-625(원 이슈), [2026-08-04 ouroboros benchmarking §4.1](glucofit-partners docs/research/2026-08-04-ouroboros-benchmarking.md)(채택 O2)
+- BAC-625(원 이슈), glucofit-partners `docs/research/2026-08-04-ouroboros-benchmarking.md` §4.1(채택 O2)

--- a/tools/loop-engine/.claude-plugin/plugin.json
+++ b/tools/loop-engine/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "loop-engine",
-  "version": "0.5.1",
-  "description": "Core loop mechanics: verdict-run (machine-readable PASS/FAIL contract), loop-fix (closed verify->fix loop), lessons (verified-fix memory), classify-risk, require-tests. verifier=ceiling — the agent's self-judgement never substitutes for it.",
+  "version": "0.6.0",
+  "description": "Core loop mechanics: verdict-run (machine-readable PASS/FAIL contract), loop-fix (closed verify->fix loop), lessons (verified-fix memory), classify-risk, require-tests, check-docs-hygiene/check-pr-hygiene/check-module-size (repo hygiene gates). verifier=ceiling — the agent's self-judgement never substitutes for it.",
   "author": {
     "name": "paulkim-lansik"
   },

--- a/tools/loop-engine/bin/check-docs-hygiene.mjs
+++ b/tools/loop-engine/bin/check-docs-hygiene.mjs
@@ -1,0 +1,256 @@
+#!/usr/bin/env node
+// bin/check-docs-hygiene.mjs — BAC-754 (ported from glucofit-partners' tools/check-docs-hygiene.mjs,
+// originally BAC-558/BAC-551/BAC-574 — see that repo's history for the incident this codifies).
+//
+// docs 위생을 값싼 정적 검사로 게이트한다. `docs/adr/`의 번호 유일성/README 인덱스 완전성처럼
+// 사람 기억에만 의존하면 조용히 드리프트하는 불변식을 여기서 기계로 잠근다. 4개 체크, 앞 3개는
+// RED(게이트), SKILL.md 단어수 상한은 WARN만(예방 가드).
+//
+//   1. ADR 번호 유일성 — docs/adr/*.md 파일명 번호에 중복·결번 없음
+//   2. README 인덱스 완전성 — 파일 번호 집합 == docs/adr/README.md 링크 번호 집합 (양방향)
+//   3. dangling reference — 링크(`[..](path)`)는 CLAUDE.md·docs/adr/** 전체에서, 레포 경로로 보이는
+//      백틱 스팬(`apps/`·`docs/`·`.claude/` 등 알려진 최상위 디렉터리로 시작)은 **CLAUDE.md만**에서
+//      검사한다. ADR은 의사결정 당시 시점의 스냅샷이라 그 뒤 파일이 삭제·이동돼도 정상(역사 기록) —
+//      실측 확인: docs/adr/**에 같은 백틱 검사를 적용했더니 실패 80건 전부가 정당한 역사적 언급(예:
+//      ADR-0078이 기록한 tools/loop-engine의 plugin 추출 이후 경로, ADR-0062의 회전 만료된
+//      .loop/lessons/<id>.json)이었다 — CLAUDE.md는 "현재" 컨벤션을 서술하는 always-on 헌법이라
+//      다르다(BAC-551의 실제 적발도 CLAUDE.md였다). CLAUDE.md 안에서도 "이제 없다"는 취지의 서술은
+//      NEGATION_CUES로 같은 줄에서 억제한다(예: §8의 `.claude/skills/ship-feature`는 "더 이상 없다"는
+//      의도적 부재 서술).
+//   4. SKILL.md 단어수 상한 — 공식 기준 2,000(target)/5,000(max) 단어. WARN만, exit code에 반영 안 함
+//
+// Exit 0 unless check 1-3 fail. --json으로 기계가독 결과, --root로 픽스처 루트 지정(테스트용).
+
+import { execFileSync } from 'node:child_process';
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import { dirname, join, relative, resolve } from 'node:path';
+
+function resolveRoot(argv) {
+  const i = argv.indexOf('--root');
+  if (i !== -1 && argv[i + 1]) return resolve(argv[i + 1]);
+  return execFileSync('git', ['rev-parse', '--show-toplevel'], { encoding: 'utf8' }).trim();
+}
+
+const argv = process.argv.slice(2);
+const ROOT = resolveRoot(argv);
+const asJson = argv.includes('--json');
+
+const failures = []; // { check, detail }
+const warnings = []; // { check, detail }
+
+// ── 1+2: ADR 번호 유일성 + README 인덱스 완전성 ──────────────────────────────────────────────
+function checkAdrCorpus() {
+  const adrDir = join(ROOT, 'docs/adr');
+  if (!existsSync(adrDir)) return;
+
+  const files = readdirSync(adrDir).filter(
+    (f) => /^\d{4}-.+\.md$/.test(f) && f !== '0000-template.md',
+  );
+  const numSet = new Set();
+  const dupes = new Set();
+  for (const f of files) {
+    const n = f.slice(0, 4);
+    if (numSet.has(n)) dupes.add(n);
+    numSet.add(n);
+  }
+  if (dupes.size > 0) {
+    failures.push({
+      check: 'adr-number-uniqueness',
+      detail: `중복 번호: ${[...dupes].sort().join(', ')}`,
+    });
+  }
+
+  const sorted = [...numSet].map(Number).sort((a, b) => a - b);
+  if (sorted.length > 0) {
+    const [min, max] = [sorted[0], sorted[sorted.length - 1]];
+    const missing = [];
+    for (let n = min; n <= max; n++) {
+      const padded = String(n).padStart(4, '0');
+      if (!numSet.has(padded)) missing.push(padded);
+    }
+    if (missing.length > 0) {
+      failures.push({ check: 'adr-number-gaps', detail: `결번: ${missing.join(', ')}` });
+    }
+  }
+
+  const readmePath = join(adrDir, 'README.md');
+  if (existsSync(readmePath)) {
+    const readme = readFileSync(readmePath, 'utf8');
+    const readmeNums = new Set([...readme.matchAll(/\[(\d{4})\]/g)].map((m) => m[1]));
+    const missingFromReadme = [...numSet].filter((n) => !readmeNums.has(n)).sort();
+    const missingFromFiles = [...readmeNums].filter((n) => !numSet.has(n)).sort();
+    if (missingFromReadme.length > 0) {
+      failures.push({
+        check: 'adr-readme-index-completeness',
+        detail: `docs/adr/README.md 인덱스 누락(파일은 있는데 표에 없음): ${missingFromReadme.join(', ')}`,
+      });
+    }
+    if (missingFromFiles.length > 0) {
+      failures.push({
+        check: 'adr-readme-index-completeness',
+        detail: `docs/adr/README.md가 존재하지 않는 파일을 가리킴: ${missingFromFiles.join(', ')}`,
+      });
+    }
+  }
+}
+
+// ── 3: dangling reference (CLAUDE.md + docs/adr/**/*.md) ───────────────────────────────────────
+const REPO_PATH_PREFIXES = [
+  'apps/',
+  'docs/',
+  'infra/',
+  'packages/',
+  'tools/',
+  '.claude/',
+  '.github/',
+  '.husky/',
+  '.loop/',
+];
+
+function stripAnchorAndTitle(target) {
+  let t = target.trim();
+  const spaceIdx = t.search(/\s/);
+  if (spaceIdx !== -1) t = t.slice(0, spaceIdx);
+  const hashIdx = t.indexOf('#');
+  if (hashIdx !== -1) t = t.slice(0, hashIdx);
+  return t;
+}
+
+function isCheckableRepoPath(p) {
+  if (!p) return false;
+  if (p.includes('*')) return false; // glob, not a literal path
+  if (/^[a-z]+:/i.test(p)) return false; // scheme (http:, https:, mailto:, ...)
+  return true;
+}
+
+// 백틱 스팬 전용 필터 — 명령어 체인·placeholder·brace-expansion을 걸러 CLAUDE.md 백틱 검사의
+// 오탐을 없앤다(실측: apps/api/src/<feature>/<name>.ts, .claude/skills/{a,b}, `cmd1 && cmd2` 등).
+function isCheckableBacktickPath(p) {
+  if (!isCheckableRepoPath(p)) return false;
+  if (p.includes(' ') || p.includes('<') || p.includes('{')) return false;
+  return true;
+}
+
+const NEGATION_CUES = ['더 이상 없다', '더는 없다', '이제 없다', '삭제됨', '폐기됨', '제거됨'];
+
+function lineContaining(content, index) {
+  const start = content.lastIndexOf('\n', index) + 1;
+  const end = content.indexOf('\n', index);
+  return content.slice(start, end === -1 ? content.length : end);
+}
+
+function collectAdrFiles() {
+  const adrDir = join(ROOT, 'docs/adr');
+  if (!existsSync(adrDir)) return [];
+  return readdirSync(adrDir)
+    .filter((f) => f.endsWith('.md'))
+    .map((f) => join(adrDir, f));
+}
+
+function checkLinksInFile(file) {
+  const content = readFileSync(file, 'utf8');
+  // 인라인 링크 `[text](path)` + reference-style 정의 `[label]: path` 둘 다 잡는다 — 후자는 현재
+  // 레포에 0건이지만(문법 자체는 유효한 Markdown) 검사 안 하면 향후 사각지대가 된다.
+  const linkRe = /\]\(([^)]+)\)/g;
+  const refDefRe = /^\[[^\]]+\]:\s*(\S+)/gm;
+  const reported = new Set();
+  const checkTarget = (raw) => {
+    if (!isCheckableRepoPath(raw)) return;
+    const target = raw.startsWith('/') ? join(ROOT, raw) : resolve(dirname(file), raw);
+    if (reported.has(raw)) return;
+    reported.add(raw);
+    if (!existsSync(target)) {
+      failures.push({
+        check: 'dangling-reference',
+        detail: `${relative(ROOT, file)}: 링크가 가리키는 경로 없음 — ${raw}`,
+      });
+    }
+  };
+  for (const m of content.matchAll(linkRe)) checkTarget(stripAnchorAndTitle(m[1]));
+  for (const m of content.matchAll(refDefRe)) checkTarget(stripAnchorAndTitle(m[1]));
+}
+
+function checkBacktickPathsInFile(file) {
+  const content = readFileSync(file, 'utf8');
+  const backtickRe = /`([^`\n]+)`/g;
+  // 실패로 확정된 경로만 dedup한다(negation-cue로 억제된 언급은 절대 여기 안 들어간다) — 그래야
+  // 같은 경로가 "이제 없다"(억제)와 진짜 stale 언급 두 곳에 등장할 때, 어느 쪽이 먼저 스캔되든
+  // 진짜 stale 언급이 항상 잡힌다(순서 의존적 오탐 억제 방지, test-hunter 발견).
+  const reportedFailures = new Set();
+  for (const m of content.matchAll(backtickRe)) {
+    const raw = stripAnchorAndTitle(m[1]);
+    if (!raw.includes('/')) continue;
+    if (!REPO_PATH_PREFIXES.some((p) => raw.startsWith(p))) continue;
+    if (!isCheckableBacktickPath(raw)) continue;
+    const clean = raw.split(':')[0]; // strip trailing "file.ts:12" / "file.ts:12-34" line refs
+    if (existsSync(join(ROOT, clean))) continue;
+    const line = lineContaining(content, m.index);
+    if (NEGATION_CUES.some((cue) => line.includes(cue))) continue; // deliberate "no longer exists" note
+    if (reportedFailures.has(clean)) continue;
+    reportedFailures.add(clean);
+    failures.push({
+      check: 'dangling-reference',
+      detail: `${relative(ROOT, file)}: 백틱 경로 없음 — ${raw}`,
+    });
+  }
+}
+
+function checkDanglingReferences() {
+  const claudeMd = join(ROOT, 'CLAUDE.md');
+  const docFiles = [claudeMd, ...collectAdrFiles()].filter(existsSync);
+  for (const file of docFiles) checkLinksInFile(file);
+  if (existsSync(claudeMd)) checkBacktickPathsInFile(claudeMd);
+}
+
+// ── 4: SKILL.md 단어수 상한 — WARN만 (BAC-574, exit code에 반영 안 함) ───────────────────────
+const SKILL_WORD_TARGET = 2000;
+const SKILL_WORD_MAX = 5000;
+
+function findSkillFiles(dir, out = []) {
+  if (!existsSync(dir)) return out;
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name === 'node_modules' || entry.name === '.git') continue;
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      findSkillFiles(full, out);
+    } else if (entry.isFile() && entry.name === 'SKILL.md') {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+function checkSkillWordCap() {
+  for (const file of findSkillFiles(ROOT)) {
+    const words = readFileSync(file, 'utf8').trim().split(/\s+/).filter(Boolean).length;
+    if (words >= SKILL_WORD_MAX) {
+      warnings.push({
+        check: 'skill-word-cap',
+        detail: `${relative(ROOT, file)}: ${words}단어 — 공식 상한 ${SKILL_WORD_MAX} 초과`,
+      });
+    } else if (words >= SKILL_WORD_TARGET) {
+      warnings.push({
+        check: 'skill-word-cap',
+        detail: `${relative(ROOT, file)}: ${words}단어 — 공식 target ${SKILL_WORD_TARGET} 초과`,
+      });
+    }
+  }
+}
+
+checkAdrCorpus();
+checkDanglingReferences();
+checkSkillWordCap();
+
+if (asJson) {
+  console.log(JSON.stringify({ failures, warnings }, null, 2));
+} else {
+  for (const w of warnings) console.warn(`WARN  ${w.check} — ${w.detail}`);
+  for (const f of failures) console.error(`FAIL  ${f.check} — ${f.detail}`);
+  if (failures.length === 0) {
+    console.log(`check-docs-hygiene: OK (${warnings.length}건 WARN, 0건 FAIL)`);
+  } else {
+    console.error(`check-docs-hygiene: ${failures.length}건 FAIL`);
+  }
+}
+
+process.exit(failures.length > 0 ? 1 : 0);

--- a/tools/loop-engine/bin/check-module-size.mjs
+++ b/tools/loop-engine/bin/check-module-size.mjs
@@ -1,0 +1,251 @@
+#!/usr/bin/env node
+// bin/check-module-size.mjs — BAC-754 (ported from glucofit-partners' tools/check-module-size.mjs,
+// originally BAC-629 — ouroboros O8 채택, see that repo's docs/research/2026-08-04-ouroboros-
+// benchmarking.md §4.4/§6 for the source study).
+//
+// module-size ratchet: threshold(기본 2000줄)를 넘는 모듈은 "줄기만 가능"으로 고정한다. ouroboros
+// 실측(2,000줄 초과 모듈 26개=소스 35.3%, 리뷰 중 PR이 324줄 몰래 성장)에서 코디파이된 게이트 —
+// 우리는 사고 전에 도입한다.
+//
+//   1. growth 위반: threshold를 넘는 파일의 현재 줄수가 baseline에 기록된 한도(없으면 0)보다 크면
+//      FAIL. baseline에 없던 파일이 새로 threshold를 넘는 것도 growth(한도 0 초과)로 잡힌다.
+//   2. 자가변조(self-modification) 위반: 이 PR이 제안하는 baseline(작업트리)이 base-ref 시점의
+//      baseline보다 **완화**되어 있으면(threshold 상향, 개별 모듈 한도 상향, 신규 모듈 한도 추가)
+//      FAIL — 같은 커밋에서 정책 문구를 완화해 위반을 숨기는 경로를 막는다. base-ref에 baseline
+//      파일이 아예 없었다면(최초 도입) 비교 대상이 없으므로 스킵(부트스트랩).
+//
+// Exit 0 = 위반 없음. Exit 1 = growth 또는 자가변조 위반. --json으로 기계가독 결과.
+
+import { execFileSync } from 'node:child_process';
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { join, relative, resolve } from 'node:path';
+
+const DEFAULT_BASELINE_REL = 'tools/module-size-baseline.json';
+const SKIP_DIRS = new Set([
+  'node_modules',
+  'dist',
+  '.next',
+  '.turbo',
+  '.git',
+  'drizzle',
+  'coverage',
+  '.gstack',
+]);
+const SKIP_PATH_SEGMENTS = ['/migrations/', '/generated/'];
+const SOURCE_EXT = /\.(ts|tsx)$/;
+const EXCLUDE_SUFFIX = /\.(d\.ts|test\.ts|test\.tsx|spec\.ts|spec\.tsx)$/;
+
+function parseArgs(argv) {
+  const opts = {
+    root: undefined,
+    baselinePath: undefined,
+    baseRef: undefined,
+    baseBaselineFile: undefined,
+    json: false,
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--root') opts.root = argv[++i];
+    else if (a === '--baseline') opts.baselinePath = argv[++i];
+    else if (a === '--base-ref') opts.baseRef = argv[++i];
+    else if (a === '--base-baseline') opts.baseBaselineFile = argv[++i];
+    else if (a === '--json') opts.json = true;
+  }
+  return opts;
+}
+
+function resolveRoot(argv) {
+  if (argv.root) return resolve(argv.root);
+  return execFileSync('git', ['rev-parse', '--show-toplevel'], { encoding: 'utf8' }).trim();
+}
+
+function countLines(filePath) {
+  const content = readFileSync(filePath, 'utf8');
+  if (content.length === 0) return 0;
+  const lines = content.split('\n');
+  // trailing newline이면 split이 만드는 마지막 빈 요소는 줄이 아님
+  return lines[lines.length - 1] === '' ? lines.length - 1 : lines.length;
+}
+
+function walkSourceFiles(root) {
+  const out = [];
+  (function walk(dir) {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      if (entry.isDirectory()) {
+        if (SKIP_DIRS.has(entry.name)) continue;
+        walk(join(dir, entry.name));
+        continue;
+      }
+      if (!entry.isFile()) continue; // 심볼릭 링크는 의도적으로 스킵(추적 밖 콘텐츠를 끌어들이거나 순환 링크 위험 회피)
+      const full = join(dir, entry.name);
+      const rel = relative(root, full).split('\\').join('/');
+      if (!SOURCE_EXT.test(entry.name)) continue;
+      if (EXCLUDE_SUFFIX.test(entry.name)) continue;
+      if (SKIP_PATH_SEGMENTS.some((seg) => `/${rel}`.includes(seg))) continue;
+      out.push(rel);
+    }
+  })(root);
+  return out;
+}
+
+function loadJson(text) {
+  const parsed = JSON.parse(text);
+  return { threshold: parsed.threshold, modules: parsed.modules ?? {} };
+}
+
+function loadWorkingBaseline(root, baselinePath) {
+  const abs = resolve(root, baselinePath);
+  if (!existsSync(abs)) return { threshold: 2000, modules: {} };
+  return loadJson(readFileSync(abs, 'utf8'));
+}
+
+// base-ref 시점의 baseline — 자가변조 비교 대상. 없으면(최초 도입 등) null(부트스트랩, 비교 스킵).
+//
+// "파일이 그 시점에 없었음(진짜 부트스트랩)"과 "그 외 모든 실패(잘못된 ref·git 오류·손상된 JSON)"를
+// 반드시 구분한다 — 뭉뚱그려 catch하면 자가변조 체크 자체가 조용히 꺼진다(이 게이트의 존재 이유가
+// 정확히 이걸 막는 것이므로 fail-open이 가장 나쁜 결과, 리뷰에서 실증됨). ref가 아예 resolve 안 되면
+// 에러로 드러내고, ref는 유효한데 그 경로만 없으면(정상 부트스트랩) null.
+function loadBaseBaseline({ root, baselinePath, baseRef, baseBaselineFile }) {
+  if (baseBaselineFile) {
+    if (!existsSync(baseBaselineFile)) return null;
+    return loadJson(readFileSync(baseBaselineFile, 'utf8'));
+  }
+  if (!baseRef) return null;
+
+  try {
+    execFileSync('git', ['rev-parse', '--verify', `${baseRef}^{commit}`], {
+      cwd: root,
+      stdio: ['ignore', 'ignore', 'ignore'],
+    });
+  } catch {
+    throw new Error(
+      `--base-ref '${baseRef}'가 resolve되지 않습니다 (fetch-depth 부족 등 CI 배선 오류로 의심됨) — ` +
+        '자가변조 체크를 조용히 건너뛰지 않고 에러로 중단합니다.',
+    );
+  }
+
+  let text;
+  try {
+    text = execFileSync('git', ['show', `${baseRef}:${baselinePath}`], {
+      cwd: root,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+  } catch (err) {
+    const stderr = err.stderr?.toString() ?? '';
+    if (/does not exist in|exists on disk, but not in/.test(stderr)) {
+      return null; // base-ref는 유효하지만 그 시점에 baseline 파일이 없었음 — 정상 부트스트랩
+    }
+    throw new Error(
+      `--base-ref '${baseRef}':${baselinePath} 읽기 실패(부트스트랩 아님) — ${stderr.trim() || err.message}`,
+    );
+  }
+
+  try {
+    return loadJson(text);
+  } catch (err) {
+    throw new Error(
+      `--base-ref '${baseRef}':${baselinePath}의 JSON이 손상되었습니다 — ${err.message}`,
+    );
+  }
+}
+
+function checkSelfModification(working, base) {
+  const violations = [];
+  if (!base) return violations; // 부트스트랩 — 비교 대상 없음
+
+  if (working.threshold > base.threshold) {
+    violations.push({
+      kind: 'threshold-relaxed',
+      detail: `threshold ${base.threshold} → ${working.threshold}`,
+    });
+  }
+  for (const [path, limit] of Object.entries(working.modules)) {
+    const baseLimit = base.modules[path];
+    if (baseLimit === undefined) {
+      violations.push({
+        kind: 'new-module-entry',
+        path,
+        // 주의: 이 레포는 develop→main 릴리스 PR에서만 CI가 돈다(ADR-0053) — 즉 이 게이트가 도는
+        // 유일한 PR이 항상 "같은 PR" 판정 대상이라, 신규 오버사이즈 모듈을 정상적으로 등록할 자동화
+        // 경로가 없다. 실제로 필요해지면 브랜치 보호를 사람이 수동으로 완화하는 것 외엔 방법이 없다
+        // (CLAUDE.md §8 비상 우회 절차와 동일 계열) — "별도 리뷰"는 그 수동 경로를 가리킨다.
+        detail: `base-ref에 없던 모듈 한도 신설: ${limit}줄 (같은 PR에서 등록 불가 — 사람의 수동 브랜치보호 우회 필요)`,
+      });
+    } else if (limit > baseLimit) {
+      violations.push({
+        kind: 'module-limit-relaxed',
+        path,
+        detail: `${baseLimit} → ${limit}`,
+      });
+    }
+  }
+  return violations;
+}
+
+function checkGrowth(root, working) {
+  const violations = [];
+  const files = walkSourceFiles(root);
+  for (const rel of files) {
+    const lines = countLines(join(root, rel));
+    if (lines <= working.threshold) continue;
+    const limit = working.modules[rel] ?? 0;
+    if (lines > limit) {
+      violations.push({ kind: 'growth', path: rel, lines, limit });
+    }
+  }
+  return violations;
+}
+
+function main() {
+  const argv = parseArgs(process.argv.slice(2));
+  const root = resolveRoot(argv);
+  const baselinePath = argv.baselinePath ?? DEFAULT_BASELINE_REL;
+
+  let working;
+  let base;
+  try {
+    working = loadWorkingBaseline(root, baselinePath);
+    base = loadBaseBaseline({
+      root,
+      baselinePath,
+      baseRef: argv.baseRef,
+      baseBaselineFile: argv.baseBaselineFile,
+    });
+  } catch (err) {
+    if (argv.json) {
+      console.log(JSON.stringify({ ok: false, violations: [], error: err.message }));
+    } else {
+      console.error(`FAIL[wiring]: ${err.message}`);
+    }
+    process.exit(1);
+  }
+
+  const selfMod = checkSelfModification(working, base);
+  const growth = checkGrowth(root, working);
+  const violations = [...selfMod, ...growth];
+  const ok = violations.length === 0;
+
+  if (argv.json) {
+    console.log(JSON.stringify({ ok, violations }));
+  } else if (ok) {
+    console.log('PASS: module-size ratchet — 위반 없음');
+  } else {
+    for (const v of violations) {
+      if (v.kind === 'growth') {
+        console.error(
+          `FAIL[growth]: ${v.path} — ${v.lines}줄 (한도 ${v.limit}줄 초과, threshold=${working.threshold}). ` +
+            '초과 모듈은 이 PR에서 줄어들거나 그대로여야 합니다.',
+        );
+      } else {
+        console.error(`FAIL[${v.kind}]: ${v.path ?? '(threshold)'} — ${v.detail}`);
+      }
+    }
+  }
+
+  process.exit(ok ? 0 : 1);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/tools/loop-engine/bin/check-pr-hygiene.mjs
+++ b/tools/loop-engine/bin/check-pr-hygiene.mjs
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+// bin/check-pr-hygiene.mjs — BAC-754 (ported from glucofit-partners' tools/check-pr-hygiene.mjs,
+// originally BAC-629 — ouroboros O7 채택, see that repo's docs/research/2026-08-04-ouroboros-
+// benchmarking.md §4.4/§6 for the source study).
+//
+// PR 본문이 최소 1개의 트래킹 이슈를 참조하는지 검사한다. ouroboros 실측 감사(30일 merged PR 80개
+// 중 17개 무참조, 닫힌 이슈 11개 중 6개가 이미 구현된 채 방치)에서 온 게이트 — 관행에만 의존한 참조는
+// 조용히 새어나간다.
+//
+// 이슈 id 패턴은 소비 레포마다 다르다(BAC-*/PRO-*, JIRA 스타일 PROJ-*, 그 외) — `--pattern`으로
+// 주입하고, 아무 것도 안 주면 흔한 "영문 접두사-숫자" 트래커 관례(BAC-123·PRO-123·JIRA의 PROJ-123
+// 등)를 두루 잡는 일반 정규식으로 기본 동작한다. 소비 레포는 자기 트래커 id 패턴을
+// `.claude/ship-flow.config.json`(예: `trackerIdPattern`)에 두고 CI/스킬 호출부에서 `--pattern`으로
+// 넘기는 것을 권장한다(ship-flow의 setup/publisher가 이 값을 읽어 넘긴다).
+//
+// 의도적으로 **closing 키워드(Closes/Fixes #N)가 아니라 참조 존재만** 요구한다 — 트래커가 GitHub
+// 키워드로 자동 close되지 않는 경우가 흔하고(Linear 등), 강제하면 "임시로 키워드를 넣었다가 빼먹어
+// 오발 close"라는 별도 실패모드만 늘어난다(ouroboros 설계 그대로).
+//
+// Exit 0 = 참조 있음. Exit 1 = 없음. --json으로 기계가독 결과.
+
+import { readFileSync } from 'node:fs';
+
+// case-insensitive — 목적은 "참조가 존재하는가"이지 표기 규칙 검사가 아니다.
+const DEFAULT_REF_PATTERN = /\b[A-Z]{2,}-\d+\b/i;
+
+function parseArgs(argv) {
+  const opts = { body: undefined, bodyFile: undefined, json: false, pattern: undefined };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--body') opts.body = argv[++i];
+    else if (a === '--body-file') opts.bodyFile = argv[++i];
+    else if (a === '--pattern') opts.pattern = argv[++i];
+    else if (a === '--json') opts.json = true;
+  }
+  return opts;
+}
+
+function resolveBody(opts) {
+  if (opts.body !== undefined) return opts.body;
+  if (opts.bodyFile !== undefined) return readFileSync(opts.bodyFile, 'utf8');
+  return readFileSync(0, 'utf8'); // stdin
+}
+
+function resolvePattern(raw) {
+  if (!raw) return DEFAULT_REF_PATTERN;
+  return new RegExp(raw, 'i');
+}
+
+export function checkPrHygiene(body, pattern = DEFAULT_REF_PATTERN) {
+  const text = body ?? '';
+  const match = text.match(pattern);
+  return { ok: match !== null, matched: match?.[0] ?? null };
+}
+
+function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  const body = resolveBody(opts);
+  const pattern = resolvePattern(opts.pattern);
+  const result = checkPrHygiene(body, pattern);
+
+  if (opts.json) {
+    console.log(JSON.stringify(result));
+  } else if (result.ok) {
+    console.log(`PASS: PR body references ${result.matched}`);
+  } else {
+    console.error(
+      'FAIL: PR body에 트래킹 이슈 참조가 없습니다. closing 키워드는 필요 없습니다 — ' +
+        '그냥 이슈 번호를 본문 어딘가에 적어주세요.',
+    );
+  }
+
+  process.exit(result.ok ? 0 : 1);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/tools/loop-engine/test/check-docs-hygiene.test.sh
+++ b/tools/loop-engine/test/check-docs-hygiene.test.sh
@@ -1,0 +1,280 @@
+#!/usr/bin/env bash
+# BAC-754 (ported from glucofit-partners' docs-hygiene.test.sh cases 1-13b — bin/check-docs-hygiene.mjs
+# is a synthetic-fixture-testable plugin bin, not consumer-repo state; case 14 (asserting THIS repo's
+# own docs/adr + CLAUDE.md are clean) stayed local — a real-repo-state assertion isn't portable).
+#
+# 계약: docs/adr/ 번호 유일성 + README.md 인덱스 완전성(양방향) + CLAUDE.md·docs/adr/**의 dangling
+# 링크/(CLAUDE.md만) dangling 백틱 경로는 FAIL(exit 1). SKILL.md 단어수 상한은 WARN만 — exit code에
+# 반영 안 됨(예방 가드로 시작).
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+CHECK="$HERE/../bin/check-docs-hygiene.mjs"
+
+fail() { echo "FAIL: $1"; exit 1; }
+[ -f "$CHECK" ] || fail "check-docs-hygiene.mjs not found at $CHECK"
+
+DIR="$(mktemp -d "${TMPDIR:-/tmp}/tmp.XXXXXXXX")" || fail "mktemp -d failed"
+trap 'rm -rf "$DIR"' EXIT
+
+mk_readme() {
+  # $1 = target root, $2... = "NNNN|제목|상태" 행
+  local root="$1"; shift
+  {
+    echo "# ADR"
+    echo ""
+    echo "| # | 결정 | 상태 |"
+    echo "|---|---|---|"
+    for row in "$@"; do
+      IFS='|' read -r num title status <<<"$row"
+      echo "| [$num](./$num-x.md) | $title | $status |"
+    done
+  } > "$root/docs/adr/README.md"
+}
+
+# ── 1) 정상 코퍼스(연속 번호·중복 없음·README 완전) → exit 0, FAIL 0 ────────────────────────────
+OK="$DIR/ok"
+mkdir -p "$OK/docs/adr"
+printf '# ADR-0001\n' > "$OK/docs/adr/0001-x.md"
+printf '# ADR-0002\n' > "$OK/docs/adr/0002-x.md"
+printf '# ADR-0000 template\n' > "$OK/docs/adr/0000-template.md"
+mk_readme "$OK" "0001|a|승인됨" "0002|b|승인됨"
+OUT_OK="$(node "$CHECK" --root "$OK" --json)"; rc=$?
+[ "$rc" = "0" ] || fail "clean corpus must exit 0, got $rc: $OUT_OK"
+node -e '
+  const m = JSON.parse(process.argv[1]);
+  if (m.failures.length !== 0) throw new Error("clean corpus must have 0 failures, got " + JSON.stringify(m.failures));
+' "$OUT_OK" || fail "clean corpus JSON wrong"
+echo "PASS: sequential, duplicate-free ADR corpus with a complete README index exits 0"
+
+# ── 2) 0000-template.md은 번호 유일성/README 완전성 검사에서 제외된다 ───────────────────────────
+# (위 OK 픽스처가 이미 0000을 갖고도 통과했다는 사실 자체가 증거 — 별도 assert 불필요)
+
+# ── 3) ADR 번호 중복 → FAIL ──────────────────────────────────────────────────────────────────
+DUP="$DIR/dup"
+mkdir -p "$DUP/docs/adr"
+printf '# a\n' > "$DUP/docs/adr/0001-a.md"
+printf '# b\n' > "$DUP/docs/adr/0001-x.md"
+mk_readme "$DUP" "0001|a|승인됨"
+OUT_DUP="$(node "$CHECK" --root "$DUP" --json)"; rc=$?
+[ "$rc" = "1" ] || fail "duplicate ADR number must exit 1, got $rc"
+printf '%s' "$OUT_DUP" | grep -q 'adr-number-uniqueness' || fail "duplicate must be tagged adr-number-uniqueness"
+echo "PASS: duplicate ADR numbers are flagged with exit 1"
+
+# ── 4) ADR 번호 결번(중간에 구멍) → FAIL ─────────────────────────────────────────────────────
+GAP="$DIR/gap"
+mkdir -p "$GAP/docs/adr"
+printf '# a\n' > "$GAP/docs/adr/0001-x.md"
+printf '# c\n' > "$GAP/docs/adr/0003-x.md"
+mk_readme "$GAP" "0001|a|승인됨" "0003|c|승인됨"
+OUT_GAP="$(node "$CHECK" --root "$GAP" --json)"; rc=$?
+[ "$rc" = "1" ] || fail "gap in ADR numbering must exit 1, got $rc"
+printf '%s' "$OUT_GAP" | grep -q 'adr-number-gaps' || fail "gap must be tagged adr-number-gaps"
+printf '%s' "$OUT_GAP" | grep -q '0002' || fail "gap detail must name the missing number 0002"
+echo "PASS: a gap in ADR numbering (0001, 0003 — no 0002) is flagged with exit 1"
+
+# ── 5) README 인덱스 누락(파일은 있는데 표에 없음) → FAIL (BAC-551 48시간 재발의 실제 형태) ────
+MISS="$DIR/missing-from-readme"
+mkdir -p "$MISS/docs/adr"
+printf '# a\n' > "$MISS/docs/adr/0001-x.md"
+printf '# b\n' > "$MISS/docs/adr/0002-b.md"
+mk_readme "$MISS" "0001|a|승인됨"
+OUT_MISS="$(node "$CHECK" --root "$MISS" --json)"; rc=$?
+[ "$rc" = "1" ] || fail "ADR missing from README index must exit 1, got $rc"
+printf '%s' "$OUT_MISS" | grep -q 'adr-readme-index-completeness' || fail "must be tagged adr-readme-index-completeness"
+printf '%s' "$OUT_MISS" | grep -q '0002' || fail "detail must name the missing number 0002"
+echo "PASS: an ADR file present but missing from README.md's index is flagged with exit 1"
+
+# ── 6) README이 존재하지 않는 파일을 가리킴(반대 방향) → FAIL ──────────────────────────────────
+STALE="$DIR/stale-readme"
+mkdir -p "$STALE/docs/adr"
+printf '# a\n' > "$STALE/docs/adr/0001-x.md"
+mk_readme "$STALE" "0001|a|승인됨" "0002|ghost|승인됨"
+OUT_STALE="$(node "$CHECK" --root "$STALE" --json)"; rc=$?
+[ "$rc" = "1" ] || fail "README pointing at a nonexistent ADR must exit 1, got $rc"
+printf '%s' "$OUT_STALE" | grep -q '존재하지 않는 파일을 가리킴' || fail "must report the reverse-direction stale-index case"
+echo "PASS: README.md indexing a number with no matching file is flagged with exit 1"
+
+# ── 7) CLAUDE.md의 dangling 마크다운 링크 → FAIL ────────────────────────────────────────────
+DLINK="$DIR/dangling-link"
+mkdir -p "$DLINK/docs/adr"
+printf -- '# CLAUDE\n\nSee [ghost](./docs/does-not-exist.md) for details.\n' > "$DLINK/CLAUDE.md"
+OUT_DLINK="$(node "$CHECK" --root "$DLINK" --json)"; rc=$?
+[ "$rc" = "1" ] || fail "dangling markdown link in CLAUDE.md must exit 1, got $rc"
+printf '%s' "$OUT_DLINK" | grep -q 'dangling-reference' || fail "must be tagged dangling-reference"
+echo "PASS: a markdown link in CLAUDE.md pointing nowhere is flagged with exit 1"
+
+# ── 8) 유효한 상대 링크는 통과한다 ───────────────────────────────────────────────────────────
+VLINK="$DIR/valid-link"
+mkdir -p "$VLINK/docs/adr"
+printf '# target\n' > "$VLINK/docs/adr/0001-x.md"
+printf -- '# CLAUDE\n\nSee [target](./docs/adr/0001-x.md).\n' > "$VLINK/CLAUDE.md"
+mk_readme "$VLINK" "0001|target|승인됨"
+node "$CHECK" --root "$VLINK" --json >/dev/null; rc=$?
+[ "$rc" = "0" ] || fail "a link to a file that actually exists must not fail, got $rc"
+echo "PASS: a markdown link that resolves to a real file does not fail the gate"
+
+# ── 9) CLAUDE.md의 dangling 백틱 경로(알려진 레포 prefix로 시작) → FAIL ─────────────────────────
+DTICK="$DIR/dangling-tick"
+mkdir -p "$DTICK/docs/adr"
+printf -- '# CLAUDE\n\nSee `apps/api/src/does-not-exist.ts` for the pattern.\n' > "$DTICK/CLAUDE.md"
+OUT_DTICK="$(node "$CHECK" --root "$DTICK" --json)"; rc=$?
+[ "$rc" = "1" ] || fail "dangling backtick repo-path in CLAUDE.md must exit 1, got $rc"
+printf '%s' "$OUT_DTICK" | grep -q 'apps/api/src/does-not-exist.ts' || fail "detail must name the missing path"
+echo "PASS: a backtick-quoted repo path in CLAUDE.md pointing nowhere is flagged with exit 1"
+
+# ── 10) 같은 줄에 부정 단서("더 이상 없다" 등)가 있으면 억제된다 — 의도적 부재 서술 ─────────────
+NEG="$DIR/negation"
+mkdir -p "$NEG/docs/adr"
+printf -- '# CLAUDE\n\n로컬 `apps/api/src/does-not-exist.ts`는 더 이상 없다.\n' > "$NEG/CLAUDE.md"
+node "$CHECK" --root "$NEG" --json >/dev/null; rc=$?
+[ "$rc" = "0" ] || fail "a same-line negation cue must suppress the dangling backtick finding, got $rc"
+echo "PASS: '...는 더 이상 없다' on the same line suppresses a deliberate non-existence note"
+
+# ── 10b) 같은 경로가 부정 단서 있는 줄과 없는 줄에 둘 다 등장하면, 순서와 무관하게 진짜 stale
+#         언급은 여전히 잡혀야 한다 — 먼저 스캔된 억제 언급이 dedup으로 뒤의 진짜 실패를 삼키면 안
+#         된다(test-hunter 발견: negation-cue 체크 전에 dedup Set에 추가하던 버그) ─────────────
+DUPNEG="$DIR/dup-negation-order"
+mkdir -p "$DUPNEG/docs/adr"
+printf -- '# CLAUDE\n\n로컬 `apps/api/src/does-not-exist.ts`는 더 이상 없다.\n나중에 다시 쓴다: `apps/api/src/does-not-exist.ts`를 참고할 것.\n' > "$DUPNEG/CLAUDE.md"
+OUT_DUPNEG="$(node "$CHECK" --root "$DUPNEG" --json)"; rc=$?
+[ "$rc" = "1" ] || fail "a real (non-negated) mention of a path must still fail even if an earlier negated mention of the SAME path exists, got $rc"
+printf '%s' "$OUT_DUPNEG" | grep -q 'apps/api/src/does-not-exist.ts' || fail "detail must name the missing path"
+echo "PASS: a genuine dangling mention is caught even when a negated mention of the same path appears earlier in the file"
+
+# ── 11) glob 백틱 스팬(**)은 경로로 취급되지 않는다 ──────────────────────────────────────────
+GLOB="$DIR/glob"
+mkdir -p "$GLOB/docs/adr"
+printf -- '# CLAUDE\n\n`apps/web/**` import는 금지.\n' > "$GLOB/CLAUDE.md"
+node "$CHECK" --root "$GLOB" --json >/dev/null; rc=$?
+[ "$rc" = "0" ] || fail "a glob-style backtick span (apps/web/**) must not be treated as a literal path, got $rc"
+echo "PASS: glob-style backtick spans (containing *) are not checked as literal paths"
+
+# ── 12) docs/adr/**의 dangling 백틱 경로는 검사 대상이 아니다 — ADR은 역사 기록(스냅샷)이라 ─────
+#       구현 파일이 나중에 삭제/이동돼도 정상. 링크는 여전히 검사한다(같은 파일에서 확인).
+ADRHIST="$DIR/adr-history"
+mkdir -p "$ADRHIST/docs/adr"
+printf '# a\n' > "$ADRHIST/docs/adr/0001-x.md"
+printf -- '# ADR-0002\n\n참고 코드는 `apps/api/src/long-deleted-file.ts`였다.\n' > "$ADRHIST/docs/adr/0002-x.md"
+mk_readme "$ADRHIST" "0001|a|승인됨" "0002|b|승인됨"
+node "$CHECK" --root "$ADRHIST" --json >/dev/null; rc=$?
+[ "$rc" = "0" ] || fail "a dangling backtick path inside docs/adr/**/*.md (historical record) must not fail, got $rc"
+echo "PASS: docs/adr/**/*.md backtick paths are exempt from the dangling check (ADRs are historical snapshots)"
+
+ADRHISTLINK="$DIR/adr-history-link"
+mkdir -p "$ADRHISTLINK/docs/adr"
+printf '# a\n' > "$ADRHISTLINK/docs/adr/0001-x.md"
+printf -- '# ADR-0002\n\nSee [ghost](./0999-ghost.md).\n' > "$ADRHISTLINK/docs/adr/0002-x.md"
+mk_readme "$ADRHISTLINK" "0001|a|승인됨" "0002|b|승인됨"
+OUT_ADRHISTLINK="$(node "$CHECK" --root "$ADRHISTLINK" --json)"; rc=$?
+[ "$rc" = "1" ] || fail "a dangling markdown LINK inside an ADR file must still fail (links are always checked), got $rc"
+echo "PASS: markdown links inside docs/adr/**/*.md are still checked (only backtick paths are exempt there)"
+
+# ── 12c) reference-style 링크 정의(`[label]: path`)도 검사한다 ───────────────────────────────
+REFDEF="$DIR/ref-def"
+mkdir -p "$REFDEF/docs/adr"
+printf -- '# CLAUDE\n\nSee [ghost][1].\n\n[1]: ./docs/does-not-exist.md\n' > "$REFDEF/CLAUDE.md"
+OUT_REFDEF="$(node "$CHECK" --root "$REFDEF" --json)"; rc=$?
+[ "$rc" = "1" ] || fail "a dangling reference-style link definition must exit 1, got $rc"
+printf '%s' "$OUT_REFDEF" | grep -q 'dangling-reference' || fail "must be tagged dangling-reference"
+echo "PASS: a dangling reference-style link definition ([label]: path) is flagged with exit 1"
+
+# ── 12d) 경로 해석 경계 케이스 — 절대경로 스타일 링크, title 텍스트, 앵커전용/앵커접미 링크 ─────
+EDGE="$DIR/path-edges"
+mkdir -p "$EDGE/docs/adr"
+printf '# target\n' > "$EDGE/docs/adr/0001-x.md"
+mk_readme "$EDGE" "0001|target|승인됨"
+printf -- '%s\n' \
+  '# CLAUDE' '' \
+  'absolute-style: [a](/docs/adr/0001-x.md)' \
+  'title text: [b](./docs/adr/0001-x.md "Some Title")' \
+  'anchor-only: [c](#자체-섹션)' \
+  'anchor-suffixed, existing file: [d](./docs/adr/0001-x.md#heading)' \
+  > "$EDGE/CLAUDE.md"
+node "$CHECK" --root "$EDGE" --json >/dev/null; rc=$?
+[ "$rc" = "0" ] || fail "absolute-style links, titled links, anchor-only links, and anchor-suffixed links to real files must all pass, got $rc"
+echo "PASS: absolute-style links, link titles, anchor-only links, and anchor-suffixed real-file links all resolve correctly"
+
+EDGEBAD="$DIR/path-edges-bad"
+mkdir -p "$EDGEBAD/docs/adr"
+printf -- '# CLAUDE\n\nanchor-suffixed, missing file: [d](./docs/adr/0999-ghost.md#heading)\n' > "$EDGEBAD/CLAUDE.md"
+node "$CHECK" --root "$EDGEBAD" --json >/dev/null; rc=$?
+[ "$rc" = "1" ] || fail "an anchor-suffixed link to a MISSING file must still fail, got $rc"
+echo "PASS: an anchor-suffixed link to a missing file still fails (the anchor doesn't hide a bad path)"
+
+# ── 12e) scheme-prefixed 링크(http/https/mailto)는 경로로 취급되지 않는다 ───────────────────────
+SCHEME="$DIR/scheme"
+mkdir -p "$SCHEME/docs/adr"
+printf -- '# CLAUDE\n\n[a](https://example.com/apps/ghost.ts) [b](mailto:x@example.com)\n' > "$SCHEME/CLAUDE.md"
+node "$CHECK" --root "$SCHEME" --json >/dev/null; rc=$?
+[ "$rc" = "0" ] || fail "http(s):// and mailto: links must be excluded from path resolution, got $rc"
+echo "PASS: scheme-prefixed links (http/https/mailto) are excluded from filesystem resolution"
+
+# ── 12f) 줄번호 접미 백틱 경로(file.ts:12-34)는 접미를 떼고 실제 파일 존재로 판정한다 ────────────
+LNSUFFIX="$DIR/line-number-suffix"
+mkdir -p "$LNSUFFIX/docs/adr" "$LNSUFFIX/apps/api/src"
+printf 'export {}\n' > "$LNSUFFIX/apps/api/src/real.ts"
+printf -- '# CLAUDE\n\nSee `apps/api/src/real.ts:12-34` for the pattern.\n' > "$LNSUFFIX/CLAUDE.md"
+node "$CHECK" --root "$LNSUFFIX" --json >/dev/null; rc=$?
+[ "$rc" = "0" ] || fail "a line-number-suffixed backtick path to a real file must not fail, got $rc"
+echo "PASS: a line-number suffix (file.ts:12-34) on a backtick path is stripped before existence is checked"
+
+LNSUFFIXBAD="$DIR/line-number-suffix-bad"
+mkdir -p "$LNSUFFIXBAD/docs/adr"
+printf -- '# CLAUDE\n\nSee `apps/api/src/ghost.ts:12-34` for the pattern.\n' > "$LNSUFFIXBAD/CLAUDE.md"
+node "$CHECK" --root "$LNSUFFIXBAD" --json >/dev/null; rc=$?
+[ "$rc" = "1" ] || fail "a line-number-suffixed backtick path to a MISSING file must still fail, got $rc"
+echo "PASS: a line-number suffix on a backtick path to a missing file still fails"
+
+# ── 13) SKILL.md 단어수 상한은 WARN만 — target/max 초과해도 exit code는 0 ──────────────────────
+SKILLWARN="$DIR/skill-warn"
+mkdir -p "$SKILLWARN/.claude/skills/big/"
+node -e 'process.stdout.write(Array(2100).fill("word").join(" "))' > "$SKILLWARN/.claude/skills/big/SKILL.md"
+OUT_SKILLWARN="$(node "$CHECK" --root "$SKILLWARN" --json)"; rc=$?
+[ "$rc" = "0" ] || fail "SKILL.md over the word target must still exit 0 (WARN tier only), got $rc"
+printf '%s' "$OUT_SKILLWARN" | grep -q 'skill-word-cap' || fail "must report a skill-word-cap warning"
+echo "PASS: a SKILL.md over the 2,000-word target is reported as a warning but does not fail the gate"
+
+SKILLOVERMAX="$DIR/skill-over-max"
+mkdir -p "$SKILLOVERMAX/.claude/skills/huge/"
+node -e 'process.stdout.write(Array(5100).fill("word").join(" "))' > "$SKILLOVERMAX/.claude/skills/huge/SKILL.md"
+OUT_SKILLOVERMAX="$(node "$CHECK" --root "$SKILLOVERMAX" --json)"; rc=$?
+[ "$rc" = "0" ] || fail "SKILL.md over the 5,000-word max must still exit 0 (WARN-only preventive guard, BAC-574), got $rc"
+printf '%s' "$OUT_SKILLOVERMAX" | grep -q '공식 상한' || fail "over-max warning must use the distinct '공식 상한' wording, not the target wording"
+echo "PASS: a SKILL.md over the 5,000-word official max is still WARN-only (not yet promoted to a gate)"
+
+# ── 13b) 경계값(정확히 2,000/5,000 단어) — >= 판정 회귀 잠금 + target/max 두 티어 메시지가
+#         실제로 구분됨을 확인 ─────────────────────────────────────────────────────────────────
+SKILLBELOW="$DIR/skill-below-target"
+mkdir -p "$SKILLBELOW/.claude/skills/s/"
+node -e 'process.stdout.write(Array(1999).fill("word").join(" "))' > "$SKILLBELOW/.claude/skills/s/SKILL.md"
+OUT_SKILLBELOW="$(node "$CHECK" --root "$SKILLBELOW" --json)"; rc=$?
+[ "$rc" = "0" ] || fail "1999 words (just under target) must not warn, got exit $rc"
+node -e '
+  const m = JSON.parse(process.argv[1]);
+  if (m.warnings.length !== 0) throw new Error("1999 words must not warn, got " + JSON.stringify(m.warnings));
+' "$OUT_SKILLBELOW" || fail "1999-word SKILL.md must produce zero warnings"
+echo "PASS: a SKILL.md at 1,999 words (just under target) produces no warning"
+
+SKILLATTARGET="$DIR/skill-at-target"
+mkdir -p "$SKILLATTARGET/.claude/skills/s/"
+node -e 'process.stdout.write(Array(2000).fill("word").join(" "))' > "$SKILLATTARGET/.claude/skills/s/SKILL.md"
+OUT_SKILLATTARGET="$(node "$CHECK" --root "$SKILLATTARGET" --json)"
+printf '%s' "$OUT_SKILLATTARGET" | grep -q '공식 target' || fail "exactly 2000 words must warn at the target tier (>= boundary)"
+printf '%s' "$OUT_SKILLATTARGET" | grep -q '공식 상한' && fail "exactly 2000 words must NOT warn at the max tier"
+echo "PASS: a SKILL.md at exactly 2,000 words warns at the target tier (>= boundary), not the max tier"
+
+SKILLATMAX="$DIR/skill-at-max"
+mkdir -p "$SKILLATMAX/.claude/skills/s/"
+node -e 'process.stdout.write(Array(5000).fill("word").join(" "))' > "$SKILLATMAX/.claude/skills/s/SKILL.md"
+OUT_SKILLATMAX="$(node "$CHECK" --root "$SKILLATMAX" --json)"
+printf '%s' "$OUT_SKILLATMAX" | grep -q '공식 상한' || fail "exactly 5000 words must warn at the max tier (>= boundary)"
+echo "PASS: a SKILL.md at exactly 5,000 words warns at the max tier (>= boundary)"
+
+# ── 14) paul-loop 자신의 docs/adr/도 이 게이트의 실사용자다 — 이 레포에 대해 항상 통과해야 한다
+#       (BAC-754 AC: "업스트림 자체 docs/adr/에 대해 docs-hygiene이 통과") ───────────────────────
+REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
+OUT_REAL="$(node "$CHECK" --root "$REPO_ROOT" --json)"; rc=$?
+[ "$rc" = "0" ] || fail "paul-loop's own docs/adr/ must have zero dangling-reference/index failures, got exit $rc: $OUT_REAL"
+echo "PASS: paul-loop's own docs/adr/ numbering and references are clean (real gate, not just fixtures)"
+
+exit 0

--- a/tools/loop-engine/test/check-module-size.test.sh
+++ b/tools/loop-engine/test/check-module-size.test.sh
@@ -1,0 +1,196 @@
+#!/usr/bin/env bash
+# BAC-754 (ported from glucofit-partners' module-size.test.sh, originally BAC-629 — ouroboros O8
+# 채택). bin/check-module-size.mjs is entirely synthetic-fixture-testable — every case here builds its
+# own throwaway root, no consumer-repo state involved.
+#
+# 계약:
+#   1) threshold를 넘는 파일의 현재 줄수가 baseline 한도(없으면 0)보다 크면 growth 위반 → exit 1.
+#   2) 이 PR이 제안하는 baseline(작업트리)이 base-ref 시점 baseline보다 완화(threshold 상향/모듈
+#      한도 상향/신규 모듈 한도 추가)되어 있으면 self-modification 위반 → exit 1.
+#   3) base-ref에 baseline이 아예 없으면(최초 도입) self-mod 비교는 스킵(부트스트랩).
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+CHECK="$HERE/../bin/check-module-size.mjs"
+
+fail() { echo "FAIL: $1"; exit 1; }
+[ -f "$CHECK" ] || fail "check-module-size.mjs not found at $CHECK"
+
+DIR="$(mktemp -d "${TMPDIR:-/tmp}/tmp.XXXXXXXX")" || fail "mktemp -d failed"
+trap 'rm -rf "$DIR"' EXIT
+
+mk_lines() {
+  # $1 = target file, $2 = line count
+  local f="$1" n="$2"
+  mkdir -p "$(dirname "$f")"
+  : > "$f"
+  for ((i = 1; i <= n; i++)); do echo "// line $i" >> "$f"; done
+}
+
+mk_baseline() {
+  # $1 = target path, $2 = threshold, $3... = "path:limit" pairs
+  local f="$1" threshold="$2"; shift 2
+  mkdir -p "$(dirname "$f")"
+  local entries="" first=1
+  for pair in "$@"; do
+    local p="${pair%%:*}" lim="${pair#*:}"
+    [ "$first" = "1" ] || entries="$entries,"
+    entries="$entries\"$p\":$lim"
+    first=0
+  done
+  printf '{"threshold":%s,"modules":{%s}}\n' "$threshold" "$entries" > "$f"
+}
+
+# ── 1) baseline과 정확히 일치하는 오버사이즈 모듈 → exit 0 ──────────────────────────────────────
+OK="$DIR/ok"
+mkdir -p "$OK/src"
+mk_lines "$OK/src/big.ts" 2500
+mk_baseline "$OK/tools/module-size-baseline.json" 2000 "src/big.ts:2500"
+OUT_OK="$(node "$CHECK" --root "$OK" --json)"; rc=$?
+[ "$rc" = "0" ] || fail "baseline-matching oversized module must exit 0, got $rc: $OUT_OK"
+echo "PASS: module at exactly its baseline limit exits 0"
+
+# ── 2) threshold 이하 모듈은 baseline에 없어도 통과 ─────────────────────────────────────────
+mk_lines "$OK/src/small.ts" 100
+OUT_OK2="$(node "$CHECK" --root "$OK" --json)"; rc=$?
+[ "$rc" = "0" ] || fail "under-threshold file with no baseline entry must exit 0, got $rc: $OUT_OK2"
+echo "PASS: file under threshold with no baseline entry exits 0"
+
+# ── 3) growth 위반: baseline 한도를 넘겨 자란 모듈 → exit 1, kind=growth ────────────────────────
+GROW="$DIR/grow"
+mkdir -p "$GROW/src"
+mk_lines "$GROW/src/big.ts" 2600
+mk_baseline "$GROW/tools/module-size-baseline.json" 2000 "src/big.ts:2500"
+OUT_GROW="$(node "$CHECK" --root "$GROW" --json)"; rc=$?
+[ "$rc" = "1" ] || fail "module grown past its baseline limit must exit 1, got $rc"
+node -e '
+  const r = JSON.parse(process.argv[1]);
+  const v = r.violations.find(v => v.kind === "growth" && v.path === "src/big.ts");
+  if (!v) throw new Error("expected growth violation for src/big.ts, got " + JSON.stringify(r));
+  if (v.lines !== 2600 || v.limit !== 2500) throw new Error("wrong lines/limit: " + JSON.stringify(v));
+' "$OUT_GROW" || fail "growth violation JSON shape wrong"
+echo "PASS: module grown past its baseline limit is flagged growth and exits 1"
+
+# ── 4) growth 위반: baseline에 아예 없던 신규 모듈이 threshold를 넘김(한도 0 초과) → exit 1 ──────
+NEWBIG="$DIR/newbig"
+mkdir -p "$NEWBIG/src"
+mk_lines "$NEWBIG/src/surprise.ts" 2100
+mk_baseline "$NEWBIG/tools/module-size-baseline.json" 2000
+OUT_NEWBIG="$(node "$CHECK" --root "$NEWBIG" --json)"; rc=$?
+[ "$rc" = "1" ] || fail "new module crossing threshold must exit 1, got $rc"
+node -e '
+  const r = JSON.parse(process.argv[1]);
+  const v = r.violations.find(v => v.kind === "growth" && v.path === "src/surprise.ts");
+  if (!v || v.limit !== 0) throw new Error("expected growth violation with limit 0, got " + JSON.stringify(r));
+' "$OUT_NEWBIG" || fail "new-module growth violation JSON shape wrong"
+echo "PASS: a module newly crossing threshold (unregistered) exits 1"
+
+# ── 5) 정당한 shrink: 모듈이 줄어들면 통과(줄어든 만큼 baseline이 더 낮아도 무방) ────────────────
+SHRINK="$DIR/shrink"
+mkdir -p "$SHRINK/src"
+mk_lines "$SHRINK/src/big.ts" 2400
+mk_baseline "$SHRINK/tools/module-size-baseline.json" 2000 "src/big.ts:2500"
+OUT_SHRINK="$(node "$CHECK" --root "$SHRINK" --json)"; rc=$?
+[ "$rc" = "0" ] || fail "module shrunk below its baseline limit must exit 0, got $rc: $OUT_SHRINK"
+echo "PASS: module shrunk below its baseline limit exits 0"
+
+# ── 6) 자가변조: 같은 PR에서 개별 모듈 한도를 상향 → exit 1, kind=module-limit-relaxed ──────────
+RELAX="$DIR/relax"
+mkdir -p "$RELAX/src"
+mk_lines "$RELAX/src/big.ts" 2500
+mk_baseline "$RELAX/tools/module-size-baseline.json" 2000 "src/big.ts:3000"   # working: relaxed to 3000
+mk_baseline "$RELAX/base-baseline.json" 2000 "src/big.ts:2500"               # base-ref: was 2500
+OUT_RELAX="$(node "$CHECK" --root "$RELAX" --base-baseline "$RELAX/base-baseline.json" --json)"; rc=$?
+[ "$rc" = "1" ] || fail "raising a module's baseline limit in the same PR must exit 1, got $rc"
+node -e '
+  const r = JSON.parse(process.argv[1]);
+  const v = r.violations.find(v => v.kind === "module-limit-relaxed" && v.path === "src/big.ts");
+  if (!v) throw new Error("expected module-limit-relaxed violation, got " + JSON.stringify(r));
+' "$OUT_RELAX" || fail "module-limit-relaxed JSON shape wrong"
+echo "PASS: raising a module baseline limit vs. base-ref in the same PR is blocked (self-modification)"
+
+# ── 7) 자가변조: 같은 PR에서 threshold 자체를 상향 → exit 1, kind=threshold-relaxed ─────────────
+RELAXT="$DIR/relaxt"
+mkdir -p "$RELAXT/src"
+mk_lines "$RELAXT/src/big.ts" 2500
+mk_baseline "$RELAXT/tools/module-size-baseline.json" 3000 "src/big.ts:2500"  # working: threshold 3000
+mk_baseline "$RELAXT/base-baseline.json" 2000 "src/big.ts:2500"              # base-ref: threshold 2000
+OUT_RELAXT="$(node "$CHECK" --root "$RELAXT" --base-baseline "$RELAXT/base-baseline.json" --json)"; rc=$?
+[ "$rc" = "1" ] || fail "raising the global threshold in the same PR must exit 1, got $rc"
+node -e '
+  const r = JSON.parse(process.argv[1]);
+  const v = r.violations.find(v => v.kind === "threshold-relaxed");
+  if (!v) throw new Error("expected threshold-relaxed violation, got " + JSON.stringify(r));
+' "$OUT_RELAXT" || fail "threshold-relaxed JSON shape wrong"
+echo "PASS: raising the global threshold vs. base-ref in the same PR is blocked (self-modification)"
+
+# ── 8) 자가변조: base-ref에 없던 모듈 한도를 이 PR에서 신설 → exit 1, kind=new-module-entry ─────
+NEWENTRY="$DIR/newentry"
+mkdir -p "$NEWENTRY/src"
+mk_lines "$NEWENTRY/src/big.ts" 2100
+mk_baseline "$NEWENTRY/tools/module-size-baseline.json" 2000 "src/big.ts:2100"
+mk_baseline "$NEWENTRY/base-baseline.json" 2000   # base-ref: no entries at all
+OUT_NEWENTRY="$(node "$CHECK" --root "$NEWENTRY" --base-baseline "$NEWENTRY/base-baseline.json" --json)"; rc=$?
+[ "$rc" = "1" ] || fail "adding a brand-new baseline entry in the same PR must exit 1, got $rc"
+node -e '
+  const r = JSON.parse(process.argv[1]);
+  const v = r.violations.find(v => v.kind === "new-module-entry" && v.path === "src/big.ts");
+  if (!v) throw new Error("expected new-module-entry violation, got " + JSON.stringify(r));
+' "$OUT_NEWENTRY" || fail "new-module-entry JSON shape wrong"
+echo "PASS: registering a brand-new baseline entry in the same PR is blocked (self-modification)"
+
+# ── 9) 부트스트랩: base-ref에 baseline 파일이 없으면(최초 도입) self-mod 비교 스킵 ────────────────
+BOOT="$DIR/boot"
+mkdir -p "$BOOT/src"
+mk_lines "$BOOT/src/big.ts" 2500
+mk_baseline "$BOOT/tools/module-size-baseline.json" 2000 "src/big.ts:2500"
+# base-baseline.json 파일 자체를 만들지 않음 — "base-ref에 없었다"를 모사
+OUT_BOOT="$(node "$CHECK" --root "$BOOT" --base-baseline "$BOOT/base-baseline.json" --json)"; rc=$?
+[ "$rc" = "0" ] || fail "missing base-ref baseline (bootstrap) must skip self-mod check and exit 0, got $rc: $OUT_BOOT"
+echo "PASS: missing base-ref baseline (first adoption) skips self-modification check"
+
+# ── 10) --base-ref 미지정 시(로컬 실행) self-mod 비교 자체를 안 함 ─────────────────────────────
+OUT_NOBASEREF="$(node "$CHECK" --root "$RELAX" --json)"; rc=$?
+[ "$rc" = "0" ] || fail "without --base-ref/--base-baseline, self-mod check must be skipped, got $rc: $OUT_NOBASEREF"
+echo "PASS: omitting --base-ref/--base-baseline skips self-modification check entirely"
+
+# ── 11) 실제 git --base-ref 경로(CI가 실제로 쓰는 경로) — 부트스트랩 + 완화 감지 둘 다 ────────────
+# --base-baseline은 테스트 전용 훅이고, CI(.github/workflows/ci.yml)는 --base-ref로 실제
+# `git show <ref>:path`를 태운다. 그 경로 자체가 안 새는지(리뷰에서 지적된 갭) 실제 git repo로 검증.
+GITREPO="$DIR/gitrepo"
+mkdir -p "$GITREPO/src"
+git init -q "$GITREPO"
+git -C "$GITREPO" config user.email test@test.local
+git -C "$GITREPO" config user.name test
+git -C "$GITREPO" config commit.gpgsign false
+mk_lines "$GITREPO/src/big.ts" 2500
+git -C "$GITREPO" add -A
+git -C "$GITREPO" commit -q -m "before baseline"
+BASE_SHA="$(git -C "$GITREPO" rev-parse HEAD)"
+# base-ref 시점엔 baseline 파일이 없었다 — 진짜 부트스트랩. 워킹트리에서 이제 baseline을 신설.
+mk_baseline "$GITREPO/tools/module-size-baseline.json" 2000 "src/big.ts:2500"
+OUT_BOOT_GIT="$(node "$CHECK" --root "$GITREPO" --base-ref "$BASE_SHA" --json)"; rc=$?
+[ "$rc" = "0" ] || fail "real git bootstrap (--base-ref, no baseline at that ref) must exit 0, got $rc: $OUT_BOOT_GIT"
+echo "PASS: real --base-ref bootstrap (no baseline at that commit) skips self-mod check and exits 0"
+
+# 이제 base-ref에도 baseline이 있는 커밋을 만들고, 워킹트리에서 완화를 시도 → --base-ref로 잡혀야 함.
+git -C "$GITREPO" add -A
+git -C "$GITREPO" commit -q -m "add baseline (limit 2500)"
+BASE_SHA2="$(git -C "$GITREPO" rev-parse HEAD)"
+mk_baseline "$GITREPO/tools/module-size-baseline.json" 2000 "src/big.ts:9000"  # 워킹트리: 완화 시도
+OUT_RELAX_GIT="$(node "$CHECK" --root "$GITREPO" --base-ref "$BASE_SHA2" --json)"; rc=$?
+[ "$rc" = "1" ] || fail "real git relaxation (--base-ref) must exit 1, got $rc: $OUT_RELAX_GIT"
+node -e '
+  const r = JSON.parse(process.argv[1]);
+  const v = r.violations.find(v => v.kind === "module-limit-relaxed" && v.path === "src/big.ts");
+  if (!v) throw new Error("expected module-limit-relaxed via real --base-ref, got " + JSON.stringify(r));
+' "$OUT_RELAX_GIT" || fail "real --base-ref relaxation JSON shape wrong"
+echo "PASS: real --base-ref path (git show) catches baseline relaxation vs. an actual commit"
+
+# ── 12) 잘못된/resolve 안 되는 --base-ref → 부트스트랩으로 조용히 넘어가지 않고 에러로 중단(exit 1) ──
+mk_baseline "$GITREPO/tools/module-size-baseline.json" 2000 "src/big.ts:2500"
+set +e
+OUT_BADREF="$(node "$CHECK" --root "$GITREPO" --base-ref not-a-real-ref-at-all --json 2>&1)"; rc=$?
+set -e
+[ "$rc" = "1" ] || fail "invalid --base-ref must exit 1 (loud failure, not silent bootstrap), got $rc"
+printf '%s' "$OUT_BADREF" | grep -qi "resolve" || fail "invalid --base-ref must surface a wiring error, got: $OUT_BADREF"
+echo "PASS: an unresolvable --base-ref fails loudly instead of silently skipping self-mod check"

--- a/tools/loop-engine/test/check-pr-hygiene.test.sh
+++ b/tools/loop-engine/test/check-pr-hygiene.test.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# BAC-754 (ported from glucofit-partners' pr-hygiene.test.sh, originally BAC-629 — ouroboros O7
+# 채택). bin/check-pr-hygiene.mjs is entirely synthetic-fixture-testable.
+#
+# 계약: PR 본문에 트래커 id 참조가 있으면 exit 0, 없으면 exit 1. closing 키워드는 요구하지 않는다
+# (Closes #N 없이 그냥 "BAC-123" 텍스트만 있어도 통과해야 함). `--pattern` 없이 실행하면 흔한
+# "영문 접두사-숫자" 트래커 관례를 두루 잡는 일반 정규식이 기본 동작한다.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+CHECK="$HERE/../bin/check-pr-hygiene.mjs"
+
+fail() { echo "FAIL: $1"; exit 1; }
+[ -f "$CHECK" ] || fail "check-pr-hygiene.mjs not found at $CHECK"
+
+# ── 1) 참조 없는 PR 본문 → exit 1 (RED) ──────────────────────────────────────────────────────
+OUT_NOREF="$(node "$CHECK" --body "이 PR은 리팩터링입니다. 트래킹 이슈 참조 없음." --json)"; rc=$?
+[ "$rc" = "1" ] || fail "no-reference PR body must exit 1, got $rc: $OUT_NOREF"
+node -e '
+  const r = JSON.parse(process.argv[1]);
+  if (r.ok !== false) throw new Error("expected ok:false, got " + JSON.stringify(r));
+  if (r.matched !== null) throw new Error("expected matched:null, got " + JSON.stringify(r));
+' "$OUT_NOREF" || fail "no-reference JSON shape wrong"
+echo "PASS: PR body with no tracker reference exits 1"
+
+# ── 2) BAC-* 참조 있는 PR 본문 → exit 0 (GREEN, 기본 패턴) ─────────────────────────────────────
+OUT_BAC="$(node "$CHECK" --body "이 PR은 BAC-629를 구현합니다." --json)"; rc=$?
+[ "$rc" = "0" ] || fail "BAC-* reference must exit 0, got $rc: $OUT_BAC"
+node -e '
+  const r = JSON.parse(process.argv[1]);
+  if (r.ok !== true) throw new Error("expected ok:true, got " + JSON.stringify(r));
+  if (r.matched !== "BAC-629") throw new Error("expected matched:BAC-629, got " + JSON.stringify(r));
+' "$OUT_BAC" || fail "BAC-* JSON shape wrong"
+echo "PASS: PR body referencing BAC-629 exits 0 (default pattern)"
+
+# ── 3) PRO-* 참조 있는 PR 본문 → exit 0 (GREEN, 다른 프리픽스도 기본 패턴이 잡는다) ─────────────
+OUT_PRO="$(node "$CHECK" --body "관련: PRO-1234" --json)"; rc=$?
+[ "$rc" = "0" ] || fail "PRO-* reference must exit 0, got $rc: $OUT_PRO"
+echo "PASS: PR body referencing PRO-1234 exits 0 (default pattern isn't tied to one prefix)"
+
+# ── 3b) 소문자/대소문자 혼용 참조도 통과(대소문자는 취지와 무관 — 참조 존재만 본다) ────────────────
+OUT_LOWER="$(node "$CHECK" --body "fixes bac-42 eventually" --json)"; rc=$?
+[ "$rc" = "0" ] || fail "lowercase bac-* reference must exit 0, got $rc: $OUT_LOWER"
+echo "PASS: lowercase reference (bac-42) still exits 0 (case-insensitive by design)"
+
+# ── 4) closing 키워드 없이 참조만 있어도 통과 (자동 close 오발 방지 설계 확인) ──────────────────
+OUT_PLAIN="$(node "$CHECK" --body "no closing keyword, just BAC-1 mentioned mid-sentence" --json)"; rc=$?
+[ "$rc" = "0" ] || fail "plain mention without closing keyword must exit 0, got $rc"
+echo "PASS: reference without a closing keyword (Closes/Fixes) still passes"
+
+# ── 5) 빈 본문 → exit 1 ──────────────────────────────────────────────────────────────────────
+OUT_EMPTY="$(node "$CHECK" --body "" --json)"; rc=$?
+[ "$rc" = "1" ] || fail "empty PR body must exit 1, got $rc"
+echo "PASS: empty PR body exits 1"
+
+# ── 6) --body-file 입력 경로도 동작 ──────────────────────────────────────────────────────────
+DIR="$(mktemp -d "${TMPDIR:-/tmp}/tmp.XXXXXXXX")" || fail "mktemp -d failed"
+trap 'rm -rf "$DIR"' EXIT
+printf 'fixes BAC-42 eventually' > "$DIR/body.txt"
+OUT_FILE="$(node "$CHECK" --body-file "$DIR/body.txt" --json)"; rc=$?
+[ "$rc" = "0" ] || fail "--body-file with reference must exit 0, got $rc"
+echo "PASS: --body-file input path works"
+
+# ── 7) --pattern으로 소비 레포별 트래커 id 패턴을 주입할 수 있다 (BAC-754) ─────────────────────
+# 기본 패턴이 잡지 않는 형태(예: 순수 숫자 이슈 #123)를 --pattern으로 인식시킬 수 있는지 확인.
+OUT_CUSTOM="$(node "$CHECK" --body "closes #123" --pattern '#\d+' --json)"; rc=$?
+[ "$rc" = "0" ] || fail "--pattern override matching #123 must exit 0, got $rc: $OUT_CUSTOM"
+node -e '
+  const r = JSON.parse(process.argv[1]);
+  if (r.matched !== "#123") throw new Error("expected matched:#123, got " + JSON.stringify(r));
+' "$OUT_CUSTOM" || fail "--pattern override JSON shape wrong"
+echo "PASS: --pattern overrides the default regex with a consumer-repo-specific tracker id pattern"
+
+OUT_CUSTOM_MISS="$(node "$CHECK" --body "references BAC-42 only" --pattern '#\d+' --json)"; rc=$?
+[ "$rc" = "1" ] || fail "--pattern override must not fall back to the default pattern, got $rc: $OUT_CUSTOM_MISS"
+echo "PASS: --pattern override fully replaces the default (BAC-42 doesn't match a #\\d+-only pattern)"
+
+exit 0

--- a/tools/loop-memory/.claude-plugin/plugin.json
+++ b/tools/loop-memory/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "loop-memory",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "pgvector semantic recall for verified dev-loop lessons (and, optionally, ADR/glossary/research knowledge). Opt-in: installs disabled by default — this is a database dependency, not core loop mechanics.",
   "author": {
     "name": "paulkim-lansik"
@@ -10,7 +10,7 @@
   "license": "MIT",
   "keywords": ["memory", "pgvector", "recall", "semantic-search", "lessons"],
   "defaultEnabled": false,
-  "dependencies": [{ "name": "loop-engine", "version": "^0.5.0" }],
+  "dependencies": [{ "name": "loop-engine", "version": "^0.6.0" }],
   "userConfig": {
     "openai_api_key": {
       "type": "string",

--- a/tools/ship-flow/.claude-plugin/plugin.json
+++ b/tools/ship-flow/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ship-flow",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Delivery-loop skills — land and release already-verified work through a repo's real gates. Tracker- and branch-model-agnostic: reads a consuming repo's own config instead of hardcoding one repo's setup.",
   "author": {
     "name": "paulkim-lansik"
@@ -10,6 +10,6 @@
   "license": "MIT",
   "keywords": ["delivery", "git-flow", "hotfix", "ship", "release"],
   "dependencies": [
-    { "name": "loop-engine", "version": "^0.5.0" }
+    { "name": "loop-engine", "version": "^0.6.0" }
   ]
 }

--- a/tools/ship-flow/skills/setup/SKILL.md
+++ b/tools/ship-flow/skills/setup/SKILL.md
@@ -106,6 +106,20 @@ feature→integration PRs skip `ci.yml`'s trigger entirely — see `ci.yml.templ
 Like `turbo-verify-wiring.example.md`, this one is reference material to adapt by hand — the actual
 policy paths and selftest command are this repo's own, not something to copy verbatim.
 
+Also offer the commented-out `hygiene` job in `ci.yml.template` (BAC-754) — three cheap, dependency-free
+static gates from loop-engine's own `bin/`: `check-docs-hygiene.mjs` (ADR numbering/README index/
+dangling-reference/SKILL.md word cap), `check-pr-hygiene.mjs` (PR body must reference a tracker id —
+ask whether this repo's id format needs `--pattern` beyond the generic "LETTERS-digits" default), and
+`check-module-size.mjs` (module-size ratchet — needs `tools/module-size-baseline.json` committed for
+first adoption, or defaults to a bare threshold with no per-module entries). All three need the
+`setup-loop-engine` action from step 4 above; skip offering this job if that action wasn't installed.
+
+If this repo's tracker id format needs a non-default `check-pr-hygiene.mjs` pattern, note it in
+`.claude/ship-flow.config.json` (e.g. a `trackerIdPattern` field) so it stays discoverable alongside
+the rest of this repo's ship-flow config, and pass it through wherever `check-pr-hygiene.mjs` is
+invoked (the `ci.yml` job above, and `ship-feature`/`publisher`'s own PR-body composition step, if this
+repo wants the same check enforced before a PR is even opened).
+
 ### 5. Offer branch protection — human stop point, always
 **Never run `templates/branch-protect.sh` without an explicit `AskUserQuestion` confirmation first,
 every time** — this changes a real GitHub repo setting, and a past "yes" to a different question isn't

--- a/tools/ship-flow/templates/ci.yml.template
+++ b/tools/ship-flow/templates/ci.yml.template
@@ -22,6 +22,31 @@ jobs:
       # manager's cache).
       - run: {{VERIFY_COMMAND}}
 
+  # ── optional: repo hygiene gates (loop-engine bin scripts, BAC-754) ────────────────────────────
+  # Cheap, dependency-free static checks — no package-manager install needed, just node + git +
+  # loop-engine's bundled bin/ scripts (via the setup-loop-engine action, since GHA is a plain shell
+  # process outside the live plugin cache — see templates/setup-loop-engine.action.yml.template).
+  # Uncomment to adopt, then add `hygiene` to `ci-gate`'s `needs:` and to the aggregation loop below.
+  # hygiene:
+  #   name: hygiene
+  #   if: ${{ github.event_name == 'pull_request' }}
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v7
+  #       with:
+  #         fetch-depth: 0  # check-module-size --base-ref needs history beyond the merge commit
+  #     - uses: ./.github/actions/setup-loop-engine
+  #     - run: node "$LOOP_ENGINE_PATH/bin/check-docs-hygiene.mjs"
+  #     - env:
+  #         PR_BODY: ${{ github.event.pull_request.body }}
+  #       run: node "$LOOP_ENGINE_PATH/bin/check-pr-hygiene.mjs" --body "$PR_BODY"
+  #       # If this repo's tracker id format isn't caught by the default pattern (a generic
+  #       # "LETTERS-digits" shape — matches BAC-123, PROJ-123, etc.), add `--pattern '<regex>'`.
+  #     - run: node "$LOOP_ENGINE_PATH/bin/check-module-size.mjs" --base-ref ${{ github.event.pull_request.base.sha }}
+  #       # First adoption needs a tools/module-size-baseline.json committed — see check-module-size.mjs's
+  #       # own header for the {threshold, modules} shape. Omitting it entirely defaults threshold=2000
+  #       # with no per-module overrides.
+
   # ── Add more jobs here as this repo grows ──────────────────────────────────────
   # A common next step: path-filtered jobs that only run when a specific area changed (e.g. a docker
   # integration test that only needs to re-run when the DB schema or the API changed). If you add one,


### PR DESCRIPTION
## Summary

Upstream harness-maturity audit finding #15 flagged that no machine docs-hygiene gate exists here,
while glucofit-partners had already built exactly this. This ports three consumer-repo gates
upstream as generic loop-engine bins:

- **`bin/check-docs-hygiene.mjs`** (BAC-558) — ADR number uniqueness/gaps, bidirectional README
  index completeness, dangling markdown-link/backtick-path references (CLAUDE.md + docs/adr/**),
  SKILL.md word-count WARN tiers.
- **`bin/check-pr-hygiene.mjs`** (BAC-629, ouroboros O7) — PR body must reference at least one
  tracker id, no closing-keyword requirement.
- **`bin/check-module-size.mjs`** (BAC-629, ouroboros O8) — module-size ratchet with a
  self-modification guard (a PR can't relax its own baseline vs. base-ref in the same commit).

All three were already fully generic in the consumer repo (root/baseline/base-ref/json CLI flags,
no repo-specific hardcoding) **except** `check-pr-hygiene.mjs`'s tracker-id regex, which was
hardcoded to `BAC-*`/`PRO-*`. Replaced with a `--pattern` CLI override, defaulting to a generic
"LETTERS-digits" shape that still matches both plus common conventions like JIRA-style `PROJ-123`.

Running the new docs-hygiene gate against this repo's own `docs/adr/` immediately caught a malformed
cross-repo markdown link in `0006-ac-level-success-contract.md` — fixed here, matching that file's
own established backtick-quote convention two lines above.

`ship-flow`'s `templates/ci.yml.template` gets a commented-out `hygiene` job example wiring all
three via the existing `setup-loop-engine` action; `skills/setup/SKILL.md` step 4 now offers it.

## Versions

- loop-engine 0.5.1 → 0.6.0 (new public bin scripts — minor)
- ship-flow 0.2.3 → 0.2.4, loop-memory 0.2.3 → 0.2.4 — both with their `loop-engine` dependency range
  bumped `^0.5.0` → `^0.6.0` in this same PR (the joint-constraint bug class from PR #43/#44/#46,
  caught proactively this time via `grep -rn '"loop-engine"' --include=plugin.json` before publishing)

## Test plan

- [x] `bash tools/loop-engine/test/run.sh` — 39/39 passed (36 prior + check-docs-hygiene 24 cases +
      check-pr-hygiene 9 cases + check-module-size 12 cases)
- [x] `claude plugin validate --strict .` — Validation passed
- [x] `node tools/loop-engine/bin/check-docs-hygiene.mjs --root .` against this repo's own
      `docs/adr/` — 0 failures (2 pre-existing WARN-tier SKILL.md word-count notices, non-gating)

🤖 Generated with [Claude Code](https://claude.com/claude-code)