### PR TITLE
feat(loop-engine): compaction event instrumentation + run-metrics correlation fold (BAC-746)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,21 +12,21 @@
       "name": "loop-engine",
       "source": "./tools/loop-engine",
       "description": "Core loop mechanics: verdict-run (machine-readable PASS/FAIL contract), loop-fix (closed verify->fix loop), lessons (verified-fix memory), classify-risk, require-tests, plugin-path (resolve sibling plugin install paths), check-docs-hygiene/check-pr-hygiene/check-module-size (repo hygiene gates). No framework opinions beyond \"the verifier is the ceiling, never the agent's self-report\".",
-      "version": "0.6.2",
+      "version": "0.7.0",
       "keywords": ["verifier", "tdd", "loop", "verdict", "lessons"]
     },
     {
       "name": "ship-flow",
       "source": "./tools/ship-flow",
       "description": "Delivery-loop skills — ship-feature (plan-to-PR autonomous loop), hotfix, retrospect, grill-with-docs, deps-audit, to-issues/to-prd, tdd, harness-maturity-audit, improve-codebase-architecture, resolving-merge-conflicts, plus review agents and audit/research workflows — parameterized by a consuming repo's own tracker/branch-model config instead of hardcoded to one repo. dependencies: loop-engine.",
-      "version": "0.2.6",
+      "version": "0.2.7",
       "keywords": ["delivery", "git-flow", "hotfix", "ship", "release"]
     },
     {
       "name": "loop-memory",
       "source": "./tools/loop-memory",
       "description": "pgvector semantic recall for verified dev-loop lessons (and, optionally, ADR/glossary/research knowledge). Opt-in / defaultEnabled:false — a database dependency, not core loop mechanics.",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "defaultEnabled": false,
       "keywords": ["memory", "pgvector", "recall", "semantic-search", "lessons"]
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,39 @@ Explicit-version channel — see [README § Development status](README.md#develo
 not a SHA channel. Entries below `## loop-engine 0.2.0` and earlier predate the multi-plugin split
 and refer to `loop-engine` only (see the un-prefixed version numbers).
 
+## loop-engine 0.7.0
+
+- Compaction instrumentation (BAC-746, Aside harness-benchmarking research §5.1 #2): bundles a
+  `PreCompact` (matcher `auto`/`manual`) hook registration and a new `compaction` run-ledger event
+  type (payload: `cwd`, `trigger`, `custom_instructions`) via `hooks/record-run-event.mjs`. Measures
+  whether context compaction correlates with subsequent verifier failure — previously only known
+  indirectly via `instructions.loaded`'s `load_reason:"compact"` count, with no signal on whether
+  compaction actually hurt outcomes.
+- `bin/run-metrics.mjs` adds two fold outputs (both text and `--json`): per-run `compactions` (count)
+  and overall `post_compaction_red` — the fraction of "first verdict after a compaction" events that
+  were `verdict.failed`. Back-to-back compactions with no intervening verdict collapse to one pending
+  "recently compacted" state rather than double-counting the same next verdict. Follows the existing
+  `INSUFFICIENT_DATA` convention when no compaction events exist in the ledger.
+- `hooks/hooks.json` gains 2 more hook commands (14→16, still 8 distinct files — `PreCompact`'s two
+  matchers both point at the already-existing `record-run-event.mjs`) — regression-tested end-to-end
+  (a real `PreCompact` input must append a `type:"compaction"` ledger event, not just parse without
+  throwing).
+- Consuming repos: bump loop-engine (and re-tag `PreCompact` reaches them automatically via the
+  bundled hook — no local `.claude/settings.json` wiring needed per BAC-752's plugin-first decision).
+  After ~1 week of real usage, check `run-metrics.mjs`'s `post_compaction_red` to decide whether the
+  separate conditional "compaction checkpoint" issue is worth starting.
+
+## ship-flow 0.2.7
+
+- No content change — `dependencies` range on loop-engine bumped `^0.6.0` → `^0.7.0` to stay
+  satisfiable after loop-engine's minor bump above (joint-constraint: a 0.x caret range is
+  same-minor-strict, so this must land in the same PR as the loop-engine bump it depends on).
+
+## loop-memory 0.2.5
+
+- No content change — same joint-constraint dependency bump as ship-flow 0.2.7 above
+  (`loop-engine` `^0.6.0` → `^0.7.0`).
+
 ## loop-engine 0.6.2
 
 - `test/lesson-codification-bac756.test.sh` updated for the ship-flow 0.2.6 correction below — its

--- a/tools/loop-engine/.claude-plugin/plugin.json
+++ b/tools/loop-engine/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "loop-engine",
-  "version": "0.6.2",
+  "version": "0.7.0",
   "description": "Core loop mechanics: verdict-run (machine-readable PASS/FAIL contract), loop-fix (closed verify->fix loop), lessons (verified-fix memory), classify-risk, require-tests, check-docs-hygiene/check-pr-hygiene/check-module-size (repo hygiene gates). verifier=ceiling — the agent's self-judgement never substitutes for it.",
   "author": {
     "name": "paulkim-lansik"

--- a/tools/loop-engine/bin/run-metrics.mjs
+++ b/tools/loop-engine/bin/run-metrics.mjs
@@ -11,6 +11,11 @@
 //        제외 내역(excluded_by_surface)은 항상 표시한다 — 침묵 제외 금지.
 //   Q1 = first-pass green 비율 = (첫 verdict.*가 verdict.passed인 런) / (verdict 보유 런)
 //   Q2 = 재작업 = 런당 verdict.* 호출 수
+//   압축 상관(BAC-746) = 런당 compaction 이벤트 수 + "압축 직후 RED 비율" — 런 타임라인을
+//        (compaction ∪ verdict.*) ts순으로 걸어, compaction 뒤 처음 만나는 verdict 1건만
+//        "post-compaction"으로 표시한다(압축이 여러 번 연달아 와도 "최근 압축됨" 불리언 상태로
+//        취급 — 압축마다 같은 다음 verdict를 중복 카운트하지 않는다). 이 표본들 중 verdict.failed
+//        비율이 post_compaction_red — 체크포인트(별도 조건부 이슈) 착수 여부의 실측 근거.
 // 결손 축은 INSUFFICIENT_DATA를 1급 결과로(frugality proof — 측정 축이 빠지면 조작된 PASS 대신
 // 증명 불가를 정직하게): run.started 없는 런(계측 생존 마커 부재)의 H1, verdict 0 런의 Q2,
 // 해당 런이 0인 전체 축. 'unknown' 런(귀속 불가 verdict 버킷)은 별도 행+카운터로만 보고하고
@@ -88,6 +93,7 @@ for (const f of files) {
   let perm = 0
   const excluded = {}
   const verdicts = []
+  const compactions = []
   for (const e of events) {
     if (e.type === 'permission.requested') {
       const s = e.payload?.surface
@@ -99,9 +105,28 @@ for (const f of files) {
       }
     } else if (e.type.startsWith('verdict.')) {
       verdicts.push(e)
+    } else if (e.type === 'compaction') {
+      compactions.push(e)
     }
   }
   verdicts.sort((x, y) => String(x.ts).localeCompare(String(y.ts))) // ts 순 안정 정렬(파일 순 보조)
+
+  // 압축 상관(BAC-746): (compaction ∪ verdict.*)를 ts순으로 걸어, 압축 뒤 처음 만나는 verdict 1건만
+  // "post-compaction"으로 태그한다(헤더 참조 — 압축 연타는 "최근 압축됨" 불리언 상태 취급).
+  const timeline = [...compactions, ...verdicts].sort((x, y) =>
+    String(x.ts).localeCompare(String(y.ts)),
+  )
+  let pendingCompaction = false
+  const postCompactionRed = []
+  for (const e of timeline) {
+    if (e.type === 'compaction') {
+      pendingCompaction = true
+    } else if (pendingCompaction) {
+      postCompactionRed.push(e.type === 'verdict.failed')
+      pendingCompaction = false
+    }
+  }
+
   runs.push({
     run_id: runId,
     instrumented,
@@ -109,6 +134,8 @@ for (const f of files) {
     q2: verdicts.length > 0 ? verdicts.length : INSUFFICIENT,
     first_pass: verdicts.length > 0 ? verdicts[0].type === 'verdict.passed' : null,
     excluded,
+    compactions: compactions.length,
+    post_compaction_red: postCompactionRed,
   })
 }
 
@@ -127,6 +154,9 @@ const instrumentedRuns = attributed.filter((r) => r.instrumented)
 const verdictRuns = attributed.filter((r) => typeof r.q2 === 'number')
 const firstPassRuns = verdictRuns.filter((r) => r.first_pass === true)
 const h1Values = instrumentedRuns.map((r) => r.h1)
+const compactionsTotal = attributed.reduce((sum, r) => sum + r.compactions, 0)
+const postCompactionSamples = attributed.flatMap((r) => r.post_compaction_red)
+const postCompactionRedCount = postCompactionSamples.filter(Boolean).length
 
 const overall = {
   runs: runs.length,
@@ -146,6 +176,14 @@ const overall = {
   unknown_verdict_events: unknownVerdictEvents,
   skipped_lines: skippedLines,
   skipped_files: skippedFiles,
+  compactions_total: compactionsTotal,
+  post_compaction_red: postCompactionSamples.length
+    ? {
+        ratio: postCompactionRedCount / postCompactionSamples.length,
+        red: postCompactionRedCount,
+        total: postCompactionSamples.length,
+      }
+    : INSUFFICIENT,
 }
 
 if (asJson) {
@@ -174,9 +212,17 @@ if (asJson) {
   lines.push(`unknown_verdict_events: ${unknownVerdictEvents} (귀속 불가 — overall 집계 제외)`)
   lines.push(`skipped_lines: ${skippedLines}`)
   lines.push(`skipped_files: ${skippedFiles}`)
+  lines.push(`compactions_total: ${overall.compactions_total}`)
+  lines.push(
+    typeof overall.post_compaction_red === 'object'
+      ? `post_compaction_red (압축 직후 첫 verdict가 RED인 비율): ${fmt(overall.post_compaction_red.ratio)} (${overall.post_compaction_red.red}/${overall.post_compaction_red.total})`
+      : `post_compaction_red (압축 직후 첫 verdict가 RED인 비율): ${overall.post_compaction_red}`,
+  )
   for (const r of runs) {
     const tag = r.run_id === 'unknown' ? ' (귀속 불가 verdict — current 포인터 부재분)' : ''
-    lines.push(`  ${r.run_id}: H1=${fmt(r.h1)} Q2=${fmt(r.q2)} first_pass=${r.first_pass}${tag}`)
+    lines.push(
+      `  ${r.run_id}: H1=${fmt(r.h1)} Q2=${fmt(r.q2)} first_pass=${r.first_pass} compactions=${r.compactions}${tag}`,
+    )
   }
   lines.push('=== END RUN METRICS ===')
   process.stdout.write(`${lines.join('\n')}\n`)

--- a/tools/loop-engine/hooks/hooks.json
+++ b/tools/loop-engine/hooks/hooks.json
@@ -50,6 +50,20 @@
         ]
       }
     ],
+    "PreCompact": [
+      {
+        "matcher": "auto",
+        "hooks": [
+          { "type": "command", "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/record-run-event.mjs\"", "timeout": 5 }
+        ]
+      },
+      {
+        "matcher": "manual",
+        "hooks": [
+          { "type": "command", "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/record-run-event.mjs\"", "timeout": 5 }
+        ]
+      }
+    ],
     "Stop": [
       {
         "hooks": [

--- a/tools/loop-engine/hooks/record-run-event.mjs
+++ b/tools/loop-engine/hooks/record-run-event.mjs
@@ -24,6 +24,7 @@ const TYPE = {
   SubagentStart: 'subagent.started',
   SubagentStop: 'subagent.stopped',
   InstructionsLoaded: 'instructions.loaded',
+  PreCompact: 'compaction',
 };
 
 // Common stdin fields (official hooks doc) — noise to drop from instructions.loaded's "everything
@@ -69,6 +70,11 @@ function pickPayload(type, input, surfaceOf) {
   }
   if (type === 'run.started' || type === 'run.ended') {
     return { cwd: input.cwd, reason: input.reason, permission_mode: input.permission_mode };
+  }
+  if (type === 'compaction') {
+    // trigger: 'auto' | 'manual' (official PreCompact hook doc). custom_instructions only exists for
+    // manual — carry it capped, since a user could paste something long into it.
+    return { cwd: input.cwd, trigger: input.trigger, custom_instructions: capStr(input.custom_instructions) };
   }
   // instructions.loaded — the event-specific fields aren't documented: carry everything except the
   // common fields, still pre-truncating unknown long strings (sanitize's blocklist/cap defends the

--- a/tools/loop-engine/lib/run-ledger.mjs
+++ b/tools/loop-engine/lib/run-ledger.mjs
@@ -5,6 +5,8 @@
 // 스키마 v1: {id, type(dot.past_tense), ts(ISO), aggregate_id(run-id), payload, version:1}
 //   - 런 경계 = 세션 경계(1 session = 1 run): SessionStart=run.started, SessionEnd=run.ended.
 //   - 토큰 귀속 필드(token_source 등)는 v1에 없음 — BAC-587/582에서 이벤트 확장 시 예약.
+//   - compaction(PreCompact=auto|manual, BAC-746): payload={cwd, trigger, custom_instructions}. 압축
+//     빈도·직후 RED 상관을 bin/run-metrics.mjs가 fold한다(체크포인트 여부 판단의 실측 근거).
 // payload는 기록 시점에 BAC-628 sanitize(sanitizeRecord)를 통과한다 — 시크릿 키 blocklist 낙하 +
 // 장문 sha256+preview 캡. .loop/runs/*는 gitignore(로컬 텔레메트리, 커밋 금지).
 //

--- a/tools/loop-engine/test/hooks-json-wiring.test.sh
+++ b/tools/loop-engine/test/hooks-json-wiring.test.sh
@@ -110,6 +110,18 @@ LOOP_DOCTOR_HEARTBEAT_OFF=1 node "$HOOKS/loop-doctor-heartbeat.mjs" </dev/null >
   || fail "loop-doctor-heartbeat.mjs threw with the kill switch on (stderr: $(cat "$DIR/stderr.doctor"))"
 rm -f "$DIR/.loop/runs" 2>/dev/null
 
+# -- PreCompact -> compaction ledger event (BAC-746) — behavioral, not just "didn't throw": confirms
+# the event actually lands with type=compaction and the trigger payload field set.
+PC_DIR="$DIR/precompact"
+mkdir -p "$PC_DIR"
+printf '{"session_id":"precompact-test","hook_event_name":"PreCompact","trigger":"auto","cwd":"%s"}' "$PC_DIR" \
+  | CLAUDE_PROJECT_DIR="$PC_DIR" node "$HOOKS/record-run-event.mjs" >/dev/null 2>"$DIR/stderr.precompact" \
+  || fail "record-run-event.mjs threw on a valid PreCompact input (stderr: $(cat "$DIR/stderr.precompact"))"
+LEDGER_LINE="$(cat "$PC_DIR/.loop/runs/precompact-test.jsonl" 2>/dev/null)"
+[ -n "$LEDGER_LINE" ] || fail "PreCompact must append a ledger event, found none at $PC_DIR/.loop/runs/precompact-test.jsonl"
+printf '%s' "$LEDGER_LINE" | grep -q '"type":"compaction"' || fail "PreCompact ledger event must have type=compaction, got: $LEDGER_LINE"
+printf '%s' "$LEDGER_LINE" | grep -q '"trigger":"auto"' || fail "PreCompact ledger event payload must carry trigger=auto, got: $LEDGER_LINE"
+
 # -- Deny-path behavioral check: gate-before-merge.mjs on a protected branch, no ship-flow.config.json
 # present (the fallback-default path — protected = {main, master}) must deny a merge into main.
 REPO="$DIR/repo"
@@ -133,4 +145,4 @@ OUT="$(printf '{"tool_name":"Bash","tool_input":{"command":"git merge origin/dev
   | CLAUDE_PROJECT_DIR="$REPO" node "$HOOKS/gate-before-merge.mjs")"
 [ -z "$OUT" ] || fail "gate-before-merge.mjs: with ship-flow.config.json declaring release/trunk, a merge on 'main' must be allowed (main is no longer in the protected set), got: $OUT"
 
-echo "PASS: hooks/hooks.json — plugin.json wiring, file resolution, allow-path smoke test (8 hooks), gate-before-merge deny + config-driven protected-branch behavior"
+echo "PASS: hooks/hooks.json — plugin.json wiring, file resolution, allow-path smoke test (8 hooks), gate-before-merge deny + config-driven protected-branch behavior, PreCompact->compaction event"

--- a/tools/loop-engine/test/run-metrics.test.sh
+++ b/tools/loop-engine/test/run-metrics.test.sh
@@ -162,4 +162,53 @@ printf '%s' "$OUT" | grep -q "excluded_by_surface" || fail "text output must sho
 printf '%s' "$OUT" | grep -q "merge=1" || fail "text output must show merge exclusion count, got: $OUT"
 echo "PASS: text output shows the metrics block and per-surface exclusion breakdown"
 
+# ── 8) 압축 상관(BAC-746) — 런당 compaction 카운트 + 압축 직후 첫 verdict RED 비율 ────────────
+# runE: compaction(auto) -> verdict.failed(post-compaction RED) -> compaction(manual) ->
+#       compaction(auto, 연타) -> verdict.passed(연타의 다음 verdict 1건만 post-compaction) ->
+#       verdict.passed(짝없음 — 앞선 compaction이 이미 다음 verdict에 소비됨, 카운트 제외)
+# runF: compaction 없음 — compactions=0, post_compaction_red 표본에 기여 없음
+COMP="$DIR/comp"
+mkdir -p "$COMP"
+cat > "$COMP/runE.jsonl" <<'EOF'
+{"id":"e1","type":"run.started","ts":"2026-08-20T00:00:00.000Z","aggregate_id":"runE","payload":{},"version":1}
+{"id":"e2","type":"compaction","ts":"2026-08-20T00:01:00.000Z","aggregate_id":"runE","payload":{"trigger":"auto"},"version":1}
+{"id":"e3","type":"verdict.failed","ts":"2026-08-20T00:02:00.000Z","aggregate_id":"runE","payload":{},"version":1}
+{"id":"e4","type":"compaction","ts":"2026-08-20T00:03:00.000Z","aggregate_id":"runE","payload":{"trigger":"manual"},"version":1}
+{"id":"e5","type":"compaction","ts":"2026-08-20T00:04:00.000Z","aggregate_id":"runE","payload":{"trigger":"auto"},"version":1}
+{"id":"e6","type":"verdict.passed","ts":"2026-08-20T00:05:00.000Z","aggregate_id":"runE","payload":{},"version":1}
+{"id":"e7","type":"verdict.passed","ts":"2026-08-20T00:06:00.000Z","aggregate_id":"runE","payload":{},"version":1}
+EOF
+cat > "$COMP/runF.jsonl" <<'EOF'
+{"id":"f1","type":"run.started","ts":"2026-08-20T01:00:00.000Z","aggregate_id":"runF","payload":{},"version":1}
+{"id":"f2","type":"verdict.passed","ts":"2026-08-20T01:01:00.000Z","aggregate_id":"runF","payload":{},"version":1}
+EOF
+JSON="$(node "$METRICS" --runs-dir "$COMP" --json)" || fail "run-metrics with compaction events must exit 0"
+node -e '
+  const m = JSON.parse(process.argv[1]);
+  const runE = m.runs.find((r) => r.run_id === "runE");
+  const runF = m.runs.find((r) => r.run_id === "runF");
+  if (runE.compactions !== 3) throw new Error("runE compactions must be 3, got " + runE.compactions);
+  if (JSON.stringify(runE.post_compaction_red) !== JSON.stringify([true, false]))
+    throw new Error("runE post_compaction_red must be [true(e3 after e2), false(e6 after e4+e5 collapsed)], got " + JSON.stringify(runE.post_compaction_red));
+  if (runF.compactions !== 0) throw new Error("runF compactions must be 0, got " + runF.compactions);
+  if (m.overall.compactions_total !== 3) throw new Error("overall compactions_total must be 3, got " + m.overall.compactions_total);
+  if (m.overall.post_compaction_red.total !== 2) throw new Error("overall post_compaction_red.total must be 2, got " + JSON.stringify(m.overall.post_compaction_red));
+  if (m.overall.post_compaction_red.red !== 1) throw new Error("overall post_compaction_red.red must be 1, got " + JSON.stringify(m.overall.post_compaction_red));
+  if (m.overall.post_compaction_red.ratio !== 0.5) throw new Error("overall post_compaction_red.ratio must be 0.5, got " + JSON.stringify(m.overall.post_compaction_red));
+' "$JSON" || fail "compaction fold values wrong"
+OUT="$(node "$METRICS" --runs-dir "$COMP")"
+printf '%s' "$OUT" | grep -q "compactions_total: 3" || fail "text output must show compactions_total, got: $OUT"
+printf '%s' "$OUT" | grep -q "post_compaction_red" || fail "text output must show post_compaction_red, got: $OUT"
+echo "PASS: per-run compactions + post-compaction-RED fold correctly (back-to-back compactions collapse to one pending state, not double-counted)"
+
+# ── 9) compaction 없는 원장(모든 기존 픽스처)은 post_compaction_red=INSUFFICIENT_DATA ─────────
+JSON="$(node "$METRICS" --runs-dir "$AB" --json)" || fail "run-metrics on non-compaction fixture must exit 0"
+node -e '
+  const m = JSON.parse(process.argv[1]);
+  if (m.overall.post_compaction_red !== "INSUFFICIENT_DATA")
+    throw new Error("no compaction events -> post_compaction_red must be INSUFFICIENT_DATA, got " + JSON.stringify(m.overall.post_compaction_red));
+  if (m.overall.compactions_total !== 0) throw new Error("no compaction events -> compactions_total must be 0, got " + m.overall.compactions_total);
+' "$JSON" || fail "no-compaction fixture must report INSUFFICIENT_DATA, not a fabricated ratio"
+echo "PASS: runs with no compaction events report post_compaction_red=INSUFFICIENT_DATA (no fabricated ratio)"
+
 exit 0

--- a/tools/loop-memory/.claude-plugin/plugin.json
+++ b/tools/loop-memory/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "loop-memory",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "pgvector semantic recall for verified dev-loop lessons (and, optionally, ADR/glossary/research knowledge). Opt-in: installs disabled by default — this is a database dependency, not core loop mechanics.",
   "author": {
     "name": "paulkim-lansik"
@@ -10,7 +10,7 @@
   "license": "MIT",
   "keywords": ["memory", "pgvector", "recall", "semantic-search", "lessons"],
   "defaultEnabled": false,
-  "dependencies": [{ "name": "loop-engine", "version": "^0.6.0" }],
+  "dependencies": [{ "name": "loop-engine", "version": "^0.7.0" }],
   "userConfig": {
     "openai_api_key": {
       "type": "string",

--- a/tools/ship-flow/.claude-plugin/plugin.json
+++ b/tools/ship-flow/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ship-flow",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "Delivery-loop skills — land and release already-verified work through a repo's real gates. Tracker- and branch-model-agnostic: reads a consuming repo's own config instead of hardcoding one repo's setup.",
   "author": {
     "name": "paulkim-lansik"
@@ -10,6 +10,6 @@
   "license": "MIT",
   "keywords": ["delivery", "git-flow", "hotfix", "ship", "release"],
   "dependencies": [
-    { "name": "loop-engine", "version": "^0.6.0" }
+    { "name": "loop-engine", "version": "^0.7.0" }
   ]
 }


### PR DESCRIPTION
## Summary
- Instruments context compaction: bundles a `PreCompact` (matcher `auto`/`manual`) hook registration into `hooks/hooks.json`, routing to the existing `hooks/record-run-event.mjs`, which now emits a new `compaction` run-ledger event (payload: `cwd`, `trigger`, `custom_instructions`).
- Consuming repos get this via a plain plugin-version bump — no local `.claude/settings.json` wiring needed, since `record-run-event.mjs` is already on loop-engine's bundled-hooks list (BAC-752 decision, ADR-0078 addendum).
- `bin/run-metrics.mjs` adds two fold outputs (text + `--json`): per-run `compactions` (count) and overall `post_compaction_red` — the fraction of "first verdict after a compaction" events that were `verdict.failed`. Back-to-back compactions with no intervening verdict collapse to one pending "recently compacted" state, so the same next verdict isn't double-counted. Follows the existing `INSUFFICIENT_DATA` convention when a ledger has no compaction events.
- This turns "compaction happens" (previously only known indirectly, via `instructions.loaded`'s `load_reason:"compact"` count) into "does compaction correlate with subsequent failure" — the actual evidence a follow-up conditional "compaction checkpoint" issue needs before it's worth building.
- Version bumps: `loop-engine` 0.6.2→0.7.0 (minor — new event type/hook/metrics, additive & backward-compatible). `ship-flow` 0.2.6→0.2.7 and `loop-memory` 0.2.4→0.2.5 bump their `loop-engine` dependency range `^0.6.0`→`^0.7.0` in this same PR (0.x caret joint-constraint — a dependent left on the old range would become unsatisfiable).

## Test plan
- [x] `bash tools/loop-engine/test/run-metrics.test.sh` — new fold-logic cases (compaction counting, back-to-back-collapse, INSUFFICIENT_DATA-with-no-compactions) pass alongside all pre-existing H1/Q1/Q2 cases
- [x] `bash tools/loop-engine/test/hooks-json-wiring.test.sh` — new behavioral case: a real `PreCompact` input actually appends a `type:"compaction"` ledger event (not just "didn't throw")
- [x] `bash tools/loop-engine/test/run.sh` — 40/40 test files pass
- [x] `claude plugin validate --strict` on all three plugins — pass
- [x] `grep -rn '"loop-engine"' --include=plugin.json .` — dependency ranges consistent (`^0.7.0` everywhere)

BAC-746

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016y2zUZBrhEkwJyQx8nNC1Y