### PR TITLE
feat(ship-flow): codify 7 of 9 verified glucofit-partners lessons into skill prose (BAC-756)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,14 +12,14 @@
       "name": "loop-engine",
       "source": "./tools/loop-engine",
       "description": "Core loop mechanics: verdict-run (machine-readable PASS/FAIL contract), loop-fix (closed verify->fix loop), lessons (verified-fix memory), classify-risk, require-tests, plugin-path (resolve sibling plugin install paths), check-docs-hygiene/check-pr-hygiene/check-module-size (repo hygiene gates). No framework opinions beyond \"the verifier is the ceiling, never the agent's self-report\".",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "keywords": ["verifier", "tdd", "loop", "verdict", "lessons"]
     },
     {
       "name": "ship-flow",
       "source": "./tools/ship-flow",
       "description": "Delivery-loop skills — ship-feature (plan-to-PR autonomous loop), hotfix, retrospect, grill-with-docs, deps-audit, to-issues/to-prd, tdd, harness-maturity-audit, improve-codebase-architecture, resolving-merge-conflicts, plus review agents and audit/research workflows — parameterized by a consuming repo's own tracker/branch-model config instead of hardcoded to one repo. dependencies: loop-engine.",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "keywords": ["delivery", "git-flow", "hotfix", "ship", "release"]
     },
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,37 @@ Explicit-version channel — see [README § Development status](README.md#develo
 not a SHA channel. Entries below `## loop-engine 0.2.0` and earlier predate the multi-plugin split
 and refer to `loop-engine` only (see the un-prefixed version numbers).
 
+## loop-engine 0.6.1
+
+- New `test/lesson-codification-bac756.test.sh` (BAC-756) — locks the skill/agent-prose codifications
+  below in place. No bin/lib change (patch).
+
+## ship-flow 0.2.5
+
+- Codifies 7 of the 9 verified lessons a reverse-backport audit found in glucofit-partners'
+  `.loop/lessons/` with no matching guidance anywhere upstream (BAC-756). The other 2
+  (`8932917806328c0b` "workflow tier merge step must assert `merged===true`", `f3f65538bf7d33b6`
+  "`gh pr merge --admin` needs `enforce_admins` disabled first") already carry
+  `challenge.verdict: "reject"` in that repo's lesson store — CLAUDE.md's own rule is that only an
+  accept-passed lesson gets codified, so those two are deliberately left out here despite being listed
+  in the source issue's table.
+  - `skills/ship-feature/SKILL.md`: a stacked-PR + squash-merge base-retarget warning (failures
+    section) with a "verify beyond the MERGED badge" pointer; a deep-gate docker-isolation advisory in
+    step 2 (don't run more than one in a worktree at once, clean stale state after a rebase, preserve a
+    bypassed helper's isolation identifiers); an MCP-unavailable browser-automation fallback note in
+    step 3; a one-line macOS ACL cross-reference in step 0.
+  - `skills/hotfix/SKILL.md`: the same stacked-PR retarget warning and the full macOS ACL
+    `git worktree remove` fix in the cleanup step.
+  - `agents/code-reviewer.md`: a new operating rule — this reviewer has no web access, so a BLOCK on a
+    platform-spec question from a local reference doc alone should be flagged as unverified, not
+    treated as settled fact.
+  - `skills/grill-with-docs/ADR-FORMAT.md`: the Numbering section now says to check open PRs for
+    `docs/adr/` additions before finalizing a number, not just the local filesystem.
+  - `skills/setup/SKILL.md`: a new "If this repo already had local skills with the same names" section
+    on namespace-migration sweep discipline (grep the whole repo from the first pass; re-grep the raw
+    renamed substring, not just the escaping form your edit targeted, to catch differently-escaped
+    sibling occurrences).
+
 ## loop-memory 0.2.4
 
 - `loop-engine` dependency range bumped `^0.5.0` → `^0.6.0` to match loop-engine's minor bump below

--- a/tools/loop-engine/.claude-plugin/plugin.json
+++ b/tools/loop-engine/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "loop-engine",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Core loop mechanics: verdict-run (machine-readable PASS/FAIL contract), loop-fix (closed verify->fix loop), lessons (verified-fix memory), classify-risk, require-tests, check-docs-hygiene/check-pr-hygiene/check-module-size (repo hygiene gates). verifier=ceiling — the agent's self-judgement never substitutes for it.",
   "author": {
     "name": "paulkim-lansik"

--- a/tools/loop-engine/test/lesson-codification-bac756.test.sh
+++ b/tools/loop-engine/test/lesson-codification-bac756.test.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# BAC-756 — locks 7 verified-lesson codifications (glucofit-partners, ADR-0034 §9 repo→plugin
+# knowledge-ownership routing) into ship-flow's skill/agent prose. Two of the nine lessons the source
+# issue listed already carry `challenge.verdict: "reject"` in the source repo's `.loop/lessons/` —
+# 8932917806328c0b ("workflow merged===true") and f3f65538bf7d33b6 ("gh pr merge --admin") — and are
+# deliberately NOT codified here (CLAUDE.md's own rule: only an accept-passed lesson gets codified).
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+SHIP_FEATURE="$HERE/../../ship-flow/skills/ship-feature/SKILL.md"
+HOTFIX="$HERE/../../ship-flow/skills/hotfix/SKILL.md"
+CODE_REVIEWER="$HERE/../../ship-flow/agents/code-reviewer.md"
+ADR_FORMAT="$HERE/../../ship-flow/skills/grill-with-docs/ADR-FORMAT.md"
+SETUP="$HERE/../../ship-flow/skills/setup/SKILL.md"
+
+fail() { echo "FAIL: $1"; exit 1; }
+for f in "$SHIP_FEATURE" "$HOTFIX" "$CODE_REVIEWER" "$ADR_FORMAT" "$SETUP"; do
+  [ -f "$f" ] || fail "missing file: $f"
+done
+
+# 07bc4859 — stacked PR + squash-merge retarget, in both ship-feature and hotfix's failure-handling text.
+grep -qi 'stacked PR' "$SHIP_FEATURE" || fail "ship-feature SKILL.md must document the stacked-PR retarget gotcha"
+grep -q 'git show origin/<base>' "$SHIP_FEATURE" || fail "ship-feature SKILL.md must tell agents to verify landing beyond the MERGED badge"
+grep -qi 'stacked' "$HOTFIX" || fail "hotfix SKILL.md must document the stacked-PR retarget gotcha"
+echo "PASS: 07bc4859 (stacked PR + squash-merge retarget) codified in ship-feature and hotfix"
+
+# 0e5154a1/630796f2/92d95548/5b4f4c8b — deep-gate docker isolation, batched into one ship-feature note.
+grep -qi 'more than one deep gate in this worktree' "$SHIP_FEATURE" || fail "ship-feature SKILL.md must warn against parallel deep gates in one worktree"
+grep -qi 'isolation identifiers' "$SHIP_FEATURE" || fail "ship-feature SKILL.md must warn against dropping isolation identifiers when bypassing a helper"
+echo "PASS: 0e5154a1/630796f2/92d95548/5b4f4c8b (deep-gate docker isolation) codified in ship-feature step 2"
+
+# 15c8b2ca — MCP browser fallback in runtime-verify.
+grep -qi 'browser-automation MCP is unavailable' "$SHIP_FEATURE" || fail "ship-feature SKILL.md must document the MCP-unavailable browser fallback"
+echo "PASS: 15c8b2ca (MCP browser fallback) codified in ship-feature step 3"
+
+# 1a5200e3 — macOS ACL deny-delete blocking git worktree remove.
+grep -q 'chmod -R -N' "$SHIP_FEATURE" || fail "ship-feature SKILL.md must cross-reference the macOS ACL worktree-remove fix"
+grep -q 'chmod -R -N' "$HOTFIX" || fail "hotfix SKILL.md must document the macOS ACL worktree-remove fix"
+echo "PASS: 1a5200e3 (macOS ACL blocks git worktree remove) codified in ship-feature and hotfix"
+
+# fb72c699 — reviewer subagent has no web access, shouldn't BLOCK on spec questions as settled fact.
+grep -qi 'no web access' "$CODE_REVIEWER" || fail "code-reviewer.md must caution that it has no web access"
+echo "PASS: fb72c699 (reviewer no-web-access caution) codified in agents/code-reviewer.md"
+
+# 3602ba16 — ADR number collision with a concurrent open PR.
+grep -qi 'concurrent work' "$ADR_FORMAT" || fail "ADR-FORMAT.md must document the concurrent-PR ADR-number collision check"
+grep -qi 'open PRs' "$ADR_FORMAT" || fail "ADR-FORMAT.md must tell agents to check open PRs before finalizing an ADR number"
+echo "PASS: 3602ba16 (ADR number collision across concurrent PRs) codified in ADR-FORMAT.md"
+
+# 38e9a48c/53da49e1 — namespace migration grep-sweep discipline (repo-wide-from-the-start + raw-substring re-grep).
+grep -qi 'repo-wide-from-the-start' "$SETUP" || fail "setup SKILL.md must document the repo-wide-from-the-start sweep habit"
+grep -qi 'raw renamed substring' "$SETUP" || fail "setup SKILL.md must document the raw-substring re-grep habit for differently-escaped siblings"
+echo "PASS: 38e9a48c/53da49e1 (namespace migration grep-sweep discipline) codified in setup SKILL.md"
+
+exit 0

--- a/tools/ship-flow/.claude-plugin/plugin.json
+++ b/tools/ship-flow/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ship-flow",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Delivery-loop skills — land and release already-verified work through a repo's real gates. Tracker- and branch-model-agnostic: reads a consuming repo's own config instead of hardcoding one repo's setup.",
   "author": {
     "name": "paulkim-lansik"

--- a/tools/ship-flow/agents/code-reviewer.md
+++ b/tools/ship-flow/agents/code-reviewer.md
@@ -31,6 +31,12 @@ mediocre"). You exist to not do that.
 7. **Boundary with other review tools:** if this repo also runs a separate general-purpose PR-review
    tool, run both — don't treat this review as a superset or subset of that tool's pass. Report only
    what you actually checked; don't claim coverage you didn't do.
+8. **You have no web access.** A locally installed reference doc can be bundled for an adjacent or
+   older spec that looks authoritative but isn't the one that actually applies — e.g. a slash-command
+   frontmatter reference used to judge SKILL.md frontmatter. Don't BLOCK on a platform-spec question
+   (syntax, field existence) as settled fact from a local doc alone; note it as unverified and say what
+   would confirm it (a live fetch of the current docs, or a smoke test), so the calling session can
+   check before accepting the BLOCK.
 
 ## Fixed blocker checklist — the concrete, non-inventable bar
 

--- a/tools/ship-flow/skills/grill-with-docs/ADR-FORMAT.md
+++ b/tools/ship-flow/skills/grill-with-docs/ADR-FORMAT.md
@@ -26,6 +26,11 @@ Only include these when they add genuine value. Most ADRs won't need them.
 
 Scan `docs/adr/` for the highest existing number and increment by one.
 
+If concurrent work on other worktrees/branches is common in this repo, that scan alone isn't enough —
+a number can be claimed by another open, unmerged PR that your local worktree can't see on disk. Before
+finalizing the number and citing it elsewhere (a glossary, other issues), check open PRs for `docs/adr/`
+additions too, not just the local filesystem. If you find a collision, renumber and fix all citations.
+
 ## When to offer an ADR
 
 All three of these must be true:

--- a/tools/ship-flow/skills/hotfix/SKILL.md
+++ b/tools/ship-flow/skills/hotfix/SKILL.md
@@ -106,7 +106,9 @@ Once confirmed:
 If the deploy hook produced a way to confirm liveness (e.g. a health endpoint), check it. Clean up:
 remove the deploy worktree if one was created, delete temp logs, sync the main worktree's local
 branch with `origin/<integrationBranch-or-releaseBranch>` (a remote PR merge may have left it
-behind).
+behind). On macOS, `git worktree remove` (or a plain `rm -rf`) can fail with a permission-denied ACL
+error if something under the worktree (often `node_modules`) picked up a `deny delete` ACE — run
+`chmod -R -N <worktree-path>` to strip it, then retry.
 
 ## On failure
 - Any RED gate: report to the user and investigate the root cause — don't force the next step (the
@@ -115,4 +117,6 @@ behind).
 - `gh pr merge` reporting out-of-date/CONFLICTING: in the worktree, `git fetch origin <base>` alone
   → `git rebase origin/<base>` alone → re-verify → `git push --force-with-lease` (don't chain these —
   run each as its own independent call; a chained merge/pull-adjacent command sequence is easy to
-  mis-detect as something else).
+  mis-detect as something else). If this branch was itself the base of another still-open PR (stacked),
+  retarget or rebase that PR onto the release branch before it merges too — squash-merging this one
+  doesn't auto-retarget it, and its commits can land in a dead branch instead.

--- a/tools/ship-flow/skills/setup/SKILL.md
+++ b/tools/ship-flow/skills/setup/SKILL.md
@@ -134,6 +134,21 @@ Report what was installed/changed and what was skipped (and why — e.g. "CLAUDE
 I left it — here's what the template would have added"). If anything from steps 3-5 was skipped, say
 so explicitly rather than letting the user assume everything happened.
 
+## If this repo already had local skills with the same names
+
+Plugin skills are namespaced by the platform (`plugin:skill`, not a bare name); if this repo used to
+invoke a same-named local skill directly (e.g. `/ship-feature`), there's no compat shim to fall back
+on — every live reference has to be updated in the same pass (CLAUDE.md, `docs/agents/*`, other skill
+bodies; leave `.loop/lessons/*.json` and other historical records alone). Two sweep habits catch what a
+narrower one misses:
+- Grep the **whole repo** from the first pass, not directory-by-directory as you discover more affected
+  areas — a scope that only widens after each sweep costs a re-discovery round per widening, where a
+  repo-wide-from-the-start pass costs one.
+- After a bulk find-and-replace, grep the **raw renamed substring** across each touched file, not just
+  the specific quoting/escaping form your edit targeted — the same string can appear a second time in a
+  different escaping (e.g. a plain backtick in a single-quoted string vs. an escaped backtick inside a
+  template literal), and a `replace_all` on one form silently leaves the other.
+
 ## Testing this skill itself
 
 If you're validating this skill's own correctness (not running it for a real repo): run it against a

--- a/tools/ship-flow/skills/ship-feature/SKILL.md
+++ b/tools/ship-flow/skills/ship-feature/SKILL.md
@@ -145,7 +145,9 @@ issue (worktree isolation alone only prevents git conflicts, not duplicate start
 
 `git fetch origin && git worktree add -b <type>/<slug> <sibling-path-outside-repo> origin/<base>`. Check
 `git worktree list` first if concurrent work is common in this repo. A fresh worktree has no installed
-dependencies — install them. Every following step happens inside this worktree.
+dependencies — install them. Every following step happens inside this worktree. (macOS: if a later
+`git worktree remove` fails with a permission-denied ACL error, `chmod -R -N <path>` first — see
+hotfix's cleanup step for the full note.)
 
 ### 1. Implementation plan — `Plan` agent / `grill-with-docs` if there's a design decision
 Plan what to build and how to slice it. **If there's a new design decision involved**, use
@@ -203,6 +205,14 @@ ledger event), an exit code alone skips both.
 → **Gate:** `VERDICT: PASS` + whatever `DEEP_GATES:` step 1 identified (re-checked against the actual
 diff with `--from-git`). `VERDICT: FAIL` loops back autonomously.
 
+> If any `DEEP_GATES:` run against a shared local resource (e.g. a per-worktree docker database), don't
+> run more than one deep gate in this worktree at the same time — a second one recreating the same
+> container mid-run causes an unrelated-looking failure, not a clear error. After a rebase changes the
+> migration set, clean that resource before re-verifying rather than reusing stale state. If a helper
+> script that normally isolates this resource fails and has to be bypassed manually, preserve whatever
+> isolation identifiers it would have set (container name/port/project name) — dropping them risks
+> clobbering a resource another session is using.
+
 ### 3. Runtime verify
 Build and run the app, drive the changed surface (CLI/API/GUI — whatever applies) through it, and
 confirm **what was intended actually works**. This produces runtime evidence, not a re-run of the test
@@ -212,6 +222,12 @@ subprocess judgment (verify exit code, artifact existence, output substring) per
 composing with — not replacing — the observe-the-running-app check above.
 → **Gate:** PASS. FAIL → **loop back to step 2**. SKIP (no runtime surface exists) passes with a
 one-line reason.
+
+> If a GUI surface needs driving and a browser-automation MCP is unavailable or its profile is
+> contended by another concurrent session, fall back to a standalone script that imports this repo's
+> own test framework's browser driver directly (e.g. Playwright) and launches a fresh headless browser
+> — independent of any shared MCP browser profile. Run it from inside the package that has that
+> dependency installed (a script outside it won't resolve the same `node_modules`).
 
 ### 4. Review and fix
 Run this plugin's review agents (`code-reviewer`, `test-hunter`, `verifier-integrity-hunter`) against
@@ -299,3 +315,9 @@ CLAUDE.md/`.claude/**` from this session.
   (the integration branch, or the release branch for a release PR). **Run each command as its own
   independent call** — chaining `git merge`/`git pull` with anything else is liable to trip a merge
   guardrail hook regardless of direction, if this repo has one.
+- **Stacked PR (this branch is itself another open PR's base) + squash-merge**: once this PR merges,
+  the branch it was on is gone as a target — the stacked PR's base doesn't auto-retarget, so its commits
+  can land in a dead branch instead of the integration branch even though GitHub shows it as merged. If
+  a stacked PR exists, retarget (or rebase) it onto the integration branch **before** it merges, not
+  after. Don't trust a `MERGED` badge alone — confirm with `git show origin/<base>:<file> | grep
+  <symbol>` that the actual content landed.


### PR DESCRIPTION
## Summary

Reverse-backport audit found 9 verified lessons in glucofit-partners' `.loop/lessons/` about the loop
mechanism itself (not app code), with no matching guidance anywhere upstream. **Before writing
anything**, checked each lesson's `challenge` field — 2 of the 9 the source issue's table listed
already carry `challenge.verdict: "reject"`:

- `8932917806328c0b` ("workflow tier merge step must assert `merged===true`, not trust an async
  return") — rejected as tied to a one-off script not present in any repo (`grep 0`), and 3 recurrences
  were sub-events of one overnight run, not independent reproductions.
- `f3f65538bf7d33b6` ("`gh pr merge --admin` needs `enforce_admins` disabled first") — rejected because
  a stricter existing policy already governs this (branch-protection bypass needs per-instance human
  confirmation, never a codified standing procedure) and the underlying fact is GitHub's own documented
  API behavior, not repo-specific knowledge.

CLAUDE.md's own rule is that only an accept-passed lesson gets codified — so those two are deliberately
**not** in this PR, despite being in the source issue's table. The other 7 (11 lesson ids — one item
batches 4 docker-isolation ids, another batches 2 namespace-migration ids) are codified here:

- `skills/ship-feature/SKILL.md` — stacked-PR + squash-merge base-retarget warning with a "verify
  beyond the MERGED badge" pointer; a deep-gate docker-isolation advisory in step 2 (sequential, not
  parallel, within one worktree; clean stale state after a rebase; preserve isolation identifiers when
  bypassing a helper); an MCP-unavailable browser-automation fallback in step 3; a macOS ACL
  cross-reference.
- `skills/hotfix/SKILL.md` — the same stacked-PR retarget warning + the full macOS ACL
  `git worktree remove` fix.
- `agents/code-reviewer.md` — new rule: no web access, so a platform-spec BLOCK from a local reference
  doc alone should be flagged unverified, not treated as settled fact.
- `skills/grill-with-docs/ADR-FORMAT.md` — check open PRs for `docs/adr/` additions before finalizing a
  number, not just the local filesystem.
- `skills/setup/SKILL.md` — new namespace-migration section: sweep the whole repo from the first grep
  pass (not directory-by-directory as scope widens), and re-grep the raw renamed substring (not just
  the escaping form your edit targeted) to catch differently-escaped sibling occurrences.

New `test/lesson-codification-bac756.test.sh` locks all 7 in place.

## Versions

- loop-engine 0.6.0 → 0.6.1 (patch — test-only)
- ship-flow 0.2.4 → 0.2.5 (prose-only; its `loop-engine` dependency range `^0.6.0` already covers 0.6.1,
  no joint-constraint bump needed)

## Test plan

- [x] `bash tools/loop-engine/test/run.sh` — 40/40 passed
- [x] `claude plugin validate --strict .` — Validation passed
- [x] SKILL.md word counts checked post-edit — all stay under the 5,000-word WARN-max tier (ship-feature
      was already over the 2,000-word target pre-existing; these additions don't cross into max)

BAC-756

🤖 Generated with [Claude Code](https://claude.com/claude-code)