### PR TITLE
fix(ship-flow): correct BAC-756 codification — challenge before, not after (BAC-756)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,14 +12,14 @@
       "name": "loop-engine",
       "source": "./tools/loop-engine",
       "description": "Core loop mechanics: verdict-run (machine-readable PASS/FAIL contract), loop-fix (closed verify->fix loop), lessons (verified-fix memory), classify-risk, require-tests, plugin-path (resolve sibling plugin install paths), check-docs-hygiene/check-pr-hygiene/check-module-size (repo hygiene gates). No framework opinions beyond \"the verifier is the ceiling, never the agent's self-report\".",
-      "version": "0.6.1",
+      "version": "0.6.2",
       "keywords": ["verifier", "tdd", "loop", "verdict", "lessons"]
     },
     {
       "name": "ship-flow",
       "source": "./tools/ship-flow",
       "description": "Delivery-loop skills — ship-feature (plan-to-PR autonomous loop), hotfix, retrospect, grill-with-docs, deps-audit, to-issues/to-prd, tdd, harness-maturity-audit, improve-codebase-architecture, resolving-merge-conflicts, plus review agents and audit/research workflows — parameterized by a consuming repo's own tracker/branch-model config instead of hardcoded to one repo. dependencies: loop-engine.",
-      "version": "0.2.5",
+      "version": "0.2.6",
       "keywords": ["delivery", "git-flow", "hotfix", "ship", "release"]
     },
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,42 @@ Explicit-version channel — see [README § Development status](README.md#develo
 not a SHA channel. Entries below `## loop-engine 0.2.0` and earlier predate the multi-plugin split
 and refer to `loop-engine` only (see the un-prefixed version numbers).
 
-## loop-engine 0.6.1
+## loop-engine 0.6.2
 
-- New `test/lesson-codification-bac756.test.sh` (BAC-756) — locks the skill/agent-prose codifications
-  below in place. No bin/lib change (patch).
+- `test/lesson-codification-bac756.test.sh` updated for the ship-flow 0.2.6 correction below — its
+  PASS blocks now match what's actually codified, plus regression guards against re-adding the 5
+  reverted lessons. No bin/lib change (patch).
 
-## ship-flow 0.2.5
+## ship-flow 0.2.6
+
+- **Self-correction of 0.2.5**: PR#50 (BAC-756) codified 9 lessons before running an independent
+  challenge pass instead of after — backwards from this repo's own rule (CLAUDE.md's "회의적 평가(accept)를
+  통과한 것만 코디파이", mirrored here in `docs/adr/README.md`'s lessons-lifecycle notes). Running that
+  challenge pass afterward rejected 5 of the 9:
+  - `3602ba166619af93` (ADR-number collision across concurrent PRs) — already covered, more strictly,
+    by the consuming repo's own worktree-scan policy; not new or surprising enough on its own.
+  - `630796f2f488f993` (deep-gate container race) — a near-duplicate of the already-accepted
+    `0e5154a1`, tied to one repo's non-portable container-naming script rather than a portable fact.
+  - `92d95548aad4ebf4` (stale docker volume after a migration-set change) — restates Postgres's own
+    documented init-script behavior (init scripts only run against an empty `$PGDATA`), not a non-obvious
+    finding worth a permanent doc entry.
+  - `5b4f4c8ba005695f` (preserve isolation env vars when bypassing a helper script) — a single (count=1)
+    incident whose generalized lesson is close to generic engineering discipline.
+  - `38e9a48c3659de1d` (grep the whole repo before narrowing scope) — standard diligence most engineers
+    already default to; too obvious for a permanent doc entry.
+
+  Their prose is reverted here: `skills/ship-feature/SKILL.md` step 2's blockquote drops the
+  stale-volume and isolation-identifier sentences (keeps the still-accepted "don't run more than one
+  deep gate at once" sentence, which covers `0e5154a1`); `skills/setup/SKILL.md`'s namespace-migration
+  section drops the "grep whole repo from the first pass" bullet (keeps the still-accepted raw-substring
+  re-grep bullet, `53da49e1`); `skills/grill-with-docs/ADR-FORMAT.md`'s Numbering section drops the
+  concurrent-open-PR check entirely. The other 4 codifications from 0.2.5 stand as accepted:
+  `07bc4859` (stacked PR + squash-merge retarget), `15c8b2ca` (MCP browser fallback), `1a5200e3`
+  (macOS ACL blocking `git worktree remove`), `fb72c699` (reviewer has no web access). The 2 lessons
+  that already carried `challenge.verdict: "reject"` before this issue started
+  (`8932917806328c0b`, `f3f65538bf7d33b6`) were never codified and are unaffected.
+
+## ship-flow 0.2.5 (superseded by 0.2.6 above — see correction)
 
 - Codifies 7 of the 9 verified lessons a reverse-backport audit found in glucofit-partners'
   `.loop/lessons/` with no matching guidance anywhere upstream (BAC-756). The other 2

--- a/tools/loop-engine/.claude-plugin/plugin.json
+++ b/tools/loop-engine/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "loop-engine",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Core loop mechanics: verdict-run (machine-readable PASS/FAIL contract), loop-fix (closed verify->fix loop), lessons (verified-fix memory), classify-risk, require-tests, check-docs-hygiene/check-pr-hygiene/check-module-size (repo hygiene gates). verifier=ceiling — the agent's self-judgement never substitutes for it.",
   "author": {
     "name": "paulkim-lansik"

--- a/tools/loop-engine/test/lesson-codification-bac756.test.sh
+++ b/tools/loop-engine/test/lesson-codification-bac756.test.sh
@@ -1,9 +1,24 @@
 #!/usr/bin/env bash
-# BAC-756 — locks 7 verified-lesson codifications (glucofit-partners, ADR-0034 §9 repo→plugin
-# knowledge-ownership routing) into ship-flow's skill/agent prose. Two of the nine lessons the source
-# issue listed already carry `challenge.verdict: "reject"` in the source repo's `.loop/lessons/` —
-# 8932917806328c0b ("workflow merged===true") and f3f65538bf7d33b6 ("gh pr merge --admin") — and are
-# deliberately NOT codified here (CLAUDE.md's own rule: only an accept-passed lesson gets codified).
+# BAC-756 — locks verified-lesson codifications (glucofit-partners, ADR-0034 §9 repo→plugin
+# knowledge-ownership routing) into ship-flow's skill/agent prose.
+#
+# Correction (BAC-756 follow-up, fix/bac756-challenge-correction): the initial PR#50 codification ran
+# BEFORE an independent challenge pass instead of after (CLAUDE.md's own rule: only an accept-passed
+# lesson gets codified). A skeptical review run afterward rejected 5 of the 9 candidates as too
+# repo-specific, too thin (count=1, single review finding), or already-covered by a stricter existing
+# policy — 3602ba166619af93 (ADR-number collision, already covered by CLAUDE.md §8's own worktree-scan
+# rule), 630796f2f488f993 (deep-gate container race, a near-duplicate of the already-accepted 0e5154a1
+# tied to this repo's non-portable container-naming script), 92d95548aad4ebf4 (stale docker volume after
+# migration change, restates Postgres's own documented init-script behavior), 5b4f4c8ba005695f (preserve
+# isolation env vars when bypassing a helper — too thin/generic at count=1), and 38e9a48c3659de1d
+# (grep-whole-repo-before-narrowing — too obvious to be worth a permanent doc entry). Their prose was
+# reverted from ship-feature/SKILL.md, setup/SKILL.md, and ADR-FORMAT.md; this test's PASS blocks for
+# them were removed and replaced with regression guards below. Two more of the nine —
+# 8932917806328c0b ("workflow merged===true") and f3f65538bf7d33b6 ("gh pr merge --admin") — already
+# carried `challenge.verdict: "reject"` in the source repo's `.loop/lessons/` before this issue started
+# and were never codified. That leaves 4 accept-passed codifications actually locked below: 07bc4859
+# (pre-existing accept), 15c8b2ca, 1a5200e3, fb72c699, plus 53da49e1's half of the namespace-migration
+# section.
 set -uo pipefail
 HERE="$(cd "$(dirname "$0")" && pwd)"
 SHIP_FEATURE="$HERE/../../ship-flow/skills/ship-feature/SKILL.md"
@@ -23,10 +38,13 @@ grep -q 'git show origin/<base>' "$SHIP_FEATURE" || fail "ship-feature SKILL.md 
 grep -qi 'stacked' "$HOTFIX" || fail "hotfix SKILL.md must document the stacked-PR retarget gotcha"
 echo "PASS: 07bc4859 (stacked PR + squash-merge retarget) codified in ship-feature and hotfix"
 
-# 0e5154a1/630796f2/92d95548/5b4f4c8b — deep-gate docker isolation, batched into one ship-feature note.
+# 0e5154a1 — deep-gate docker container race (pre-existing accept, already retired against ADR-0054).
 grep -qi 'more than one deep gate in this worktree' "$SHIP_FEATURE" || fail "ship-feature SKILL.md must warn against parallel deep gates in one worktree"
-grep -qi 'isolation identifiers' "$SHIP_FEATURE" || fail "ship-feature SKILL.md must warn against dropping isolation identifiers when bypassing a helper"
-echo "PASS: 0e5154a1/630796f2/92d95548/5b4f4c8b (deep-gate docker isolation) codified in ship-feature step 2"
+echo "PASS: 0e5154a1 (deep-gate docker container race) codified in ship-feature step 2"
+# 92d95548/5b4f4c8b — rejected; must not have been re-added.
+grep -qi 'isolation identifiers' "$SHIP_FEATURE" && fail "ship-feature SKILL.md must not re-add the rejected isolation-identifiers note (5b4f4c8b)"
+grep -qi 'clean that resource before re-verifying' "$SHIP_FEATURE" && fail "ship-feature SKILL.md must not re-add the rejected stale-volume note (92d95548)"
+echo "PASS: 92d95548/5b4f4c8b correctly excluded from ship-feature step 2"
 
 # 15c8b2ca — MCP browser fallback in runtime-verify.
 grep -qi 'browser-automation MCP is unavailable' "$SHIP_FEATURE" || fail "ship-feature SKILL.md must document the MCP-unavailable browser fallback"
@@ -41,14 +59,15 @@ echo "PASS: 1a5200e3 (macOS ACL blocks git worktree remove) codified in ship-fea
 grep -qi 'no web access' "$CODE_REVIEWER" || fail "code-reviewer.md must caution that it has no web access"
 echo "PASS: fb72c699 (reviewer no-web-access caution) codified in agents/code-reviewer.md"
 
-# 3602ba16 — ADR number collision with a concurrent open PR.
-grep -qi 'concurrent work' "$ADR_FORMAT" || fail "ADR-FORMAT.md must document the concurrent-PR ADR-number collision check"
-grep -qi 'open PRs' "$ADR_FORMAT" || fail "ADR-FORMAT.md must tell agents to check open PRs before finalizing an ADR number"
-echo "PASS: 3602ba16 (ADR number collision across concurrent PRs) codified in ADR-FORMAT.md"
+# 3602ba16 — rejected; already covered by CLAUDE.md §8's own worktree-scan rule. Must not be re-added.
+grep -qi 'concurrent work' "$ADR_FORMAT" && fail "ADR-FORMAT.md must not re-add the rejected concurrent-PR ADR-number-collision note (3602ba16)"
+echo "PASS: 3602ba16 correctly excluded from ADR-FORMAT.md"
 
-# 38e9a48c/53da49e1 — namespace migration grep-sweep discipline (repo-wide-from-the-start + raw-substring re-grep).
-grep -qi 'repo-wide-from-the-start' "$SETUP" || fail "setup SKILL.md must document the repo-wide-from-the-start sweep habit"
+# 53da49e1 — namespace migration raw-substring re-grep habit.
 grep -qi 'raw renamed substring' "$SETUP" || fail "setup SKILL.md must document the raw-substring re-grep habit for differently-escaped siblings"
-echo "PASS: 38e9a48c/53da49e1 (namespace migration grep-sweep discipline) codified in setup SKILL.md"
+echo "PASS: 53da49e1 (raw-substring re-grep habit) codified in setup SKILL.md"
+# 38e9a48c — rejected (too obvious); must not have been re-added.
+grep -qi 'repo-wide-from-the-start' "$SETUP" && fail "setup SKILL.md must not re-add the rejected repo-wide-from-the-start sweep habit (38e9a48c)"
+echo "PASS: 38e9a48c correctly excluded from setup SKILL.md"
 
 exit 0

--- a/tools/ship-flow/.claude-plugin/plugin.json
+++ b/tools/ship-flow/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ship-flow",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Delivery-loop skills — land and release already-verified work through a repo's real gates. Tracker- and branch-model-agnostic: reads a consuming repo's own config instead of hardcoding one repo's setup.",
   "author": {
     "name": "paulkim-lansik"

--- a/tools/ship-flow/skills/grill-with-docs/ADR-FORMAT.md
+++ b/tools/ship-flow/skills/grill-with-docs/ADR-FORMAT.md
@@ -26,11 +26,6 @@ Only include these when they add genuine value. Most ADRs won't need them.
 
 Scan `docs/adr/` for the highest existing number and increment by one.
 
-If concurrent work on other worktrees/branches is common in this repo, that scan alone isn't enough —
-a number can be claimed by another open, unmerged PR that your local worktree can't see on disk. Before
-finalizing the number and citing it elsewhere (a glossary, other issues), check open PRs for `docs/adr/`
-additions too, not just the local filesystem. If you find a collision, renumber and fix all citations.
-
 ## When to offer an ADR
 
 All three of these must be true:

--- a/tools/ship-flow/skills/setup/SKILL.md
+++ b/tools/ship-flow/skills/setup/SKILL.md
@@ -139,11 +139,8 @@ so explicitly rather than letting the user assume everything happened.
 Plugin skills are namespaced by the platform (`plugin:skill`, not a bare name); if this repo used to
 invoke a same-named local skill directly (e.g. `/ship-feature`), there's no compat shim to fall back
 on — every live reference has to be updated in the same pass (CLAUDE.md, `docs/agents/*`, other skill
-bodies; leave `.loop/lessons/*.json` and other historical records alone). Two sweep habits catch what a
+bodies; leave `.loop/lessons/*.json` and other historical records alone). One sweep habit catches what a
 narrower one misses:
-- Grep the **whole repo** from the first pass, not directory-by-directory as you discover more affected
-  areas — a scope that only widens after each sweep costs a re-discovery round per widening, where a
-  repo-wide-from-the-start pass costs one.
 - After a bulk find-and-replace, grep the **raw renamed substring** across each touched file, not just
   the specific quoting/escaping form your edit targeted — the same string can appear a second time in a
   different escaping (e.g. a plain backtick in a single-quoted string vs. an escaped backtick inside a

--- a/tools/ship-flow/skills/ship-feature/SKILL.md
+++ b/tools/ship-flow/skills/ship-feature/SKILL.md
@@ -207,11 +207,7 @@ diff with `--from-git`). `VERDICT: FAIL` loops back autonomously.
 
 > If any `DEEP_GATES:` run against a shared local resource (e.g. a per-worktree docker database), don't
 > run more than one deep gate in this worktree at the same time — a second one recreating the same
-> container mid-run causes an unrelated-looking failure, not a clear error. After a rebase changes the
-> migration set, clean that resource before re-verifying rather than reusing stale state. If a helper
-> script that normally isolates this resource fails and has to be bypassed manually, preserve whatever
-> isolation identifiers it would have set (container name/port/project name) — dropping them risks
-> clobbering a resource another session is using.
+> container mid-run causes an unrelated-looking failure, not a clear error.
 
 ### 3. Runtime verify
 Build and run the app, drive the changed surface (CLI/API/GUI — whatever applies) through it, and


### PR DESCRIPTION
## Summary
- PR#50 (BAC-756) codified 9 glucofit-partners lessons into ship-flow's skill/agent prose **before** running an independent challenge pass — backwards from CLAUDE.md's own rule ("회의적 평가(accept)를 통과한 것만 코디파이" — only an accept-passed lesson gets codified).
- Running that challenge pass afterward (fresh, no-context skeptical reviewer, same calibration bar as the two pre-existing rejects in the lesson store) rejected 5 of the 9 candidates:
  - `3602ba166619af93` — ADR-number collision across concurrent PRs: already covered, more strictly, by the consuming repo's own worktree-scan policy.
  - `630796f2f488f993` — deep-gate container race: a near-duplicate of the already-accepted `0e5154a1`, tied to one repo's non-portable container-naming script.
  - `92d95548aad4ebf4` — stale docker volume after a migration-set change: restates Postgres's own documented init-script behavior.
  - `5b4f4c8ba005695f` — preserve isolation env vars when bypassing a helper: a single (count=1) incident, too thin/generic for a permanent doc entry.
  - `38e9a48c3659de1d` — grep the whole repo before narrowing: standard diligence, too obvious to be worth codifying.
- Reverted their prose from `skills/ship-feature/SKILL.md` (step 2 blockquote — keeps the still-accepted "don't run more than one deep gate at once" sentence covering `0e5154a1`), `skills/setup/SKILL.md` (namespace-migration section — keeps the accepted raw-substring re-grep bullet, `53da49e1`), and `skills/grill-with-docs/ADR-FORMAT.md` (Numbering section — the whole concurrent-open-PR paragraph goes).
- The 4 that genuinely passed the bar stand as-is: `07bc4859` (stacked PR + squash-merge retarget), `15c8b2ca` (MCP browser fallback), `1a5200e3` (macOS ACL blocking `git worktree remove`), `fb72c699` (reviewer has no web access).
- Updated `test/lesson-codification-bac756.test.sh` — obsolete PASS blocks replaced with regression guards (`grep ... && fail`) against re-adding the reverted content.
- Version bumps: loop-engine 0.6.1→0.6.2 (test-only), ship-flow 0.2.5→0.2.6. Full rationale in `CHANGELOG.md`.

## Test plan
- [x] `bash tools/loop-engine/test/lesson-codification-bac756.test.sh` — 9/9 PASS
- [x] `bash tools/loop-engine/test/run.sh` — 40/40 PASS
- [x] `claude plugin validate --strict tools/loop-engine` — passed
- [x] `claude plugin validate --strict tools/ship-flow` — passed
- [x] `grep -rn '"loop-engine"' --include=plugin.json .` — dependency ranges (`^0.6.0`) still satisfied by 0.6.2, no joint-constraint bump needed

BAC-756

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016y2zUZBrhEkwJyQx8nNC1Y