### PR TITLE
feat(ship-flow,loop-engine): skill frontmatter modernization + risk-rules.example.json (BAC-757)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,21 +12,21 @@
       "name": "loop-engine",
       "source": "./tools/loop-engine",
       "description": "Core loop mechanics: verdict-run (machine-readable PASS/FAIL contract), loop-fix (closed verify->fix loop), lessons (verified-fix memory), classify-risk, require-tests, plugin-path (resolve sibling plugin install paths), check-docs-hygiene/check-pr-hygiene/check-module-size (repo hygiene gates). No framework opinions beyond \"the verifier is the ceiling, never the agent's self-report\".",
-      "version": "0.7.1",
+      "version": "0.8.0",
       "keywords": ["verifier", "tdd", "loop", "verdict", "lessons"]
     },
     {
       "name": "ship-flow",
       "source": "./tools/ship-flow",
       "description": "Delivery-loop skills — ship-feature (plan-to-PR autonomous loop), hotfix, retrospect, grill-with-docs, deps-audit, to-issues/to-prd, tdd, harness-maturity-audit, improve-codebase-architecture, resolving-merge-conflicts, plus review agents and audit/research workflows — parameterized by a consuming repo's own tracker/branch-model config instead of hardcoded to one repo. dependencies: loop-engine.",
-      "version": "0.2.8",
+      "version": "0.2.9",
       "keywords": ["delivery", "git-flow", "hotfix", "ship", "release"]
     },
     {
       "name": "loop-memory",
       "source": "./tools/loop-memory",
       "description": "pgvector semantic recall for verified dev-loop lessons (and, optionally, ADR/glossary/research knowledge). Opt-in / defaultEnabled:false — a database dependency, not core loop mechanics.",
-      "version": "0.2.5",
+      "version": "0.2.6",
       "defaultEnabled": false,
       "keywords": ["memory", "pgvector", "recall", "semantic-search", "lessons"]
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,55 @@ Explicit-version channel — see [README § Development status](README.md#develo
 not a SHA channel. Entries below `## loop-engine 0.2.0` and earlier predate the multi-plugin split
 and refer to `loop-engine` only (see the un-prefixed version numbers).
 
+## loop-engine 0.8.0
+
+- New `templates/risk-rules.example.json` (BAC-757) — a shape-only starter for `classify-risk.mjs`'s
+  externalized rule table (this plugin ships zero product-specific rules by design, BAC-698/BAC-563
+  C5). Every path/pattern is a `<placeholder>` a consuming repo must replace, but the `harness` rule's
+  self-coverage property (it matches `risk-rules.json` itself, so silently weakening a rule and the
+  file that defines rules in the same PR still gets flagged) is meant to survive the copy — called out
+  explicitly in both the template's own `$comment` and `setup`'s guidance (ship-flow, below).
+- New `test/classify-risk-rules.test.sh` case (8) locking the template: valid JSON, its harness rule
+  self-covers (`risk-rules.json` and `CLAUDE.md` both match, both raise `blast=high`), and its per-rule
+  `deep` gate lists are pinned so a future edit can't silently drop one.
+- New `test/skill-frontmatter-bac757.test.sh` (BAC-757) — locks which ship-flow skills declare
+  `context: fork` and which don't (see ship-flow 0.2.9 below for what that split is and why).
+
+## ship-flow 0.2.9
+
+- Skill frontmatter modernization (BAC-757, backport of BAC-621's glucofit-partners pattern): three
+  ship-flow skills — `deps-audit`, `retrospect`, `resolving-merge-conflicts` — gain `context: fork`.
+  Each was read end-to-end to confirm it never blocks mid-run on a live user question (a forked
+  subagent's questions never reach the user); any "get a human's OK" moment in these three is async —
+  producing a report/candidate list for a *later*, separate review, not something the run itself
+  blocks on. The other 9 skills (`setup`, `grill-with-docs`, `to-issues`, `hotfix`, `ship-feature`,
+  `harness-maturity-audit`, `improve-codebase-architecture`, `tdd`, `to-prd`) deliberately do NOT get
+  `context: fork` — each has at least one load-bearing mid-flow question the rest of that same run
+  depends on (an explicit `AskUserQuestion` gate, or a "confirm/ask the user" checkpoint prose
+  describes as blocking) — full audit trail of which line justified each exclusion is in
+  `test/skill-frontmatter-bac757.test.sh`'s header comment (loop-engine, above).
+- `setup` now offers loop-engine's new `templates/risk-rules.example.json` alongside the other optional
+  scaffolding in step 4, calling out its self-coverage property so a repo's copy doesn't silently drop
+  it while filling in the placeholders.
+- **`allowed-tools` and `paths` frontmatter fields were deliberately NOT added in this pass** (unlike
+  BAC-621's glucofit-partners precedent, which uses both) — verified against the current official
+  syntax first (`allowed-tools` is a non-restrictive pre-approval hint only, cleared every turn; it
+  cannot break a skill even if incomplete) rather than assumed. `paths` doesn't semantically fit any of
+  these 12 skills — they're all intent-triggered ("Use when the user..."), not file-path-triggered like
+  `design-sync`/`partners-web-design` are in glucofit-partners. `allowed-tools` would fit, but ship-flow
+  skills are deliberately consuming-repo-agnostic (Bash commands route through "however this repo
+  invokes its bin scripts"), so a literal command-pattern list is either wrong per-repo or so broad
+  (`Read Write Edit Bash Task`) it adds no real precision — low value for the effort/review-risk of
+  enumerating 12 skills' full tool needs, especially the complex multi-agent ones. Left for a future
+  pass if a concrete need surfaces.
+- `loop-engine` dependency range `^0.7.0`→`^0.8.0` (joint-constraint: loop-engine's own bump above is
+  minor, so the old range would become unsatisfiable).
+
+## loop-memory 0.2.6
+
+- No content change — same joint-constraint dependency bump as ship-flow 0.2.9 above
+  (`loop-engine` `^0.7.0` → `^0.8.0`).
+
 ## loop-engine 0.7.1
 
 - New `test/runtime-verify-evidence-bac749.test.sh` (BAC-749) — locks the two ship-feature step 3

--- a/tools/loop-engine/.claude-plugin/plugin.json
+++ b/tools/loop-engine/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "loop-engine",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "Core loop mechanics: verdict-run (machine-readable PASS/FAIL contract), loop-fix (closed verify->fix loop), lessons (verified-fix memory), classify-risk, require-tests, check-docs-hygiene/check-pr-hygiene/check-module-size (repo hygiene gates). verifier=ceiling — the agent's self-judgement never substitutes for it.",
   "author": {
     "name": "paulkim-lansik"

--- a/tools/loop-engine/templates/risk-rules.example.json
+++ b/tools/loop-engine/templates/risk-rules.example.json
@@ -1,0 +1,58 @@
+{
+  "$comment": "Shape-only example — this plugin ships NO product-specific rules (BAC-698/BAC-563 C5): which paths are a migration, which are auth, etc. is domain knowledge that belongs to each consuming repo, not to the portable plugin. Copy this to <repo-root>/risk-rules.json (or point --rules / CLASSIFY_RISK_RULES at a copy elsewhere) and replace every placeholder path with this repo's real ones. Schema SSOT: bin/classify-risk.mjs's own header comment. The 'harness' rule below is not optional filler — it makes editing this file itself (and the harness dirs that gate it) blast=high, so a rule silently weakened in the same PR that relies on the weaker rule still gets flagged for human review (BAC-757's self-coverage requirement, mirroring a consuming repo's own 'harness-covers-risk-rules-json' wiring check).",
+  "pathRules": [
+    {
+      "id": "example-irreversible-migration",
+      "startsWith": ["<path-to-your-migrations-dir>/"],
+      "dims": { "revers": "none" },
+      "deep": ["<your-deep-verify-command, e.g. verify:db>"],
+      "why": "REPLACE ME: describe why this path is irreversible once applied"
+    },
+    {
+      "id": "example-security-surface",
+      "startsWith": ["<path-to-your-auth-or-security-dir>/"],
+      "endsWith": [".guard.ts"],
+      "dims": { "blast": "high" },
+      "deep": ["<your-deep-verify-command, e.g. verify:auth>"],
+      "why": "REPLACE ME: describe the invariant this surface protects"
+    },
+    {
+      "id": "example-outbound-side-effect",
+      "startsWith": ["<path-to-your-notification-or-payment-dir>/"],
+      "dims": { "blast": "high" },
+      "why": "REPLACE ME: describe the real-world effect this surface triggers (sends a message, charges a card, etc.)"
+    },
+    {
+      "id": "harness",
+      "startsWith": [".claude/", "tools/", ".husky/", ".loop/", "docs/adr/"],
+      "exact": ["CLAUDE.md", "risk-rules.json"],
+      "excludeStartsWith": [".loop/lessons/"],
+      "dims": { "blast": "high" },
+      "why": "harness/constitution layer — silently weakening the gate itself must not be low-risk. Keep 'risk-rules.json' in exact even after you rename/move this file locally, so this self-coverage property survives."
+    },
+    {
+      "id": "ci-deploy-infra",
+      "startsWith": [".github/", "<path-to-your-deploy-scripts>/", "infra/"],
+      "dims": { "blast": "high" },
+      "why": "CI/deploy/infra pipeline itself"
+    },
+    {
+      "id": "workspace-root",
+      "exact": ["package.json", "<your-workspace-lockfile>"],
+      "dims": { "blast": "high" },
+      "why": "workspace-root config — affects every package"
+    }
+  ],
+  "commandRules": [
+    {
+      "id": "cmd-irreversible",
+      "patterns": [
+        "\\bgh\\s+pr\\s+merge\\b",
+        "\\bgit\\s+push\\b[^|;&]*\\b(<your-protected-branches, e.g. main|develop>)\\b",
+        "<your-deploy-command-pattern>"
+      ],
+      "dims": { "revers": "none" },
+      "why": "deploy/merge commands — change shared state the moment they run"
+    }
+  ]
+}

--- a/tools/loop-engine/test/classify-risk-rules.test.sh
+++ b/tools/loop-engine/test/classify-risk-rules.test.sh
@@ -13,10 +13,15 @@
 #     empty-rules fallback — a rules file the tool couldn't read must not under-report risk,
 # (6) a --rules path that does not exist is also a loud usage error, not a silent fallback,
 # (7) excludeStartsWith carves an exception out of a broader startsWith match.
+# (8) templates/risk-rules.example.json (BAC-757, shape-only starter for a consuming repo) is itself
+#     valid, self-covering (its own harness rule matches "risk-rules.json" — the same self-coverage
+#     idea as a consuming repo's own verify-loop-wiring "harness-covers-risk-rules-json" case), and
+#     its per-rule deep-gate lists are locked so a future edit can't silently drop one.
 set -uo pipefail
 HERE="$(cd "$(dirname "$0")" && pwd)"
 ROOT="$HERE/../../.."
 CR="$ROOT/tools/loop-engine/bin/classify-risk.mjs"
+EXAMPLE_RULES="$ROOT/tools/loop-engine/templates/risk-rules.example.json"
 
 fail() { echo "FAIL: $1"; exit 1; }
 [ -f "$CR" ] || fail "classify-risk.mjs not found at $CR"
@@ -103,5 +108,44 @@ OUT_EX="$(node "$CR" --path ".loop/lessons/foo.json" --rules "$DIR/exclude-rules
 echo "$OUT_EX" | grep -q "harness-like" && fail "excludeStartsWith must carve out the excluded prefix, got: $OUT_EX"
 echo "$OUT_EX" | grep -q "app-code-low-risk-baseline" || fail "the excluded path must fall through to the low-risk baseline, got: $OUT_EX"
 echo "PASS: excludeStartsWith carves an exception out of a broader startsWith match"
+
+# ── 8) templates/risk-rules.example.json — self-coverage, deep-gates locked, structurally sound ─
+[ -f "$EXAMPLE_RULES" ] || fail "templates/risk-rules.example.json not found at $EXAMPLE_RULES"
+node -e 'JSON.parse(require("fs").readFileSync(process.argv[1], "utf8"))' "$EXAMPLE_RULES" \
+  || fail "templates/risk-rules.example.json is not valid JSON"
+
+OUT_SELF="$(node "$CR" --path "risk-rules.json" --rules "$EXAMPLE_RULES" --no-gate 2>&1)"
+echo "$OUT_SELF" | grep -q "MATCHED: harness" || fail "the example template's own harness rule must match a change to risk-rules.json itself, got: $OUT_SELF"
+echo "$OUT_SELF" | grep -q "blast_radius=high" || fail "a self-covering harness match must raise blast=high, got: $OUT_SELF"
+echo "PASS: templates/risk-rules.example.json's harness rule covers risk-rules.json itself (self-coverage)"
+
+OUT_CLAUDE="$(node "$CR" --path "CLAUDE.md" --rules "$EXAMPLE_RULES" --no-gate 2>&1)"
+echo "$OUT_CLAUDE" | grep -q "MATCHED: harness" || fail "the example template's harness rule must also cover CLAUDE.md, got: $OUT_CLAUDE"
+echo "PASS: templates/risk-rules.example.json's harness rule also covers CLAUDE.md"
+
+node -e '
+  const rules = JSON.parse(require("fs").readFileSync(process.argv[1], "utf8"));
+  const byId = Object.fromEntries(rules.pathRules.map((r) => [r.id, r.deep ?? []]));
+  const expected = {
+    "example-irreversible-migration": ["<your-deep-verify-command, e.g. verify:db>"],
+    "example-security-surface": ["<your-deep-verify-command, e.g. verify:auth>"],
+    "example-outbound-side-effect": [],
+    harness: [],
+    "ci-deploy-infra": [],
+    "workspace-root": [],
+  };
+  for (const [id, want] of Object.entries(expected)) {
+    const got = byId[id];
+    if (got === undefined) throw new Error(`rule id missing from example template: ${id}`);
+    if (JSON.stringify(got) !== JSON.stringify(want))
+      throw new Error(`rule ${id} deep gates changed — want ${JSON.stringify(want)}, got ${JSON.stringify(got)}`);
+  }
+  for (const r of rules.pathRules) {
+    for (const g of r.deep ?? []) {
+      if (typeof g !== "string" || !g.trim()) throw new Error(`rule ${r.id} has an empty/non-string deep-gate entry`);
+    }
+  }
+' "$EXAMPLE_RULES" || fail "templates/risk-rules.example.json per-rule deep-gate lists changed unexpectedly or are malformed"
+echo "PASS: templates/risk-rules.example.json's per-rule deep-gate lists are locked and structurally sound"
 
 exit 0

--- a/tools/loop-engine/test/skill-frontmatter-bac757.test.sh
+++ b/tools/loop-engine/test/skill-frontmatter-bac757.test.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# BAC-757 — locks ship-flow's skill frontmatter modernization: `context: fork` on skills confirmed
+# self-contained (verified by reading each SKILL.md end-to-end — no live AskUserQuestion call or
+# "confirm/ask the user"-style mid-flow checkpoint whose answer the rest of that same run depends on),
+# and its ABSENCE on skills that genuinely interview the user mid-flow (a forked subagent's questions
+# never reach the user — see the Agent tool's own fork semantics). Also locks that `setup` points a
+# repo at the new risk-rules.example.json template.
+#
+# Fork-safe (produce a report/result and hand it back; any "ask a human" moment is async — surface a
+# candidate list for a LATER, separate review, not a live blocking question this same run needs
+# answered to continue): deps-audit, retrospect, resolving-merge-conflicts.
+# NOT fork-safe (a literal AskUserQuestion call, or a "confirm with the user"/"ask the user" step this
+# same run blocks on before continuing): setup, grill-with-docs, to-issues (the three the issue itself
+# names), hotfix (3x AskUserQuestion approval gates), ship-feature (config-fallback question — also the
+# plugin's own top-level entrypoint, so forking it doesn't make architectural sense either way),
+# harness-maturity-audit ("ask what they want next" branches the rest of the run), improve-codebase-
+# architecture ("ask the user: which of these would you like to explore?"), tdd ("confirm with user"
+# interface/behavior checkpoint gates writing any code), to-prd ("check with the user" seam-confirmation
+# step gates publishing).
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+SKILLS="$HERE/../../ship-flow/skills"
+SETUP="$SKILLS/setup/SKILL.md"
+
+fail() { echo "FAIL: $1"; exit 1; }
+
+FORK_SAFE="deps-audit retrospect resolving-merge-conflicts"
+NOT_FORK_SAFE="setup grill-with-docs to-issues hotfix ship-feature harness-maturity-audit improve-codebase-architecture tdd to-prd"
+
+for name in $FORK_SAFE; do
+  f="$SKILLS/$name/SKILL.md"
+  [ -f "$f" ] || fail "missing skill file: $f"
+  grep -q '^context: fork$' "$f" || fail "$name/SKILL.md must declare context: fork (confirmed self-contained, no mid-flow user question)"
+done
+echo "PASS: fork-safe skills ($FORK_SAFE) all declare context: fork"
+
+for name in $NOT_FORK_SAFE; do
+  f="$SKILLS/$name/SKILL.md"
+  [ -f "$f" ] || fail "missing skill file: $f"
+  grep -q '^context: fork$' "$f" && fail "$name/SKILL.md must NOT declare context: fork — it asks the user something mid-flow, which a fork can never surface"
+done
+echo "PASS: interactive skills ($NOT_FORK_SAFE) correctly do NOT declare context: fork"
+
+# risk-rules.example.json guidance wired into setup
+[ -f "$SETUP" ] || fail "missing file: $SETUP"
+grep -qi 'risk-rules.example.json' "$SETUP" || fail "setup SKILL.md must offer templates/risk-rules.example.json"
+grep -qi 'self-covering' "$SETUP" || fail "setup SKILL.md must call out the example template's self-coverage property (so a repo copy doesn't silently drop it)"
+echo "PASS: setup SKILL.md offers risk-rules.example.json and calls out its self-coverage property"
+
+exit 0

--- a/tools/loop-memory/.claude-plugin/plugin.json
+++ b/tools/loop-memory/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "loop-memory",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "pgvector semantic recall for verified dev-loop lessons (and, optionally, ADR/glossary/research knowledge). Opt-in: installs disabled by default — this is a database dependency, not core loop mechanics.",
   "author": {
     "name": "paulkim-lansik"
@@ -10,7 +10,7 @@
   "license": "MIT",
   "keywords": ["memory", "pgvector", "recall", "semantic-search", "lessons"],
   "defaultEnabled": false,
-  "dependencies": [{ "name": "loop-engine", "version": "^0.7.0" }],
+  "dependencies": [{ "name": "loop-engine", "version": "^0.8.0" }],
   "userConfig": {
     "openai_api_key": {
       "type": "string",

--- a/tools/ship-flow/.claude-plugin/plugin.json
+++ b/tools/ship-flow/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ship-flow",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "description": "Delivery-loop skills — land and release already-verified work through a repo's real gates. Tracker- and branch-model-agnostic: reads a consuming repo's own config instead of hardcoding one repo's setup.",
   "author": {
     "name": "paulkim-lansik"
@@ -10,6 +10,6 @@
   "license": "MIT",
   "keywords": ["delivery", "git-flow", "hotfix", "ship", "release"],
   "dependencies": [
-    { "name": "loop-engine", "version": "^0.7.0" }
+    { "name": "loop-engine", "version": "^0.8.0" }
   ]
 }

--- a/tools/ship-flow/skills/deps-audit/SKILL.md
+++ b/tools/ship-flow/skills/deps-audit/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: deps-audit
 description: Maintenance check for installed Claude Code extensions (marketplace plugins, skills.sh skills, gstack, and repo-embedded skills). Produces one report answering whether upstream is still maintained, whether the local install is current, and what's unused. Use when the user asks to audit or clean up skills/plugins, find unused skills, check whether things are up to date, check for divergence, or when a weekly heartbeat nudges.
+context: fork
 ---
 
 # deps-audit — extension maintenance dashboard

--- a/tools/ship-flow/skills/resolving-merge-conflicts/SKILL.md
+++ b/tools/ship-flow/skills/resolving-merge-conflicts/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: resolving-merge-conflicts
 description: "Use when you need to resolve an in-progress git merge/rebase conflict."
+context: fork
 ---
 
 1. **See the current state** of the merge/rebase. Check git history, and the conflicting files.

--- a/tools/ship-flow/skills/retrospect/SKILL.md
+++ b/tools/ship-flow/skills/retrospect/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: retrospect
 description: Turn loop outcomes into a verified-lessons memory — record what fixed a failure, recall it next time, and promote recurring lessons into skills/guidelines. Use when the user wants the loop to learn from past runs, capture a fix as a reusable lesson, see why runs keep failing, or decide what to codify into a skill or CLAUDE.md.
+context: fork
 ---
 
 # retrospect — the learning layer (verified lessons)

--- a/tools/ship-flow/skills/setup/SKILL.md
+++ b/tools/ship-flow/skills/setup/SKILL.md
@@ -120,6 +120,16 @@ the rest of this repo's ship-flow config, and pass it through wherever `check-pr
 invoked (the `ci.yml` job above, and `ship-feature`/`publisher`'s own PR-body composition step, if this
 repo wants the same check enforced before a PR is even opened).
 
+Offer `${CLAUDE_PLUGIN_ROOT}/templates/risk-rules.example.json` too, if this repo doesn't already have a
+`risk-rules.json` at its root — `classify-risk.mjs` ships zero product-specific rules on purpose
+(BAC-698/BAC-563 C5), so without one, this plugin's risk gating only ever sees its structural baselines
+(docs-only, low-file-count, etc.) and every domain-specific path (migrations, auth, outbound sends) goes
+unclassified. This is reference material to adapt by hand, not something to copy verbatim — every
+placeholder path needs replacing with this repo's real ones. Point out that the template's `harness`
+rule is self-covering by design (it matches `risk-rules.json` itself, so silently weakening a rule and
+the file that defines rules in the same PR still gets flagged) — the copy should keep that property, not
+drop it while filling in the other placeholders.
+
 ### 5. Offer branch protection — human stop point, always
 **Never run `templates/branch-protect.sh` without an explicit `AskUserQuestion` confirmation first,
 every time** — this changes a real GitHub repo setting, and a past "yes" to a different question isn't


### PR DESCRIPTION
## Summary
- **`context: fork`** added to 3 ship-flow skills confirmed self-contained by reading each SKILL.md end-to-end: `deps-audit`, `retrospect`, `resolving-merge-conflicts`. None of the three block mid-run on a live user question — any "get a human's OK" moment is async (produce a report/candidate list for a *later*, separate review).
- **Explicitly withheld** from the other 9 skills, each of which has a load-bearing mid-flow checkpoint a fork could never surface (a forked subagent's questions never reach the user): `setup`, `grill-with-docs`, `to-issues` (the three the issue itself named — interview/quiz skills), plus `hotfix` (3× `AskUserQuestion` merge/bypass/deploy gates), `ship-feature` (config-fallback question + it's the plugin's own top-level entrypoint), `harness-maturity-audit` ("ask what they want next" branches the run), `improve-codebase-architecture` ("ask the user: which of these would you like to explore?"), `tdd` ("confirm with user" interface/behavior checkpoint gates writing any code), `to-prd` ("check with the user" seam-confirmation gates publishing). These weren't assumed — found via `grep` + full read of each file.
- **`allowed-tools`/`paths` deliberately NOT added** this pass, verified rather than assumed: dispatched a live doc-check confirming `allowed-tools` is a non-restrictive pre-approval hint only (cleared every turn, can't break a skill even incomplete) — but ship-flow skills route Bash through "however this repo invokes its bin scripts" (genuinely consuming-repo-agnostic), so a literal command-pattern list is either wrong per-repo or so broad it adds no precision. `paths` doesn't semantically fit any of these 12 skills — they're all intent-triggered, not file-path-triggered like glucofit-partners' `design-sync`/`partners-web-design`. Full rationale in CHANGELOG.
- New `tools/loop-engine/templates/risk-rules.example.json` — a shape-only `classify-risk.mjs` rule-table starter (the plugin ships zero product-specific rules by design, BAC-698/BAC-563 C5). Its `harness` rule is self-covering by construction (matches `risk-rules.json` itself) — live-tested against `classify-risk.mjs` before writing the regression test, not just eyeballed.
- `setup`'s step 4 now offers this template alongside the other optional scaffolding, calling out the self-coverage property so a repo's copy doesn't silently drop it while filling in placeholders.
- Version bumps: `loop-engine` 0.7.1→0.8.0 (minor — new template asset). `ship-flow` 0.2.8→0.2.9, dependency range `^0.7.0`→`^0.8.0` (joint-constraint). `loop-memory` 0.2.5→0.2.6, same dependency bump, no content change.

## Test plan
- [x] `bash tools/loop-engine/test/skill-frontmatter-bac757.test.sh` — locks the fork/no-fork split for all 12 skills + setup's risk-rules.example.json guidance
- [x] `bash tools/loop-engine/test/classify-risk-rules.test.sh` — new case (8): example template is valid JSON, self-covers (`risk-rules.json` and `CLAUDE.md` both match, both raise `blast=high`), per-rule `deep` gates locked
- [x] `bash tools/loop-engine/test/run.sh` — 42/42 test files pass
- [x] `claude plugin validate --strict` on all three plugins — pass
- [x] `grep -rn '"loop-engine"' --include=plugin.json .` — dependency ranges consistent (`^0.8.0` everywhere)

BAC-757

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016y2zUZBrhEkwJyQx8nNC1Y