### PR TITLE
feat(ship-flow): runtime-verify evidence guidance — a11y snapshot over screenshot, no user-browser MCP (BAC-749)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,14 +12,14 @@
       "name": "loop-engine",
       "source": "./tools/loop-engine",
       "description": "Core loop mechanics: verdict-run (machine-readable PASS/FAIL contract), loop-fix (closed verify->fix loop), lessons (verified-fix memory), classify-risk, require-tests, plugin-path (resolve sibling plugin install paths), check-docs-hygiene/check-pr-hygiene/check-module-size (repo hygiene gates). No framework opinions beyond \"the verifier is the ceiling, never the agent's self-report\".",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "keywords": ["verifier", "tdd", "loop", "verdict", "lessons"]
     },
     {
       "name": "ship-flow",
       "source": "./tools/ship-flow",
       "description": "Delivery-loop skills — ship-feature (plan-to-PR autonomous loop), hotfix, retrospect, grill-with-docs, deps-audit, to-issues/to-prd, tdd, harness-maturity-audit, improve-codebase-architecture, resolving-merge-conflicts, plus review agents and audit/research workflows — parameterized by a consuming repo's own tracker/branch-model config instead of hardcoded to one repo. dependencies: loop-engine.",
-      "version": "0.2.7",
+      "version": "0.2.8",
       "keywords": ["delivery", "git-flow", "hotfix", "ship", "release"]
     },
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ Explicit-version channel — see [README § Development status](README.md#develo
 not a SHA channel. Entries below `## loop-engine 0.2.0` and earlier predate the multi-plugin split
 and refer to `loop-engine` only (see the un-prefixed version numbers).
 
+## loop-engine 0.7.1
+
+- New `test/runtime-verify-evidence-bac749.test.sh` (BAC-749) — locks the two ship-feature step 3
+  guidelines below in place. No bin/lib change (patch).
+
+## ship-flow 0.2.8
+
+- ship-feature step 3 (runtime-verify) gains two evidence-gathering guidelines (BAC-749, Aside
+  harness-benchmarking research §5.1 conditional candidate A3, downgraded from a full ARIA-diff-first
+  build to a one-line guideline since equivalent tooling already exists in most consuming repos):
+  when a browser is involved, prefer an accessibility-tree snapshot (+ diff) as the observation
+  evidence over a screenshot — a screenshot is for when something genuinely needs visual confirmation,
+  not the default; and never attach a browser-automation MCP that drives the user's own logged-in
+  browser (their cookies, their accounts) to this autonomous step, since a prompt injection on the
+  page under test would then reach the user's real accounts instead of a sandboxed session.
+
 ## loop-engine 0.7.0
 
 - Compaction instrumentation (BAC-746, Aside harness-benchmarking research §5.1 #2): bundles a

--- a/tools/loop-engine/.claude-plugin/plugin.json
+++ b/tools/loop-engine/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "loop-engine",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Core loop mechanics: verdict-run (machine-readable PASS/FAIL contract), loop-fix (closed verify->fix loop), lessons (verified-fix memory), classify-risk, require-tests, check-docs-hygiene/check-pr-hygiene/check-module-size (repo hygiene gates). verifier=ceiling — the agent's self-judgement never substitutes for it.",
   "author": {
     "name": "paulkim-lansik"

--- a/tools/loop-engine/test/runtime-verify-evidence-bac749.test.sh
+++ b/tools/loop-engine/test/runtime-verify-evidence-bac749.test.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# BAC-749 — locks two runtime-verify (ship-feature step 3) evidence-gathering guidelines: prefer an
+# accessibility-tree snapshot over a screenshot as observation evidence, and never attach a
+# browser-automation MCP that drives the user's own logged-in browser to an autonomous run.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+SHIP_FEATURE="$HERE/../../ship-flow/skills/ship-feature/SKILL.md"
+
+fail() { echo "FAIL: $1"; exit 1; }
+[ -f "$SHIP_FEATURE" ] || fail "missing file: $SHIP_FEATURE"
+
+grep -qi 'accessibility-tree snapshot' "$SHIP_FEATURE" || fail "ship-feature SKILL.md must prefer accessibility-tree snapshots over screenshots as runtime-verify evidence"
+grep -qi "user's own" "$SHIP_FEATURE" || fail "ship-feature SKILL.md must warn against attaching a browser-automation MCP bound to the user's own logged-in browser"
+echo "PASS: BAC-749 (a11y-snapshot-first evidence + no user-logged-in-browser MCP in autonomous runs) codified in ship-feature step 3"
+
+exit 0

--- a/tools/ship-flow/.claude-plugin/plugin.json
+++ b/tools/ship-flow/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ship-flow",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "Delivery-loop skills — land and release already-verified work through a repo's real gates. Tracker- and branch-model-agnostic: reads a consuming repo's own config instead of hardcoding one repo's setup.",
   "author": {
     "name": "paulkim-lansik"

--- a/tools/ship-flow/skills/ship-feature/SKILL.md
+++ b/tools/ship-flow/skills/ship-feature/SKILL.md
@@ -225,6 +225,13 @@ one-line reason.
 > — independent of any shared MCP browser profile. Run it from inside the package that has that
 > dependency installed (a script outside it won't resolve the same `node_modules`).
 
+> When a browser is involved, prefer an accessibility-tree snapshot (+ diff against the prior state) as
+> the observation evidence over a screenshot — most repos already have a tool for this (e.g. a
+> `take_snapshot`-style MCP call); reach for a screenshot only when something genuinely needs visual
+> confirmation, not as the default. Never attach a browser-automation MCP that drives the user's own
+> logged-in browser (their cookies, their accounts) to this autonomous step — a prompt injection on the
+> page under test would then reach the user's real accounts, not a sandboxed session.
+
 ### 4. Review and fix
 Run this plugin's review agents (`code-reviewer`, `test-hunter`, `verifier-integrity-hunter`) against
 the diff. If this repo also runs a separate general-purpose PR-review tool, run both — during any


### PR DESCRIPTION
## Summary
- ship-feature step 3 (runtime-verify) gains two one-line guidelines instead of building a full ARIA-diff-first tool — the original Aside-benchmarking research candidate (§5.1) was downgraded to guidance-only since equivalent snapshot/diff tooling already exists in most consuming repos (e.g. `chrome-devtools-mcp`'s `take_snapshot`). The gap was guidance, not capability.
  - Prefer an accessibility-tree snapshot (+ diff against prior state) as observation evidence over a screenshot; a screenshot is for when something genuinely needs visual confirmation, not the default.
  - Never attach a browser-automation MCP that drives the user's own logged-in browser (their cookies, their accounts) to this autonomous step — a prompt injection on the page under test would then reach the user's real accounts instead of a sandboxed session.
- Version bumps: `loop-engine` 0.7.0→0.7.1 (test-only patch, new regression lock). `ship-flow` 0.2.7→0.2.8 (the guideline text). No dependency-range change needed — `^0.7.0` already covers 0.7.1.

## Test plan
- [x] `bash tools/loop-engine/test/runtime-verify-evidence-bac749.test.sh` — new lock-in test passes standalone
- [x] `bash tools/loop-engine/test/run.sh` — 41/41 test files pass
- [x] `claude plugin validate --strict` on loop-engine and ship-flow — pass
- [x] `grep -rn '"loop-engine"' --include=plugin.json .` — dependency ranges consistent (`^0.7.0`, still satisfied)

BAC-749

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016y2zUZBrhEkwJyQx8nNC1Y