### PR TITLE
fix(loop-memory): hooks load the repo's .env before the key gate — silent no-op fixed (0.3.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -26,7 +26,7 @@
       "name": "loop-memory",
       "source": "./tools/loop-memory",
       "description": "pgvector semantic recall for verified dev-loop lessons (and, optionally, ADR/glossary/research knowledge). Opt-in / defaultEnabled:false — a database dependency, not core loop mechanics.",
-      "version": "0.2.6",
+      "version": "0.3.0",
       "defaultEnabled": false,
       "keywords": ["memory", "pgvector", "recall", "semantic-search", "lessons"]
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,34 @@ Explicit-version channel — see [README § Development status](README.md#develo
 not a SHA channel. Entries below `## loop-engine 0.2.0` and earlier predate the multi-plugin split
 and refer to `loop-engine` only (see the un-prefixed version numbers).
 
+## loop-memory 0.3.0
+
+- **Fixes a silent no-op**: both hooks read the embedding key from the process env only, but Claude
+  Code hands a hook the *session process env* — it never loads `.env` files. A repo keeping its key
+  in a gitignored `.env` (the normal way to hold a secret that must not be committed) and not
+  `export`ing it therefore tripped each hook's own no-key gate: recall and graduation were both dead,
+  with no error anywhere. The plugin now loads a dotenv-shaped file itself, before that gate
+  (`hooks/lib/load-dotenv.mjs`, dependency-free), so no consuming repo needs to carry a local loader
+  hook — which is how the capability got lost in the first place, when a repo dropped its local hook
+  copies in favour of this plugin.
+- New `loop_dotenv_path` userConfig option (env `LOOP_DOTENV_PATH`), default `.loop/.env` — the file's
+  location is a per-repo layout question, so it's configurable rather than assumed. Precedence is
+  session env > userConfig > file; a key already set is never overwritten. Every key in the file is
+  loaded, not only the ones with a matching userConfig option (so `LOOP_EMBED_PROVIDER` and friends
+  reach the CLI from the file too).
+- Worktree fallback: a gitignored `.env` does not exist in a freshly-created feature worktree, which
+  is exactly where an isolated agent loop runs. If the configured path is missing there, the *main*
+  worktree's copy is read instead (`git rev-parse --git-common-dir`). Nothing is copied — the key
+  stays untracked and in one place. Without this the plugin fails closed in every worktree, which is
+  how this same failure class stayed invisible for six weeks in the plugin's origin repo.
+- Loading stays best-effort: a missing/unreadable file, or a non-git directory, leaves the env
+  untouched and the hooks return to their normal fail-open no-op.
+- New `test/hooks-dotenv.test.ts` (11 tests) exercising the **real hook processes**, not the loader in
+  isolation: key-from-file reaches the gate (both hooks), session env and userConfig each beat the
+  file, custom path honoured, quoting/`export`/inline-comment parsing, missing file → clean no-op,
+  directory-instead-of-file → no throw, worktree fallback resolves, a worktree's own `.env` preferred
+  over the main one's, non-git directory → clean no-op.
+
 ## loop-engine 0.8.0
 
 - New `templates/risk-rules.example.json` (BAC-757) — a shape-only starter for `classify-risk.mjs`'s

--- a/README.md
+++ b/README.md
@@ -187,8 +187,30 @@ interactively via `/plugin configure loop-memory@paul-loop`:
 | `openai_api_key` / `gemini_api_key` | no (but you need at least one) | `sensitive: true` — stored in the OS keychain / `~/.claude/.credentials.json`, never in `settings.json`. Without either key both hooks no-op. |
 | `loop_database_url` | no | Defaults to `postgresql://postgres:postgres@localhost:5434/loop_memory` — this plugin's `docker-compose.yml` matches that default (`docker compose up -d --wait` from `tools/loop-memory/`). |
 | `loop_memory_signing_key` | no | HMAC-SHA256 secret. Without it, lesson writes are unsigned and lesson recall stays fail-closed (returns nothing) — see "Threat model" below. `sensitive: true`. |
+| `loop_dotenv_path` | no | Repo-relative (or absolute) dotenv-shaped file the hooks read **before** their key gate. Default `.loop/.env`. See "Keys that live in a `.env`" below. |
 | `loop_adr_dir` / `loop_context_file` / `loop_research_dir` / `loop_design_dir` | no | Optional *knowledge* corpus sources (separate from lessons) — a directory of `# ADR-NNNN: Title`-headed decision docs, a single `**Term**:`-chunked glossary file, and two `##`-section-chunked doc directories, respectively. Unset = that source is skipped entirely; nothing is assumed about your repo's docs unless you point at them. |
 | `loop_recall_max_distance` / `loop_knowledge_max_distance` | no | Cosine-distance cutoffs (0=identical..2=opposite) for the lessons and knowledge corpora respectively — a hit farther than this is dropped instead of injected. **Embedder-dependent**, calibrate for your provider/corpus; the code default (0.65) is a loose safety net if left unset. |
+
+### Keys that live in a `.env`
+
+Claude Code hands a hook the **session process env** — it does not load `.env` files. A repo that
+keeps its embedding key in a gitignored `.env` and never `export`s it to the shell would therefore
+trip both hooks' own no-key gate and no-op *silently*: no recall, no graduation, no error. So the
+hooks load a dotenv-shaped file themselves, before that gate:
+
+- **Path**: `loop_dotenv_path` (default `.loop/.env`, repo-relative; absolute paths work too). If
+  your key is at, say, `packages/loop-memory/.env`, set the option — the default is a guess, not a
+  discovery mechanism.
+- **Precedence**: session env > `userConfig` > file. A key already set is never overwritten.
+- **Worktree fallback**: a gitignored `.env` doesn't exist in a freshly-created feature worktree —
+  which is exactly where an isolated agent loop runs. If the path is missing there, the *main*
+  worktree's copy is read instead (resolved via `git rev-parse --git-common-dir`). Nothing is
+  copied; the key stays untracked and in one place.
+- **Best-effort**: a missing/unreadable file, or a non-git directory, leaves the env untouched and
+  the hooks fall back to their normal fail-open no-op.
+
+Every key in the file is loaded, not just the ones with a matching `userConfig` option — so
+`LOOP_EMBED_PROVIDER` and friends reach the CLI from the file too.
 
 ### Threat model — write-path provenance
 
@@ -257,6 +279,7 @@ tools/ship-flow/                  # delivery-loop skills — see the plugin's ow
 tools/loop-memory/
   .claude-plugin/plugin.json      # this plugin's manifest — defaultEnabled:false, userConfig schema
   hooks/                          # SessionStart (graduate) + UserPromptSubmit (recall), plus hooks.json
+  hooks/lib/                      # helpers the hooks import (dotenv loader) — plain JS, no deps
   src/                            # TypeScript source (drizzle schema, CLI, embedder seam)
   dist/cli.js                     # committed, dependency-free esbuild bundle — what hooks actually run
   drizzle/                        # pgvector schema migrations

--- a/tools/loop-memory/.claude-plugin/plugin.json
+++ b/tools/loop-memory/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "loop-memory",
-  "version": "0.2.6",
+  "version": "0.3.0",
   "description": "pgvector semantic recall for verified dev-loop lessons (and, optionally, ADR/glossary/research knowledge). Opt-in: installs disabled by default — this is a database dependency, not core loop mechanics.",
   "author": {
     "name": "paulkim-lansik"
@@ -37,6 +37,12 @@
       "title": "Write-path signing key",
       "description": "HMAC-SHA256 secret that signs graduated lesson notes (defends against memory poisoning of untrusted write paths — see README \"Threat model\"). Without it, lesson writes are unsigned and lesson recall stays fail-closed (returns nothing); the knowledge corpus is unaffected.",
       "sensitive": true,
+      "required": false
+    },
+    "loop_dotenv_path": {
+      "type": "string",
+      "title": "Dotenv file the hooks load keys from",
+      "description": "Repo-relative (or absolute) path to a dotenv-shaped file the hooks read before their embedding-key gate — Claude Code hands hooks the session process env only and never loads .env files, so a key that lives solely in an (unexported, gitignored) .env would otherwise make both hooks no-op silently. Values already set in the session env or via the options above always win. Default (if unset): .loop/.env. If the path is missing in a feature worktree, the main worktree's copy is used (a gitignored .env is never copied into a new worktree).",
       "required": false
     },
     "loop_adr_dir": {

--- a/tools/loop-memory/.env.example
+++ b/tools/loop-memory/.env.example
@@ -3,6 +3,11 @@
 # (see README "What's in loop-memory" — plugin.json's userConfig, Keychain-backed for sensitive keys),
 # not this file — hooks bridge Claude Code's CLAUDE_PLUGIN_OPTION_<KEY> injection into these same
 # plain env var names, so the CLI itself doesn't need to know about plugins at all.
+#
+# A *consuming repo* may also keep a gitignored file in exactly this shape (default location:
+# `.loop/.env`) — the hooks load it into the CLI's env before their embedding-key gate, so a key that
+# was never exported to the shell still works. Point the `loop_dotenv_path` option at it if it lives
+# somewhere else. Session env and userConfig values always win over the file.
 
 # Dedicated loop-memory DB (separate pgvector container). See docker-compose.yml.
 LOOP_DATABASE_URL=postgresql://postgres:postgres@localhost:5434/loop_memory

--- a/tools/loop-memory/hooks/graduate-lessons.mjs
+++ b/tools/loop-memory/hooks/graduate-lessons.mjs
@@ -12,6 +12,7 @@
 import { spawnSync } from 'node:child_process';
 import { appendFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { loadDotenv } from './lib/load-dotenv.mjs';
 
 const env = process.env;
 const projectDir = env.CLAUDE_PROJECT_DIR || process.cwd();
@@ -36,9 +37,16 @@ for (const [pluginOpt, plain] of [
   ['CLAUDE_PLUGIN_OPTION_GEMINI_API_KEY', 'GEMINI_API_KEY'],
   ['CLAUDE_PLUGIN_OPTION_LOOP_DATABASE_URL', 'LOOP_DATABASE_URL'],
   ['CLAUDE_PLUGIN_OPTION_LOOP_MEMORY_SIGNING_KEY', 'LOOP_MEMORY_SIGNING_KEY'],
+  ['CLAUDE_PLUGIN_OPTION_LOOP_DOTENV_PATH', 'LOOP_DOTENV_PATH'],
 ]) {
   if (!childEnv[plain] && env[pluginOpt]) childEnv[plain] = env[pluginOpt];
 }
+// Then the repo's gitignored dotenv file, for keys neither the session env nor userConfig supplied
+// (Claude Code passes hooks the session process env only — it does not read .env files, so a key that
+// lives solely in .env would hit the no-key gate below and no-op silently). Runs *after* the bridge
+// above so the file never overrides an explicit export or userConfig value.
+const dotenv = loadDotenv(projectDir, childEnv.LOOP_DOTENV_PATH, childEnv);
+dbg(dotenv ? `dotenv: loaded ${dotenv}` : 'dotenv: none found');
 // Source tag (paul-loop issue #35) — self-reported, good-faith metadata for observability/debugging,
 // NOT a security or forgery-proof signal. Anyone with shell access can run `node dist/cli.js graduate`
 // directly and set this same env var by hand, at the same trust level as querying the database

--- a/tools/loop-memory/hooks/lib/load-dotenv.mjs
+++ b/tools/loop-memory/hooks/lib/load-dotenv.mjs
@@ -1,0 +1,94 @@
+// Loads a dotenv-shaped file into a hook's child-env object.
+//
+// Why this exists: Claude Code hands a hook the *session process env* — it does not load `.env` files.
+// A repo that keeps its embedding key in a gitignored `.env` (the normal way to hold a secret that
+// must not be committed) and never `export`s it to the shell therefore hits both hooks' own
+// no-key gate, and recall/graduate no-op **silently**. That failure mode already burned this
+// plugin's origin repo once for six weeks, so the loader ships *with the plugin* rather than being
+// something each consuming repo has to re-implement as a local hook.
+//
+// Contract (all three properties are load-bearing — see test/hooks-dotenv.test.ts):
+//   1. Never overwrite a key already present in `target` — an explicit shell/session export, and the
+//      `CLAUDE_PLUGIN_OPTION_*` userConfig bridge the hooks run first, both outrank the file.
+//   2. Worktree fallback: a gitignored `.env` does not exist in a freshly-created feature worktree,
+//      which is exactly where an isolated agent loop runs. If the primary path is missing, resolve the
+//      *main* worktree via `git rev-parse --git-common-dir` and read its copy instead. Without this,
+//      every worktree fails closed. No file is copied — the key stays untracked, in one place.
+//   3. Best-effort: any failure (missing file, unreadable, non-git, no git binary) leaves `target`
+//      untouched and returns null. A hook must never break a session over its own optional config.
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { basename, dirname, isAbsolute, resolve } from 'node:path';
+
+/** Repo-relative default. `.loop/` is loop-engine's own convention directory (it already holds
+ * `.loop/lessons`) and is conventionally gitignored, so `.loop/.env` is the one path that is a
+ * sensible guess for *any* consuming repo. Repos that keep the file elsewhere point the
+ * `loop_dotenv_path` plugin option (env `LOOP_DOTENV_PATH`) at it. */
+export const DEFAULT_DOTENV_PATH = '.loop/.env';
+
+/** Absolute path of the main worktree, via `git rev-parse --git-common-dir`. null if not a git repo,
+ * git is missing/slow, or the common dir isn't a `.git` directory (i.e. nothing to fall back to). */
+function mainWorktreeRoot(cwd) {
+  try {
+    const out = execFileSync('git', ['rev-parse', '--git-common-dir'], {
+      cwd,
+      encoding: 'utf8',
+      timeout: 3000,
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+    if (!out) return null;
+    const commonDir = resolve(cwd, out);
+    // The main worktree's `.git` is a directory (= commonDir itself) — its parent is that worktree's root.
+    return basename(commonDir) === '.git' ? dirname(commonDir) : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Resolves the dotenv file to read, applying the worktree fallback (property 2 above).
+ * Returns null when nothing readable exists. An absolute `configured` path is used as-is (a path
+ * outside the project has no "main worktree" counterpart to fall back to). */
+export function resolveDotenvPath(projectDir, configured) {
+  const rel = configured || DEFAULT_DOTENV_PATH;
+  if (isAbsolute(rel)) return existsSync(rel) ? rel : null;
+  const local = resolve(projectDir, rel);
+  if (existsSync(local)) return local;
+  const mainRoot = mainWorktreeRoot(projectDir);
+  if (!mainRoot) return null;
+  const fallback = resolve(mainRoot, rel);
+  return existsSync(fallback) ? fallback : null;
+}
+
+/** Fills `target` with the `KEY=VALUE` lines of the resolved dotenv file, skipping keys already set.
+ * Returns the path actually read, or null if nothing was loaded (so callers can log which it was —
+ * "silently loaded nothing" and "silently found nothing" must be distinguishable in the debug log). */
+export function loadDotenv(projectDir, configured, target = process.env) {
+  try {
+    const file = resolveDotenvPath(projectDir, configured);
+    if (!file) return null;
+    for (const raw of readFileSync(file, 'utf8').split('\n')) {
+      const line = raw.trim(); // also drops CRLF's \r
+      if (!line || line.startsWith('#')) continue; // blank / comment line
+      const eq = line.indexOf('='); // split on the FIRST '=' only — values may contain '='
+      if (eq < 1) continue;
+      const key = line
+        .slice(0, eq)
+        .replace(/^export\s+/, '')
+        .trim(); // tolerate `export KEY=...`
+      if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key) || key in target) continue; // already set: file loses
+      let val = line.slice(eq + 1).trim();
+      const q = val[0];
+      if (q === '"' || q === "'") {
+        const end = val.indexOf(q, 1); // value ends at the closing quote (trailing inline comment ignored)
+        val = end === -1 ? val.slice(1) : val.slice(1, end);
+      } else {
+        const c = val.search(/\s#/); // unquoted `val # comment` — strip the comment
+        if (c !== -1) val = val.slice(0, c).trim();
+      }
+      target[key] = val;
+    }
+    return file;
+  } catch {
+    return null; // best-effort: the caller's own key gate handles "still no key"
+  }
+}

--- a/tools/loop-memory/hooks/recall-lessons.mjs
+++ b/tools/loop-memory/hooks/recall-lessons.mjs
@@ -14,6 +14,7 @@
 import { spawn, spawnSync } from 'node:child_process';
 import { appendFileSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { loadDotenv } from './lib/load-dotenv.mjs';
 
 const env = process.env;
 const projectDir = env.CLAUDE_PROJECT_DIR || process.cwd();
@@ -65,9 +66,16 @@ try {
     ['CLAUDE_PLUGIN_OPTION_LOOP_MEMORY_SIGNING_KEY', 'LOOP_MEMORY_SIGNING_KEY'],
     ['CLAUDE_PLUGIN_OPTION_LOOP_RECALL_MAX_DISTANCE', 'LOOP_RECALL_MAX_DISTANCE'],
     ['CLAUDE_PLUGIN_OPTION_LOOP_KNOWLEDGE_MAX_DISTANCE', 'LOOP_KNOWLEDGE_MAX_DISTANCE'],
+    ['CLAUDE_PLUGIN_OPTION_LOOP_DOTENV_PATH', 'LOOP_DOTENV_PATH'],
   ]) {
     if (!childEnv[plain] && env[pluginOpt]) childEnv[plain] = env[pluginOpt];
   }
+  // Then the repo's gitignored dotenv file, for keys neither the session env nor userConfig supplied
+  // (Claude Code passes hooks the session process env only — it does not read .env files, so a key
+  // that lives solely in .env would hit the no-key gate below and no-op silently). Runs *after* the
+  // bridge above so the file never overrides an explicit export or userConfig value.
+  const dotenv = loadDotenv(projectDir, childEnv.LOOP_DOTENV_PATH, childEnv);
+  dbg(dotenv ? `dotenv: loaded ${dotenv}` : 'dotenv: none found');
   // Source tag (paul-loop issue #35) — self-reported, good-faith metadata for observability/debugging,
   // NOT a security or forgery-proof signal. Anyone with shell access can run the CLI directly and set
   // this same env var by hand, at the same trust level as querying the database directly — there is

--- a/tools/loop-memory/test/hooks-dotenv.test.ts
+++ b/tools/loop-memory/test/hooks-dotenv.test.ts
@@ -1,0 +1,257 @@
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+// Regression: both hooks read the embedding key from the process env only, but Claude Code hands a
+// hook the *session process env* — it never loads `.env` files. A repo holding its key in a
+// gitignored `.env` therefore tripped each hook's own no-key gate and no-op'd **silently**: no
+// semantic recall, no lesson graduation, no error anywhere. These tests exercise the real hook
+// processes (not the loader in isolation) so what's locked is "the key reaches the gate", which is
+// the property that was actually broken.
+const GRADUATE = join(__dirname, '..', 'hooks', 'graduate-lessons.mjs');
+const RECALL = join(__dirname, '..', 'hooks', 'recall-lessons.mjs');
+
+let base: string;
+let pluginRoot: string;
+let dataDir: string;
+let projectDir: string;
+
+/** Fake `dist/cli.js` — the hooks spawn this; it dumps the env it was given, per subcommand, so a
+ * test can assert both *that* the gate let it run and *what* env crossed over. */
+function writeFakeCli(root = pluginRoot) {
+  mkdirSync(join(root, 'dist'), { recursive: true });
+  writeFileSync(
+    join(root, 'dist', 'cli.js'),
+    [
+      "const fs = require('node:fs');",
+      "const sub = process.argv[2] || 'none';",
+      'fs.writeFileSync(`${process.env.TEST_ENV_DUMP}.${sub}.json`, JSON.stringify(process.env));',
+      // recall parses a single-line JSON object off stdout; distance 0.1 is inside the 0.65 default cutoff.
+      "if (sub === 'recall')",
+      "  process.stdout.write(JSON.stringify({ lessons: [{ id: 'l1', content: 'a recalled lesson', distance: 0.1 }], knowledge: [] }) + '\\n');",
+      'process.exit(0);',
+    ].join('\n'),
+  );
+}
+
+function dumpPath(sub: string) {
+  return join(dataDir, `cli-env.${sub}.json`);
+}
+
+/** The env a spawned CLI actually saw, or null if the hook's gate never spawned it. */
+function spawnedEnv(sub: string): Record<string, string> | null {
+  try {
+    return JSON.parse(readFileSync(dumpPath(sub), 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+function writeDotenv(dir: string, relPath: string, body: string) {
+  const full = join(dir, relPath);
+  mkdirSync(join(full, '..'), { recursive: true });
+  writeFileSync(full, body);
+}
+
+function runGraduate(extraEnv: Record<string, string> = {}, cwd = projectDir) {
+  return spawnSync('node', [GRADUATE], {
+    cwd,
+    encoding: 'utf8',
+    env: {
+      PATH: process.env.PATH,
+      CLAUDE_PLUGIN_ROOT: pluginRoot,
+      CLAUDE_PLUGIN_DATA: dataDir,
+      CLAUDE_PROJECT_DIR: cwd,
+      TEST_ENV_DUMP: join(dataDir, 'cli-env'),
+      ...extraEnv,
+    } as NodeJS.ProcessEnv,
+  });
+}
+
+function runRecall(extraEnv: Record<string, string> = {}, cwd = projectDir) {
+  return spawnSync('node', [RECALL], {
+    cwd,
+    encoding: 'utf8',
+    input: JSON.stringify({ user_input: 'a prompt long enough to pass the length gate' }),
+    env: {
+      PATH: process.env.PATH,
+      CLAUDE_PLUGIN_ROOT: pluginRoot,
+      CLAUDE_PLUGIN_DATA: dataDir,
+      CLAUDE_PROJECT_DIR: cwd,
+      TEST_ENV_DUMP: join(dataDir, 'cli-env'),
+      ...extraEnv,
+    } as NodeJS.ProcessEnv,
+  });
+}
+
+describe('hooks — .env loading before the embedding-key gate', () => {
+  beforeEach(() => {
+    base = mkdtempSync(join(tmpdir(), 'loop-memory-dotenv-'));
+    pluginRoot = join(base, 'plugin');
+    dataDir = join(base, 'data');
+    projectDir = join(base, 'project');
+    mkdirSync(dataDir, { recursive: true });
+    mkdirSync(join(projectDir, '.loop', 'lessons'), { recursive: true });
+    writeFakeCli();
+  });
+
+  afterEach(() => {
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  it('a key that exists only in .loop/.env reaches the gate (graduate spawns the CLI with it)', () => {
+    writeDotenv(projectDir, '.loop/.env', '# comment\nGEMINI_API_KEY=from-dotenv\n');
+    const res = runGraduate();
+    expect(res.status).toBe(0);
+    const env = spawnedEnv('graduate');
+    expect(env, 'CLI was not spawned — the no-key gate still blocked').not.toBeNull();
+    expect(env?.GEMINI_API_KEY).toBe('from-dotenv');
+  });
+
+  it('the same for recall — the hook injects context instead of no-oping', () => {
+    writeDotenv(projectDir, '.loop/.env', 'GEMINI_API_KEY=from-dotenv\n');
+    const res = runRecall();
+    expect(res.status).toBe(0);
+    expect(res.stdout).toContain('a recalled lesson');
+    expect(spawnedEnv('recall')?.GEMINI_API_KEY).toBe('from-dotenv');
+  });
+
+  it('does NOT overwrite a value already set in the session env (shell export wins)', () => {
+    writeDotenv(projectDir, '.loop/.env', 'OPENAI_API_KEY=from-dotenv\nLOOP_EMBED_PROVIDER=gemini\n');
+    const res = runGraduate({ OPENAI_API_KEY: 'from-shell' });
+    expect(res.status).toBe(0);
+    const env = spawnedEnv('graduate');
+    expect(env?.OPENAI_API_KEY).toBe('from-shell');
+    // ...while a key the session env did NOT set still comes through from the file.
+    expect(env?.LOOP_EMBED_PROVIDER).toBe('gemini');
+  });
+
+  it('does NOT overwrite a userConfig value bridged from CLAUDE_PLUGIN_OPTION_*', () => {
+    writeDotenv(projectDir, '.loop/.env', 'OPENAI_API_KEY=from-dotenv\n');
+    const res = runGraduate({ CLAUDE_PLUGIN_OPTION_OPENAI_API_KEY: 'from-user-config' });
+    expect(res.status).toBe(0);
+    expect(spawnedEnv('graduate')?.OPENAI_API_KEY).toBe('from-user-config');
+  });
+
+  it('missing .env file: no throw, both hooks stay fail-open no-ops (exit 0, empty stdout, no CLI run)', () => {
+    const g = runGraduate();
+    expect(g.status).toBe(0);
+    expect(g.stdout).toBe('');
+    expect(spawnedEnv('graduate')).toBeNull();
+
+    const r = runRecall();
+    expect(r.status).toBe(0);
+    expect(r.stdout).toBe('');
+    expect(spawnedEnv('recall')).toBeNull();
+  });
+
+  it('unreadable dotenv path (a directory, not a file): no throw, hook still no-ops cleanly', () => {
+    mkdirSync(join(projectDir, '.loop', '.env'), { recursive: true });
+    const res = runGraduate();
+    expect(res.status).toBe(0);
+    expect(res.stderr).toBe('');
+    expect(spawnedEnv('graduate')).toBeNull();
+  });
+
+  it('honours a custom path from the loop_dotenv_path plugin option', () => {
+    writeDotenv(projectDir, 'packages/loop-memory/.env', 'GEMINI_API_KEY=custom-path-key\n');
+    const blocked = runGraduate();
+    expect(spawnedEnv('graduate'), 'default path must not find it').toBeNull();
+
+    expect(blocked.status).toBe(0);
+    const res = runGraduate({
+      CLAUDE_PLUGIN_OPTION_LOOP_DOTENV_PATH: 'packages/loop-memory/.env',
+    });
+    expect(res.status).toBe(0);
+    expect(spawnedEnv('graduate')?.GEMINI_API_KEY).toBe('custom-path-key');
+  });
+
+  it('parses quoted values, `export KEY=`, and inline comments; skips junk lines', () => {
+    writeDotenv(
+      projectDir,
+      '.loop/.env',
+      [
+        'not a key=value line but has spaces',
+        '=novalue',
+        'export GEMINI_API_KEY="quoted key" # trailing comment',
+        'LOOP_DATABASE_URL=postgres://u:p@localhost:5434/db # inline',
+        "LOOP_MEMORY_SIGNING_KEY='single=quoted=with=equals'",
+      ].join('\n'),
+    );
+    const res = runGraduate();
+    expect(res.status).toBe(0);
+    const env = spawnedEnv('graduate');
+    expect(env?.GEMINI_API_KEY).toBe('quoted key');
+    expect(env?.LOOP_DATABASE_URL).toBe('postgres://u:p@localhost:5434/db');
+    expect(env?.LOOP_MEMORY_SIGNING_KEY).toBe('single=quoted=with=equals');
+  });
+});
+
+// A gitignored `.env` is by definition absent from a freshly-created feature worktree — which is
+// exactly where an isolated agent loop runs. Without this fallback the plugin fails closed in every
+// worktree, which is how the original six-week silent no-op stayed invisible.
+describe('hooks — worktree fallback to the main worktree .env', () => {
+  let mainRoot: string;
+  let linked: string;
+
+  const git = (args: string[], cwd: string) => {
+    const r = spawnSync('git', args, { cwd, encoding: 'utf8' });
+    if (r.status !== 0) throw new Error(`git ${args.join(' ')} failed: ${r.stderr}`);
+    return r;
+  };
+
+  beforeEach(() => {
+    base = mkdtempSync(join(tmpdir(), 'loop-memory-worktree-'));
+    pluginRoot = join(base, 'plugin');
+    dataDir = join(base, 'data');
+    mainRoot = join(base, 'main');
+    linked = join(base, 'feature-wt');
+    mkdirSync(dataDir, { recursive: true });
+    mkdirSync(mainRoot, { recursive: true });
+    writeFakeCli();
+
+    git(['init', '-b', 'main'], mainRoot);
+    writeFileSync(join(mainRoot, 'README.md'), 'seed\n');
+    git(['add', '.'], mainRoot);
+    git(
+      ['-c', 'user.email=t@example.com', '-c', 'user.name=t', 'commit', '--no-gpg-sign', '-m', 'init'],
+      mainRoot,
+    );
+    git(['worktree', 'add', '-b', 'feat', linked], mainRoot);
+    mkdirSync(join(linked, '.loop', 'lessons'), { recursive: true });
+    // The key lives only in the main worktree (gitignored → never copied into the linked one).
+    writeDotenv(mainRoot, '.loop/.env', 'GEMINI_API_KEY=main-worktree-key\n');
+  });
+
+  afterEach(() => {
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  it('finds the main worktree .env when the feature worktree has none', () => {
+    projectDir = linked;
+    const res = runGraduate({}, linked);
+    expect(res.status).toBe(0);
+    const env = spawnedEnv('graduate');
+    expect(env, 'fallback did not resolve — CLI never spawned').not.toBeNull();
+    expect(env?.GEMINI_API_KEY).toBe('main-worktree-key');
+  });
+
+  it("prefers the worktree's own .env over the main worktree's when both exist", () => {
+    projectDir = linked;
+    writeDotenv(linked, '.loop/.env', 'GEMINI_API_KEY=local-worktree-key\n');
+    const res = runGraduate({}, linked);
+    expect(res.status).toBe(0);
+    expect(spawnedEnv('graduate')?.GEMINI_API_KEY).toBe('local-worktree-key');
+  });
+
+  it('outside a git repo with no .env: still a clean no-op (no git binary crash, no throw)', () => {
+    projectDir = join(base, 'not-a-repo');
+    mkdirSync(join(projectDir, '.loop', 'lessons'), { recursive: true });
+    const res = runGraduate({}, projectDir);
+    expect(res.status).toBe(0);
+    expect(res.stderr).toBe('');
+    expect(spawnedEnv('graduate')).toBeNull();
+  });
+});


### PR DESCRIPTION
## The bug

Claude Code hands a hook the **session process env** — it never loads `.env` files. Both
`hooks/recall-lessons.mjs` and `hooks/graduate-lessons.mjs` read the embedding key from that env
only, so a consuming repo that keeps its key in a gitignored `.env` (the normal way to hold a secret
that must not be committed) and never `export`s it hits each hook's own self-gate:

```js
if (!childEnv.OPENAI_API_KEY && !childEnv.GEMINI_API_KEY) out('', 'no embedding key');
```

Result: semantic recall and lesson graduation both dead, **with no error anywhere**. Everything
"works" — it just does nothing.

The capability existed before: the consuming repo carried local hook copies calling a
`loadLoopEnv(projectDir)` helper immediately before the key gate. When those local copies were
dropped in favour of this plugin, the `.env`-loading step went with them, because the plugin's copies
never had it. So the fix lands **in the plugin** — no consuming repo should have to carry a loader
hook just to make the plugin's own hooks work.

## What changed

- **`hooks/lib/load-dotenv.mjs`** (new, dependency-free — hand-rolled parser, no `dotenv` package).
  Both hooks call it right after the `CLAUDE_PLUGIN_OPTION_*` bridge and before their key gate.
  Precedence: **session env > userConfig > file**; a key already set is never overwritten.
- **New `loop_dotenv_path` userConfig option** (env `LOOP_DOTENV_PATH`), default `.loop/.env`
  (`.loop/` is already loop-engine's convention directory and conventionally gitignored). The file's
  location is a per-repo layout question — `packages/loop-memory/.env` is one repo's layout, not a
  universal one — so it's configured, not assumed. Absolute paths work too.
- **Worktree fallback**: a gitignored `.env` doesn't exist in a freshly-created feature worktree,
  which is exactly where an isolated agent loop runs. If the configured path is missing there, the
  *main* worktree's copy is read instead (`git rev-parse --git-common-dir`). Nothing is copied; the
  key stays untracked and in one place. Without this the plugin fails closed in every worktree —
  which is how this same failure class stayed invisible for six weeks in the origin repo.
- **Best-effort throughout**: missing file, unreadable file, directory-in-place-of-file, non-git
  directory, missing `git` binary → env untouched, hooks return to their normal fail-open no-op. A
  hook must never break a session over its own optional config.
- **Observability**: the existing `LOOP_RECALL_DEBUG=1` / `LOOP_GRADUATE_DEBUG=1` logs now record
  which dotenv file was loaded, or `dotenv: none found` — "silently loaded nothing" and "silently
  found nothing" are the two states this bug lived in.
- Every key in the file is loaded, not just those with a matching userConfig option — so
  `LOOP_EMBED_PROVIDER` and friends reach the CLI from the file too.
- Version `0.2.6` → `0.3.0` (new feature + new userConfig key) in `plugin.json`, `marketplace.json`,
  `CHANGELOG.md`; README gets a "Keys that live in a `.env`" section and a config-table row;
  `.env.example` notes the consuming-repo use of the same file shape.

## Tests

`test/hooks-dotenv.test.ts` — 11 tests that spawn the **real hook processes** (not the loader in
isolation), with a fake `dist/cli.js` that dumps the env it received, so what's locked is "the key
actually reaches the gate", the property that was broken:

| | |
|---|---|
| (a) key only in the file reaches the gate | both hooks — graduate spawns the CLI with it; recall injects context instead of no-oping |
| (b) already-set values are not overwritten | session-env export wins; `CLAUDE_PLUGIN_OPTION_*` userConfig wins; a key the session *didn't* set still comes from the file |
| (c) missing file → no throw | exit 0, empty stdout, CLI never spawned (both hooks). Plus directory-instead-of-file → no throw, empty stderr |
| (d) worktree fallback resolves | real `git init` + `git worktree add`; key only in the main worktree reaches the linked worktree's hook. Also: local `.env` preferred when both exist; non-git dir → clean no-op |
| extra | custom `loop_dotenv_path` honoured (and default path does *not* find that file); quoted values, `export KEY=`, inline comments, junk lines |

**Red verified**: stashing only the two hook edits (leaving the new tests and loader in place) makes
**7 of the 11 fail**. The other 4 are the fail-open/no-op guards, which must pass either way.

## Verification run locally (full `.github/workflows/loop-memory-test.yml` sequence)

| Step | Result |
|---|---|
| `npm ci` | ok |
| `npm run typecheck` | ok (no output) |
| `npm test` | **10 files, 87 passed / 2 skipped** |
| `npm run build` | ok — `dist/cli.js 432.4kb`, byte-identical to the committed bundle (no `src/` change) |
| bundle smoke (`node dist/cli.js recall` with no keys) | exit `1` + "no embedding API key" — as expected |
| `node --check` on both hooks *and* the new lib | ok |
| hook fail-open no-op smoke (`env -i`, both hooks) | both exit 0, recall stdout empty |
| `claude plugin validate --strict .` / `... tools/loop-memory` | both "Validation passed" |

## Not fixed here (deliberate)

- **`graduate-lessons.mjs` still reads the knowledge-corpus paths (`LOOP_ADR_DIR`, `LOOP_CONTEXT_FILE`,
  `LOOP_RESEARCH_DIR`, `LOOP_DESIGN_DIR`) from `CLAUDE_PLUGIN_OPTION_*` only**, so putting those in a
  `.env` has no effect. Out of scope for a silent-failure fix, and they're config-shaped rather than
  secret-shaped (they belong in userConfig). Worth a follow-up for consistency.
- **`src/cli.ts` still reads only the process env** for a bare-shell invocation — its header comment
  documents that as intentional ("standalone CLI invocation reads them straight from the shell, no
  .env file involved"). This PR changes hook behaviour only.
- **A consuming repo whose `.env` isn't at `.loop/.env` must set `loop_dotenv_path`** — e.g.
  `claude plugin install loop-memory@paul-loop --config loop_dotenv_path=packages/loop-memory/.env`
  (or `/plugin configure`). That's a one-line repo-side step this PR can't make for it; a
  multi-candidate default was rejected as ambiguous.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VNR8Xbi414uHHzUFzmmMDp