### PR TITLE
feat(loop-engine): close ledger instrumentation holes + verify-pipe and session-scope gates (BAC-778)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,21 +12,21 @@
       "name": "loop-engine",
       "source": "./tools/loop-engine",
       "description": "Core loop mechanics: verdict-run (machine-readable PASS/FAIL contract), loop-fix (closed verify->fix loop), lessons (verified-fix memory), classify-risk, require-tests, plugin-path (resolve sibling plugin install paths), check-docs-hygiene/check-pr-hygiene/check-module-size (repo hygiene gates). No framework opinions beyond \"the verifier is the ceiling, never the agent's self-report\".",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "keywords": ["verifier", "tdd", "loop", "verdict", "lessons"]
     },
     {
       "name": "ship-flow",
       "source": "./tools/ship-flow",
       "description": "Delivery-loop skills — ship-feature (plan-to-PR autonomous loop), hotfix, retrospect, grill-with-docs, deps-audit, to-issues/to-prd, tdd, harness-maturity-audit, improve-codebase-architecture, resolving-merge-conflicts, plus review agents and audit/research workflows — parameterized by a consuming repo's own tracker/branch-model config instead of hardcoded to one repo. dependencies: loop-engine.",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "keywords": ["delivery", "git-flow", "hotfix", "ship", "release"]
     },
     {
       "name": "loop-memory",
       "source": "./tools/loop-memory",
       "description": "pgvector semantic recall for verified dev-loop lessons (and, optionally, ADR/glossary/research knowledge). Opt-in / defaultEnabled:false — a database dependency, not core loop mechanics.",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "defaultEnabled": false,
       "keywords": ["memory", "pgvector", "recall", "semantic-search", "lessons"]
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,90 @@ Explicit-version channel — see [README § Development status](README.md#develo
 not a SHA channel. Entries below `## loop-engine 0.2.0` and earlier predate the multi-plugin split
 and refer to `loop-engine` only (see the un-prefixed version numbers).
 
+## ship-flow 0.3.1 · loop-memory 0.3.1
+
+- Dependency range only: both declared `loop-engine ^0.8.0`, which `0.9.0` (below) falls outside of.
+  Bumped to `^0.9.0`, following the convention of every prior loop-engine minor (`^0.6.0`→`^0.7.0` with
+  0.7.0, `^0.7.0`→`^0.8.0` with 0.8.0). Neither plugin's behaviour changed and neither actually needs a
+  0.9.0 feature — the patch bump exists because this is an explicit-version channel, so changed manifest
+  content must not ship under an already-published version number.
+
+## loop-engine 0.9.0
+
+Ledger instrumentation repairs + two new gates, all evidence-driven from a 7-day audit of a consuming
+repo's own `.loop/runs/` (3,096 events across 111 run files).
+
+- **Verdict events now reach the session ledger (BAC-778).** Measured hole: the instrumentation hook
+  writes under `CLAUDE_PROJECT_DIR` while `bin/verdict-run.sh` writes under its own **cwd**, so any
+  repo that isolates work in git worktrees split the two apart on every run — the main ledger held
+  **zero** `verdict.*` events across all 111 runs while one worktree's `.loop/runs/unknown.jsonl`
+  held 14 `verdict.passed` + 2 `verdict.failed`. `bin/run-metrics.mjs` therefore reported `q2` and
+  `first_pass` as `INSUFFICIENT_DATA` for every single run: the loop's headline metric (verify
+  first-pass rate) was unmeasurable from its own ledger. New `lib/run-ledger.mjs` →
+  `resolveLedgerTarget()`, used by `bin/ledger-append.mjs --auto-run-id`, resolves both the ledger
+  root and the run-id by **corroboration** — an event only moves to another root if that root already
+  holds `<run-id>.jsonl` (proof the hook is writing this session there). Run-id prefers
+  `CLAUDE_CODE_SESSION_ID` (present in the Bash tool's env — verified empirically; `CLAUDE_PROJECT_DIR`
+  is **not**, which is why the main worktree also has to be inferred via `git rev-parse
+  --git-common-dir`), which is immune to the `current` pointer's concurrent-session last-writer-wins.
+  With no corroboration the previous behaviour (cwd + `current` pointer + `unknown` bucket) is
+  unchanged byte-for-byte. `verdict-run.sh` now also records `payload.cwd`, so a redirected event
+  doesn't lose which worktree it actually ran in.
+- **Subagent events stop implying a count they can't support (BAC-778).** Measured: 2,307
+  `subagent.stopped` vs 472 `subagent.started`, with 1,896 stops carrying `agent_type: ""`.
+  Cross-checking `agent_id` across the whole ledger settles the cause and rules out a payload bug on
+  our side — **405/405** distinct *typed* stop ids have a matching `started`; **1,901/1,901** distinct
+  *untyped* stop ids have none. The platform fires `SubagentStop` for agent kinds whose
+  `SubagentStart` never fires, and its stdin for those carries no `agent_type`; a hook cannot invent
+  it. So the shape gets honest instead: absent → `agent_type: null` (never `""`, which reads as "we
+  captured a type and it was blank"), plus `attributable: false` and an `extra` bag preserving
+  whatever else the platform did send — the only way a later audit discovers an identity field under
+  a name we don't know yet. `bin/run-metrics.mjs` gains a `subagents` axis splitting `started` /
+  `stopped_paired` / `stopped_unattributed`, so per-agent duration/success can only be derived from
+  the paired population.
+- **`permission.denied` is diagnosable for every tool shape (BAC-778).** Bash denials already
+  recorded `command` and Edit/Write `file_path` (checked against 28 real denial events — the audit's
+  "Bash denials record only the tool name" did not reproduce against this code), but every other tool
+  landed with `tool_name` and nothing else (measured: `SendMessage`, `ScheduleWakeup`). Denial events
+  now carry `tool_input_keys` — the key **names** only, never the values, so it can't carry a secret
+  or grow the ledger.
+- **New gate `hooks/gate-verify-pipe.mjs` (PreToolUse/Bash).** Denies a verify-shaped command piped
+  into another command when the same invocation preserves no real exit status. Measured in four
+  audited runs: `cd <wt> && timeout 590 pnpm verify 2>&1 | tail -200` followed, in a *separate* Bash
+  call, by `echo "exit code of last pnpm verify: $?"` → `0`. That `0` was unrelated to verify twice
+  over (a pipeline's `$?` is the last stage's, and the tool resets the shell between calls). Those
+  runs happened to be green, so the evidence was merely worthless rather than wrong — and the same
+  sessions used the correct `> log 2>&1; echo EXIT:$?` form elsewhere. `pipefail`/`PIPESTATUS`
+  anywhere in the invocation, or a redirect instead of a pipe, pass untouched. Reuses
+  `hooks/command-tokenizer.mjs` (no second parser) and follows the established
+  fail-open-on-detection / fail-closed-once-certain shape. Verify vocabulary is config
+  (`.claude/ship-flow.config.json` → `verifyCommandPattern`), defaulting to this harness's own
+  `verify`/`verdict`; kill switch `LOOP_VERIFY_PIPE_GATE_OFF=1`.
+- **`hooks/gate-worktree-create.mjs` escalates a second feature worktree in one session** to
+  `permissionDecision: "ask"` (the human-approval prompt = the gate vocabulary's REQUIRE) — the
+  mechanical half of a boundary violation where an audited run opened its PR and then began an
+  entirely new issue. The existing `origin/*` deny rule is unchanged and still wins, and a denied
+  command doesn't consume the budget. Non-feature branches (`lessons/*`, `chore/*`, …) are exempt.
+  Prefix is config (`featureBranchPrefix`, default `feature/`); kill switch
+  `LOOP_WORKTREE_SESSION_GATE_OFF=1`. **The limits are stated in the file header and are real**: "one
+  session" is the payload's `session_id` and nothing else — no `session_id` means no escalation at
+  all (undeterminable must not become "everything is one session"); a subagent has its own session id
+  so it neither counts toward nor sees the parent's budget; `EnterWorktree` / `Agent
+  isolation:"worktree"` never reach a Bash hook; and it counts *attempts* (deduped by branch name),
+  so a `git worktree add` that later fails on its own still consumes the budget.
+- **`bin/check-pr-hygiene.mjs` gains opt-in reviewer coverage** (`--reviewers a,b,c`,
+  `--result-pattern`): each named reviewer must appear in the PR body with a result token on its line
+  or within the next 2 lines — a bare mention in prose is not a result block. Motivated by an audited
+  run that summoned 2 of 3 mandated review agents with no gate catching it. Reviewer names are
+  consumer-repo config, never hardcoded here (a self-test asserts the plugin's code contains none),
+  and without `--reviewers` the existing tracker-reference contract is untouched.
+- 5 new self-tests (`ledger-attribution`, `subagent-event-shape`, `gate-verify-pipe`,
+  `worktree-session-scope`, `pr-reviewer-coverage`); suite 42 → 47 files. `hooks/hooks.json` gains 1
+  hook command (16→17, 8→9 distinct files).
+- **Follow-up needed elsewhere**: `tools/ship-flow/.claude-plugin/plugin.json` declares
+  `loop-engine ^0.8.0`, which excludes 0.9.0 — that range needs widening in a separate PR.
+  Deliberately not edited here: concurrent work owns that file.
+
 ## ship-flow 0.3.0
 
 Forensic audit of 12 real `ship-feature` runs (2026-08-24) found the skill's own mandated deterministic
@@ -69,6 +153,7 @@ AC-contract authoring 1/5. This release fixes the cause and five adjacent findin
   output language (measuring a target-language ratio in an agent's actual prose) was considered and
   rejected: this plugin never sees agent output — `verdict-run.sh`'s LOG captures the *verifier's*
   output, not the agent's — so there is nothing here to measure it against.
+
 
 ## loop-memory 0.3.0
 

--- a/tools/loop-engine/.claude-plugin/plugin.json
+++ b/tools/loop-engine/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "loop-engine",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Core loop mechanics: verdict-run (machine-readable PASS/FAIL contract), loop-fix (closed verify->fix loop), lessons (verified-fix memory), classify-risk, require-tests, check-docs-hygiene/check-pr-hygiene/check-module-size (repo hygiene gates). verifier=ceiling — the agent's self-judgement never substitutes for it.",
   "author": {
     "name": "paulkim-lansik"

--- a/tools/loop-engine/bin/check-pr-hygiene.mjs
+++ b/tools/loop-engine/bin/check-pr-hygiene.mjs
@@ -17,20 +17,48 @@
 // 키워드로 자동 close되지 않는 경우가 흔하고(Linear 등), 강제하면 "임시로 키워드를 넣었다가 빼먹어
 // 오발 close"라는 별도 실패모드만 늘어난다(ouroboros 설계 그대로).
 //
-// Exit 0 = 참조 있음. Exit 1 = 없음. --json으로 기계가독 결과.
+// ── 리뷰어 커버리지 (BAC-778, opt-in) ─────────────────────────────────────────────────────────
+// `--reviewers a,b,c`를 주면 PR 본문이 **각 리뷰어의 결과 블록**을 담고 있는지도 검사한다. 계기(실측):
+// 감사한 어떤 런은 필수 리뷰 에이전트 3종 중 2종만 소환하고 PR을 열었는데 아무 게이트도 잡지 못했다 —
+// "3종 다 돌렸다"가 관행으로만 존재하면 조용히 2종이 된다(참조 게이트와 같은 실패 모드).
+//
+// 리뷰어 이름은 **소비 레포의 것**이라 여기 하드코딩하지 않는다(이 플러그인은 제품 고유 규칙을 싣지
+// 않는다 — `--pattern`과 같은 설계). 값은 `.claude/ship-flow.config.json`에 두고 CI/스킬 호출부에서
+// `--reviewers`로 넘기는 것을 권장한다. 플래그가 없으면 이 검사는 아예 돌지 않는다(기존 계약 불변).
+//
+// "결과 블록"의 판정: 리뷰어 이름이 나오는 줄 **또는 그 다음 2줄 안**에 결과 토큰이 있어야 한다
+// (`--result-pattern`으로 교체 가능). 이름만 스쳐 지나가는 산문("test-hunter는 생략했다")은 통과하지
+// 못하고, 표제+판정이 붙어 있는 실제 결과 블록은 형식(제목/표/불릿)과 무관하게 통과한다.
+//
+// Exit 0 = 참조 있음(+ 리뷰어 지정 시 전원 커버). Exit 1 = 하나라도 미달. --json으로 기계가독 결과.
 
 import { readFileSync } from 'node:fs';
 
 // case-insensitive — 목적은 "참조가 존재하는가"이지 표기 규칙 검사가 아니다.
 const DEFAULT_REF_PATTERN = /\b[A-Z]{2,}-\d+\b/i;
+// 결과 토큰의 기본값 — 영/한 양쪽의 흔한 판정 어휘. 소비 레포는 --result-pattern으로 갈아끼운다.
+const DEFAULT_RESULT_PATTERN =
+  /\b(PASS(?:ED)?|FAIL(?:ED)?|BLOCK(?:ER|ERS|ED)?|APPROVED?|NO[- ]?BLOCKERS?)\b|통과|차단|블로커/i;
+// 이름 줄 + 이어지는 2줄 — 제목 밑에 판정이 오는 흔한 형태를 담되, 다음 리뷰어 블록까지 넘어가지는
+// 않을 만큼 좁게.
+const RESULT_WINDOW = 2;
 
 function parseArgs(argv) {
-  const opts = { body: undefined, bodyFile: undefined, json: false, pattern: undefined };
+  const opts = {
+    body: undefined,
+    bodyFile: undefined,
+    json: false,
+    pattern: undefined,
+    reviewers: undefined,
+    resultPattern: undefined,
+  };
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
     if (a === '--body') opts.body = argv[++i];
     else if (a === '--body-file') opts.bodyFile = argv[++i];
     else if (a === '--pattern') opts.pattern = argv[++i];
+    else if (a === '--reviewers') opts.reviewers = argv[++i];
+    else if (a === '--result-pattern') opts.resultPattern = argv[++i];
     else if (a === '--json') opts.json = true;
   }
   return opts;
@@ -47,27 +75,84 @@ function resolvePattern(raw) {
   return new RegExp(raw, 'i');
 }
 
-export function checkPrHygiene(body, pattern = DEFAULT_REF_PATTERN) {
+const escapeRe = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+// 리뷰어 이름 목록 파싱 — 쉼표 구분, 공백 무시, 빈 항목 제거.
+export function parseReviewers(raw) {
+  if (typeof raw !== 'string') return [];
+  return raw
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+export function checkReviewerCoverage(
+  body,
+  reviewers,
+  resultPattern = DEFAULT_RESULT_PATTERN,
+  window = RESULT_WINDOW,
+) {
+  const lines = String(body ?? '').split('\n');
+  const covered = [];
+  const missing = [];
+  for (const name of reviewers) {
+    // 경계에서 하이픈·언더스코어를 제외한다 — 리뷰어 이름 안에는 흔하지만(`code-reviewer`), 경계로
+    // 인정하면 `meta-code-reviewer`가 `code-reviewer`를 만족시켜 버린다(다른 에이전트다). 콜론·슬래시·
+    // 공백·마크다운 장식은 경계로 인정되므로 `### code-reviewer`·`**code-reviewer**`·
+    // `ship-flow:code-reviewer`는 그대로 잡힌다.
+    const nameRe = new RegExp(`(^|[^A-Za-z0-9_-])${escapeRe(name)}([^A-Za-z0-9_-]|$)`, 'i');
+    let hit = false;
+    for (let i = 0; i < lines.length && !hit; i++) {
+      if (!nameRe.test(lines[i])) continue;
+      hit = lines.slice(i, i + window + 1).some((l) => resultPattern.test(l));
+    }
+    (hit ? covered : missing).push(name);
+  }
+  return { ok: missing.length === 0, covered, missing };
+}
+
+export function checkPrHygiene(body, pattern = DEFAULT_REF_PATTERN, opts = {}) {
   const text = body ?? '';
   const match = text.match(pattern);
-  return { ok: match !== null, matched: match?.[0] ?? null };
+  const result = { ok: match !== null, matched: match?.[0] ?? null };
+  const reviewers = opts.reviewers ?? [];
+  if (reviewers.length) {
+    result.reviewers = checkReviewerCoverage(text, reviewers, opts.resultPattern);
+    result.ok = result.ok && result.reviewers.ok;
+  }
+  return result;
 }
 
 function main() {
   const opts = parseArgs(process.argv.slice(2));
   const body = resolveBody(opts);
   const pattern = resolvePattern(opts.pattern);
-  const result = checkPrHygiene(body, pattern);
+  const reviewers = parseReviewers(opts.reviewers);
+  const result = checkPrHygiene(body, pattern, {
+    reviewers,
+    resultPattern: opts.resultPattern ? new RegExp(opts.resultPattern, 'i') : undefined,
+  });
 
   if (opts.json) {
     console.log(JSON.stringify(result));
-  } else if (result.ok) {
-    console.log(`PASS: PR body references ${result.matched}`);
   } else {
-    console.error(
-      'FAIL: PR body에 트래킹 이슈 참조가 없습니다. closing 키워드는 필요 없습니다 — ' +
-        '그냥 이슈 번호를 본문 어딘가에 적어주세요.',
-    );
+    if (result.matched) console.log(`PASS: PR body references ${result.matched}`);
+    else
+      console.error(
+        'FAIL: PR body에 트래킹 이슈 참조가 없습니다. closing 키워드는 필요 없습니다 — ' +
+          '그냥 이슈 번호를 본문 어딘가에 적어주세요.',
+      );
+    if (result.reviewers) {
+      if (result.reviewers.ok) {
+        console.log(`PASS: PR body has result blocks for ${result.reviewers.covered.join(', ')}`);
+      } else {
+        console.error(
+          `FAIL: PR body에 다음 리뷰 에이전트의 결과 블록이 없습니다: ${result.reviewers.missing.join(', ')}. ` +
+            '소환했다면 각 리뷰어 이름과 그 판정(PASS/FAIL/블로커 유무)을 본문에 함께 적어주세요 — ' +
+            '"돌렸다"는 자기보고는 증거가 아닙니다.',
+        );
+      }
+    }
   }
 
   process.exit(result.ok ? 0 : 1);

--- a/tools/loop-engine/bin/ledger-append.mjs
+++ b/tools/loop-engine/bin/ledger-append.mjs
@@ -2,14 +2,18 @@
 // ledger-append.mjs — bash 소비자(verdict-run.sh write_state)용 원장 append CLI (BAC-570).
 //
 // Usage: echo '<payload-json>' | ledger-append.mjs --type <dot.past_tense> [--run-id <id> | --auto-run-id]
-//   --auto-run-id : .loop/runs/current에서 run-id를 읽음(부재/파손 시 'unknown' 버킷).
+//   --auto-run-id : 세션 원장을 확증으로 찾아 run-id·루트를 함께 해소한다(lib/run-ledger.mjs의
+//     resolveLedgerTarget — CLAUDE_CODE_SESSION_ID → `.loop/runs/current` → 'unknown' 버킷 순).
+//     확증(`<root>/.loop/runs/<run-id>.jsonl` 존재)이 없으면 기존 동작 그대로 cwd + current 포인터다.
+//     이게 BAC-778에서 "verdict.* 이벤트가 세션 원장에 한 건도 없다"를 닫은 지점이다 — 워크트리에서
+//     돈 검증이 메인 워크트리의 세션 원장에 정상 귀속된다.
 // payload는 argv가 아니라 stdin으로 받는다 — 초대형 cmd 문자열의 argv 전달은 E2BIG로 죽는다
 // (웨이브2 검증 교훈과 동일 실패 모드 예방).
 // exit 0=기록됨, 1=실패(호출자는 || true로 무시 — best-effort, verdict·exit 불변), 2=usage.
 // root = cwd — verdict-run.sh가 검증 대상 레포/워크트리에서 실행되므로 원장도 그 곁에 남는다.
 
 import { readFileSync } from 'node:fs'
-import { appendRunEvent, readCurrentRunId } from '../lib/run-ledger.mjs'
+import { appendRunEvent, resolveLedgerTarget } from '../lib/run-ledger.mjs'
 
 function usage() {
   process.stderr.write(
@@ -32,15 +36,18 @@ for (let i = 0; i < argv.length; i++) {
 if (!type || (runId && autoRunId)) usage()
 
 try {
-  const root = process.cwd()
+  const cwd = process.cwd()
   let payload = {}
   try {
     payload = JSON.parse(readFileSync(0, 'utf8'))
   } catch {
     payload = {} // payload는 best-effort — 파싱 불가여도 이벤트 자체(type)는 기록한다
   }
-  const rid = autoRunId ? readCurrentRunId(root) : runId || 'unknown'
-  appendRunEvent(root, { type, runId: rid, payload })
+  // --run-id는 명시 지정이므로 루트도 cwd 고정(호출자가 이미 어디에 쓸지 정했다).
+  const target = autoRunId
+    ? resolveLedgerTarget({ cwd, env: process.env })
+    : { root: cwd, runId: runId || 'unknown' }
+  appendRunEvent(target.root, { type, runId: target.runId, payload })
   process.exit(0)
 } catch (e) {
   process.stderr.write(`ledger-append: ${e?.message ?? e}\n`)

--- a/tools/loop-engine/bin/run-metrics.mjs
+++ b/tools/loop-engine/bin/run-metrics.mjs
@@ -16,6 +16,9 @@
 //        "post-compaction"으로 표시한다(압축이 여러 번 연달아 와도 "최근 압축됨" 불리언 상태로
 //        취급 — 압축마다 같은 다음 verdict를 중복 카운트하지 않는다). 이 표본들 중 verdict.failed
 //        비율이 post_compaction_red — 체크포인트(별도 조건부 이슈) 착수 여부의 실측 근거.
+//   서브에이전트(BAC-778) = started / stopped_paired / stopped_unattributed 3분할. 플랫폼이
+//        SubagentStart가 안 뜨는 종류에도 SubagentStop을 쏘고 그 이벤트엔 agent_type이 없다(실측) —
+//        stopped 총계는 "서브에이전트 수"를 뒷받침하지 못하므로 짝이 맞은 것만 따로 센다.
 // 결손 축은 INSUFFICIENT_DATA를 1급 결과로(frugality proof — 측정 축이 빠지면 조작된 PASS 대신
 // 증명 불가를 정직하게): run.started 없는 런(계측 생존 마커 부재)의 H1, verdict 0 런의 Q2,
 // 해당 런이 0인 전체 축. 'unknown' 런(귀속 불가 verdict 버킷)은 별도 행+카운터로만 보고하고
@@ -94,7 +97,14 @@ for (const f of files) {
   const excluded = {}
   const verdicts = []
   const compactions = []
+  const startedAgentIds = new Set()
+  const stoppedAgentIds = []
   for (const e of events) {
+    if (e.type === 'subagent.started') {
+      if (e.payload?.agent_id) startedAgentIds.add(e.payload.agent_id)
+    } else if (e.type === 'subagent.stopped') {
+      stoppedAgentIds.push(e.payload?.agent_id ?? null)
+    }
     if (e.type === 'permission.requested') {
       const s = e.payload?.surface
       if (typeof s === 'string' && s) {
@@ -127,6 +137,13 @@ for (const f of files) {
     }
   }
 
+  // 서브에이전트 짝 맞추기(BAC-778) — stopped를 통째로 세면 안 되는 이유는 record-run-event.mjs
+  // 헤더의 실측 그대로다: 플랫폼이 SubagentStart가 안 뜨는 에이전트 종류에도 SubagentStop을 쏘고,
+  // 그런 이벤트엔 agent_type이 아예 없다(실측 7일: stopped 2,307 중 1,896이 무-타입, 그 1,901개
+  // 고유 id 중 started가 있는 건 0개 / 타입 있는 405개는 405개 전부 started가 있다). 그래서
+  // "stopped 수 = 서브에이전트 수"는 뒷받침되지 않는 숫자다 — 짝이 맞은 것과 귀속 불가를 분리해
+  // 보고하고, 지속시간/성공률 같은 파생은 짝 맞은 모집단에서만 도출하게 한다.
+  const stoppedPaired = stoppedAgentIds.filter((id) => id && startedAgentIds.has(id)).length
   runs.push({
     run_id: runId,
     instrumented,
@@ -136,6 +153,11 @@ for (const f of files) {
     excluded,
     compactions: compactions.length,
     post_compaction_red: postCompactionRed,
+    subagents: {
+      started: startedAgentIds.size,
+      stopped_paired: stoppedPaired,
+      stopped_unattributed: stoppedAgentIds.length - stoppedPaired,
+    },
   })
 }
 
@@ -172,6 +194,11 @@ const overall = {
       }
     : INSUFFICIENT,
   q2_mean: verdictRuns.length ? mean(verdictRuns.map((r) => r.q2)) : INSUFFICIENT,
+  subagents: {
+    started: attributed.reduce((s, r) => s + r.subagents.started, 0),
+    stopped_paired: attributed.reduce((s, r) => s + r.subagents.stopped_paired, 0),
+    stopped_unattributed: attributed.reduce((s, r) => s + r.subagents.stopped_unattributed, 0),
+  },
   excluded_by_surface: excludedTotal,
   unknown_verdict_events: unknownVerdictEvents,
   skipped_lines: skippedLines,
@@ -210,6 +237,12 @@ if (asJson) {
     .join(' ')
   lines.push(`excluded_by_surface: ${surf}`)
   lines.push(`unknown_verdict_events: ${unknownVerdictEvents} (귀속 불가 — overall 집계 제외)`)
+  lines.push(
+    `subagents: started=${overall.subagents.started} stopped_paired=${overall.subagents.stopped_paired} ` +
+      `stopped_unattributed=${overall.subagents.stopped_unattributed} ` +
+      '(unattributed = SubagentStart가 안 뜬 종류의 SubagentStop — agent_type 부재, 짝 맞추기 불가. ' +
+      '에이전트별 지속시간/성공률은 stopped_paired에서만 도출할 것)',
+  )
   lines.push(`skipped_lines: ${skippedLines}`)
   lines.push(`skipped_files: ${skippedFiles}`)
   lines.push(`compactions_total: ${overall.compactions_total}`)

--- a/tools/loop-engine/bin/verdict-run.sh
+++ b/tools/loop-engine/bin/verdict-run.sh
@@ -120,9 +120,12 @@ write_state() {
   # 신뢰 경계 참조; 머지 게이트 진실은 verdict-state.json + Stop 훅). best-effort: 원장 실패는
   # verdict·exit code 불변(위 state 계약과 동일). payload는 stdin으로 — 초대형 CMD_STR의 argv
   # 전달은 E2BIG로 죽는다. 중첩 시 최상위 래퍼만 append(상단 _LEDGER_NESTED — Q2 이중 기록 방지).
+  # cwd를 payload에 싣는 이유(BAC-778): --auto-run-id는 세션 원장이 있는 루트로 이벤트를 보낼 수
+  # 있다(워크트리에서 돈 검증 → 메인 워크트리 세션 원장). 그러면 이벤트만 보고는 "어느 워크트리의
+  # 검증이었나"를 알 수 없어진다 — 귀속을 고치면서 출처를 잃지 않도록 실행 위치를 함께 남긴다.
   if [ -z "$_LEDGER_NESTED" ]; then
-    printf '{"verdict":"%s","exit":%s,"cmd":"%s","log":"%s"}' \
-      "$_v" "$_c" "$(json_esc "$CMD_STR")" "$(json_esc "$LOG_ABS")" \
+    printf '{"verdict":"%s","exit":%s,"cmd":"%s","log":"%s","cwd":"%s"}' \
+      "$_v" "$_c" "$(json_esc "$CMD_STR")" "$(json_esc "$LOG_ABS")" "$(json_esc "$(pwd)")" \
       | node "$HERE/ledger-append.mjs" \
           --type "$([ "$_v" = "PASS" ] && echo verdict.passed || echo verdict.failed)" \
           --auto-run-id >/dev/null 2>&1 || true

--- a/tools/loop-engine/hooks/gate-verify-pipe.mjs
+++ b/tools/loop-engine/hooks/gate-verify-pipe.mjs
@@ -1,0 +1,181 @@
+#!/usr/bin/env node
+// PreToolUse guardrail — denies a verify-shaped command piped into another command when that same
+// invocation does nothing to preserve the verifier's real exit status.
+//
+// Why (measured, glucofit-partners run audit): four runs read their verify result like this —
+//
+//   [15:31] cd <worktree> && timeout 590 pnpm verify 2>&1 | tail -200
+//   [15:32] echo "exit code of last pnpm verify: $?"        ->  0
+//
+// Both halves are broken. A pipeline's `$?` is the *last* stage's status (`tail` here, which always
+// succeeds), and the Bash tool does not preserve shell state between calls — every result ends with
+// "Shell cwd was reset to …", so the second call's `$?` describes that brand-new shell's own `echo`.
+// The reported `0` was unrelated to verify in two independent ways. Those four runs happened to be
+// genuinely green, so nothing broke — but the evidence was worthless, and the *same sessions* used
+// the correct `> log 2>&1; echo EXIT:$?` form elsewhere. Inconsistent behaviour with no mechanical
+// backstop is exactly what a gate is for: "the verifier is the ceiling" is meaningless if the run
+// can't read the verifier's actual verdict.
+//
+// This hook is a guardrail, not a boundary (ADR-0036) — bypassable, and a coarse-net parser can't
+// fully emulate shell syntax. Detection fails open (an uncertain parse passes); once a
+// status-losing verify pipeline is confirmed, it fails closed. It reuses hooks/command-tokenizer.mjs
+// rather than growing a second parser, following gate-before-merge.mjs / gate-worktree-create.mjs.
+//
+// Not denied (the invocation keeps the real status inside itself):
+//   - `set -o pipefail; pnpm verify 2>&1 | tail -200; echo "EXIT:$?"`
+//   - `pnpm verify 2>&1 | tail -200; echo "EXIT:${PIPESTATUS[0]}"`
+//   - `pnpm verify > /tmp/v.log 2>&1; echo "EXIT:$?"; tail -200 /tmp/v.log`  (no pipe at all)
+// Detection is per-invocation, on the whole command string: `pipefail`/`PIPESTATUS` anywhere in the
+// same Bash call is accepted as intent to preserve the status. That's deliberately generous — this
+// gate exists to stop the *unaware* form, not to grade shell style.
+//
+// Configuration (this plugin ships no product-specific rules): the "what counts as verify" regex
+// comes from a consuming repo's `.claude/ship-flow.config.json` -> `verifyCommandPattern`, matched
+// against the runner subcommand (`pnpm <here>`) or a directly-invoked script's basename. Without
+// config it defaults to this harness's own vocabulary — `verify` / `verdict` and their `:`/`-`/`_`
+// suffixed variants (`verify:rls`, `verdict-run.sh`). Kill switch: LOOP_VERIFY_PIPE_GATE_OFF=1.
+
+import { readFileSync } from 'node:fs';
+import { basename, join } from 'node:path';
+import { firstSubcommand, stripHeredocs, stripPrefix, tokenize } from './command-tokenizer.mjs';
+import { logRedEvent } from './red-events-log.mjs';
+
+// biome-ignore lint/suspicious/noUndeclaredEnvVars: Claude Code injects this at hook runtime.
+const env = process.env;
+const root = env.CLAUDE_PROJECT_DIR ?? process.cwd();
+
+const DEFAULT_VERIFY_PATTERN = /^(verify|verdict)([:._-]|$)/i;
+
+// Package/task runners whose *subcommand* names the script being run.
+const RUNNERS = new Set(['pnpm', 'npm', 'yarn', 'bun', 'npx', 'make', 'just', 'turbo', 'nx']);
+// Runner global flags that consume the following token (`pnpm --filter <pkg> verify`).
+const RUNNER_VALUE_FLAGS = new Set(['--filter', '-F', '--dir', '-C', '--workspace', '-w', '--prefix']);
+// `pnpm run verify` / `npm run-script verify` / `pnpm exec …` — the real script is one token later.
+const RUNNER_INDIRECTIONS = new Set(['run', 'run-script', 'exec']);
+// `timeout`'s own value flags (a duration follows the flags and precedes the real command).
+const TIMEOUT_VALUE_FLAGS = new Set(['-s', '--signal', '-k', '--kill-after']);
+
+function loadVerifyPattern(projectRoot) {
+  try {
+    const cfg = JSON.parse(
+      readFileSync(join(projectRoot, '.claude', 'ship-flow.config.json'), 'utf8'),
+    );
+    if (typeof cfg.verifyCommandPattern === 'string' && cfg.verifyCommandPattern) {
+      return new RegExp(cfg.verifyCommandPattern, 'i');
+    }
+  } catch {
+    /* missing/unreadable/invalid config -> fall through to the default */
+  }
+  return DEFAULT_VERIFY_PATTERN;
+}
+
+function allow() {
+  process.exit(0);
+}
+function deny(reason, code) {
+  logRedEvent(root, { kind: 'verify-pipe-guard', code });
+  process.stdout.write(
+    JSON.stringify({
+      hookSpecificOutput: {
+        hookEventName: 'PreToolUse',
+        permissionDecision: 'deny',
+        permissionDecisionReason: reason,
+      },
+    }),
+  );
+  process.exit(0);
+}
+
+// Redirection operators containing `&` (`2>&1`, `>&2`, `&>log`) must not be mistaken for the `&`
+// statement separator — without this, `pnpm verify 2>&1 | tail` splits into `pnpm verify 2>` and
+// `1 | tail`, and the pipeline's first stage is no longer the verify (detection silently dies on
+// the single most common real form).
+const dropAmpRedirections = (s) => s.replace(/&>>?/g, ' ').replace(/\d?>&(-|\d?)/g, ' ');
+
+// Statements are split on everything that ends a command EXCEPT a single `|` — the pipe is the
+// structure this hook is about, so it must survive splitting (splitSegments() from the shared
+// tokenizer eats it, which is right for its own consumers and wrong here).
+const splitStatements = (s) =>
+  s
+    .split(/&&|\|\||[;\n&]/)
+    .map((x) => x.trim())
+    .filter(Boolean);
+
+// `timeout 590 pnpm verify` -> `pnpm verify`. Kept local rather than added to the shared
+// stripPrefix(): that function is shared with gate-before-merge/gate-risky-commands, and widening
+// it would silently change what those two hooks detect (the tokenizer header's S-1 warning).
+function stripTimeout(toks) {
+  if (!toks.length || basename(toks[0]) !== 'timeout') return toks;
+  let i = 1;
+  while (i < toks.length && toks[i].startsWith('-')) {
+    i += TIMEOUT_VALUE_FLAGS.has(toks[i]) && !toks[i].includes('=') ? 2 : 1;
+  }
+  if (i < toks.length && /^[0-9]/.test(toks[i])) i += 1; // the duration argument
+  return toks.slice(i);
+}
+
+// -> a human-readable label for the matched verify command, or null (not verify-shaped).
+function verifyShaped(stage, pattern) {
+  const toks = stripPrefix(stripTimeout(stripPrefix(tokenize(stage))));
+  if (!toks.length) return null;
+  const head = basename(toks[0]);
+  // A directly-invoked script: ./scripts/verify.sh, tools/loop-engine/bin/verdict-run.sh
+  if (pattern.test(head.replace(/\.(sh|bash|mjs|js|ts|py)$/i, ''))) return toks[0];
+  if (!RUNNERS.has(head)) return null;
+  let i = firstSubcommand(toks, 1, RUNNER_VALUE_FLAGS);
+  if (RUNNER_INDIRECTIONS.has(toks[i])) i += 1;
+  const sub = toks[i];
+  return typeof sub === 'string' && pattern.test(sub) ? `${toks[0]} ${sub}` : null;
+}
+
+// -- Detection (fail-open: an uncertain parse / a non-matching command passes) -----------------------
+let payload;
+try {
+  payload = JSON.parse(readFileSync(0, 'utf8'));
+} catch {
+  allow();
+}
+if (env.LOOP_VERIFY_PIPE_GATE_OFF === '1') allow();
+if (payload?.tool_name !== 'Bash') allow();
+const cmd = payload?.tool_input?.command;
+if (typeof cmd !== 'string' || !cmd) allow();
+
+const offenders = [];
+try {
+  const stripped = stripHeredocs(cmd);
+  // Any status-preserving intent anywhere in the same invocation -> not this hook's problem.
+  if (/PIPESTATUS|pipefail/.test(stripped)) allow();
+  const pattern = loadVerifyPattern(root);
+  for (const statement of splitStatements(dropAmpRedirections(stripped))) {
+    const stages = statement.split('|').map((s) => s.trim());
+    if (stages.length < 2) continue; // not a pipeline -> `$?` is already the command's own status
+    const label = verifyShaped(stages[0], pattern);
+    // The downstream stage is named for context, but the statement text itself is NOT echoed back —
+    // it has been through dropAmpRedirections(), so quoting it would show the user a mangled version
+    // of what they typed.
+    if (label) offenders.push({ label, into: tokenize(stages[1])[0] ?? 'another command' });
+  }
+} catch {
+  allow(); // a detection-stage error -> pass (a bug in this hook must not block arbitrary Bash)
+}
+if (!offenders.length) allow();
+
+// -- Confirmed -> fails closed from here -------------------------------------------------------------
+try {
+  const { label, into } = offenders[0];
+  deny(
+    `This pipes a verify-shaped command (\`${label}\`) into \`${into}\`, so \`$?\` ` +
+      `reports the LAST stage's status, not the verifier's. A follow-up \`echo $?\` in a separate ` +
+      `Bash call is worse still — the tool resets the shell between calls, so that \`$?\` belongs to ` +
+      `a brand-new shell. Preserve the real status inside this same invocation, e.g.:\n` +
+      `  ${label} > /tmp/verify.log 2>&1; echo "EXIT:$?"; tail -200 /tmp/verify.log\n` +
+      `  set -o pipefail; ${label} 2>&1 | tail -200; echo "EXIT:$?"\n` +
+      `  ${label} 2>&1 | tail -200; echo "EXIT:\${PIPESTATUS[0]}"`,
+    'verify-piped-status-lost',
+  );
+} catch (e) {
+  deny(
+    `verify-pipe guard internal error (fail-closed): ${String(e?.message ?? e).split('\n')[0]}`,
+    'internal-error',
+  );
+}

--- a/tools/loop-engine/hooks/gate-worktree-create.mjs
+++ b/tools/loop-engine/hooks/gate-worktree-create.mjs
@@ -31,8 +31,41 @@
 // scope. Any `origin/*` ref is accepted, not just the integration branch — covering both the common
 // case and the documented exception (e.g. `git worktree add -b main <path> origin/main`, a
 // main-tracking-only worktree) with one rule.
+//
+// ── Second feature worktree in one session -> REQUIRE (human approval) ───────────────────────────
+// Second job (BAC-778): opening a *second* `feature/*` worktree inside one session is the mechanical
+// half of a scope boundary this harness draws in prose — a run takes one issue to an open PR and
+// STOPS there for the human. An audited run opened its PR and then started an entirely new issue in
+// the same session, with nothing to catch it. A second feature worktree is the earliest mechanically
+// observable moment of that, so this hook escalates it to `permissionDecision: "ask"` (Claude Code's
+// human-approval prompt = the gate vocabulary's REQUIRE) rather than denying: starting a second
+// feature is legitimate when a human says so, and only when a human says so.
+//
+// Exempt: everything that isn't a feature branch — `lessons/*`, `chore/*`, `fix/*`, `docs/*`, and a
+// detached or existing-branch worktree (already out of this hook's newBranch scope). The prefix is
+// read from a consuming repo's `.claude/ship-flow.config.json` -> `featureBranchPrefix`; without
+// config it defaults to `feature/`. Kill switch: LOOP_WORKTREE_SESSION_GATE_OFF=1.
+//
+// ⚠️ How "one session" is determined, and what that can't see (be honest about the limits):
+//   - The counter is keyed on the PreToolUse payload's `session_id`, persisted at
+//     `<CLAUDE_PROJECT_DIR>/.loop/worktree-gate.<session>.json` (same per-session-file technique as
+//     gate-stop-verdict.mjs's deny counter, and for the same reason — a shared file would let two
+//     concurrent sessions reset each other).
+//   - No `session_id` on the payload -> no escalation at all (allow). A missing id can't be told
+//     apart from "some other session", and collapsing every session into one bucket would REQUIRE on
+//     the second feature worktree *ever created in this repo*. Undeterminable -> don't claim it.
+//   - A subagent has its own session id, so a subagent-created worktree neither counts toward nor
+//     sees the parent's budget. A `--resume`/`--continue` that starts a new session id starts a new
+//     budget. Deleting `.loop/worktree-gate.*.json` resets it.
+//   - Worktrees created through Claude Code's own mechanisms (`EnterWorktree`, `Agent
+//     isolation:"worktree"`) never reach a Bash PreToolUse hook — same blind spot the header above
+//     already describes for the origin/* rule.
+//   - It counts *attempts*, deduped by branch name: a `git worktree add` that later fails on its own
+//     still consumes the budget (the hook runs before the command does), while retrying the same
+//     branch name doesn't double-count.
 
-import { readFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { basename, dirname, join } from 'node:path';
 import {
   firstSubcommand,
   GIT_VALUE_GLOBAL,
@@ -44,24 +77,43 @@ import {
 import { logRedEvent } from './red-events-log.mjs';
 
 // biome-ignore lint/suspicious/noUndeclaredEnvVars: Claude Code injects this at hook runtime.
-const root = process.env.CLAUDE_PROJECT_DIR ?? process.cwd();
+const env = process.env;
+const root = env.CLAUDE_PROJECT_DIR ?? process.cwd();
+
+const DEFAULT_FEATURE_PREFIX = 'feature/';
+
+function featureBranchPrefix(projectRoot) {
+  try {
+    const cfg = JSON.parse(
+      readFileSync(join(projectRoot, '.claude', 'ship-flow.config.json'), 'utf8'),
+    );
+    if (typeof cfg.featureBranchPrefix === 'string' && cfg.featureBranchPrefix) {
+      return cfg.featureBranchPrefix;
+    }
+  } catch {
+    /* missing/unreadable config -> fall through to the default */
+  }
+  return DEFAULT_FEATURE_PREFIX;
+}
 
 function allow() {
   process.exit(0);
 }
-function deny(reason, code) {
+function decide(decision, reason, code) {
   logRedEvent(root, { kind: 'worktree-create-guard', code });
   process.stdout.write(
     JSON.stringify({
       hookSpecificOutput: {
         hookEventName: 'PreToolUse',
-        permissionDecision: 'deny',
+        permissionDecision: decision,
         permissionDecisionReason: reason,
       },
     }),
   );
   process.exit(0);
 }
+const deny = (reason, code) => decide('deny', reason, code);
+const ask = (reason, code) => decide('ask', reason, code);
 
 // `git worktree add`'s own value flags — -b/-B are the new branch name, --reason is a --lock message.
 const VALUE_WORKTREE_ADD = new Set(['-b', '-B', '--reason']);
@@ -75,10 +127,14 @@ function parseWorktreeAdd(rawToks) {
   let i = wIdx + 2;
   let explicitNewBranch = false;
   let detachOrOrphan = false;
+  let explicitBranchName = null;
   const positional = [];
   while (i < toks.length) {
     const t = toks[i];
-    if (t === '-b' || t === '-B') explicitNewBranch = true;
+    if (t === '-b' || t === '-B') {
+      explicitNewBranch = true;
+      explicitBranchName = toks[i + 1] ?? null;
+    }
     if (t === '--detach' || t === '-d' || t === '--orphan') detachOrOrphan = true;
     if (t.startsWith('-')) {
       i += VALUE_WORKTREE_ADD.has(t) && !t.includes('=') ? 2 : 1;
@@ -91,7 +147,37 @@ function parseWorktreeAdd(rawToks) {
   // branch from local HEAD as if -b $(basename <path>) were given (per `git worktree add` docs) — the
   // same risk as an explicit -b/-B, so treated identically.
   const dwimNewBranch = !explicitNewBranch && !detachOrOrphan && positional.length <= 1;
-  return { newBranch: explicitNewBranch || dwimNewBranch, ref: positional[1] ?? null };
+  // The DWIM branch name is the path's basename, by the same doc'd rule.
+  const branch = explicitNewBranch
+    ? explicitBranchName
+    : dwimNewBranch && positional[0]
+      ? basename(positional[0])
+      : null;
+  return { newBranch: explicitNewBranch || dwimNewBranch, ref: positional[1] ?? null, branch };
+}
+
+// Per-session record of feature branches this session already opened a worktree for. Best-effort:
+// an unreadable/unwritable state file means the escalation simply doesn't fire (it must never turn
+// into a broken-state deny — the origin/* rule above is this hook's actual gate).
+function sessionStatePath(sessionId) {
+  const safe = String(sessionId).replace(/[^a-zA-Z0-9_-]/g, '').slice(0, 40);
+  return safe ? join(root, '.loop', `worktree-gate.${safe}.json`) : null;
+}
+function readSessionBranches(file) {
+  try {
+    const parsed = JSON.parse(readFileSync(file, 'utf8'));
+    return Array.isArray(parsed?.branches) ? parsed.branches.filter((b) => typeof b === 'string') : [];
+  } catch {
+    return [];
+  }
+}
+function writeSessionBranches(file, branches) {
+  try {
+    if (!existsSync(dirname(file))) mkdirSync(dirname(file), { recursive: true });
+    writeFileSync(file, `${JSON.stringify({ branches })}\n`);
+  } catch {
+    /* best-effort — a state-write failure must not change this hook's verdict */
+  }
 }
 
 // -- Detection (fail-open: an uncertain parse / a non-target command passes) -------------------------
@@ -133,6 +219,37 @@ try {
           "`git fetch origin && git worktree add -b <branch> <path> origin/<integration-branch>`.",
         'non-origin-ref',
       );
+    }
+  }
+
+  // -- Every origin/* check passed. Now the session-scope escalation (see header) ------------------
+  // Deliberately after the deny checks: a command that never runs must not consume the budget.
+  if (env.LOOP_WORKTREE_SESSION_GATE_OFF !== '1') {
+    const sessionId = typeof payload?.session_id === 'string' ? payload.session_id : '';
+    const stateFile = sessionId ? sessionStatePath(sessionId) : null;
+    if (stateFile) {
+      const prefix = featureBranchPrefix(root);
+      const newFeatureBranches = segs
+        .filter((s) => s.newBranch && typeof s.branch === 'string' && s.branch.startsWith(prefix))
+        .map((s) => s.branch);
+      if (newFeatureBranches.length) {
+        const seen = readSessionBranches(stateFile);
+        const unseen = newFeatureBranches.filter((b) => !seen.includes(b));
+        if (unseen.length) {
+          const after = [...seen, ...unseen];
+          writeSessionBranches(stateFile, after);
+          if (after.length > 1) {
+            ask(
+              `REQUIRE (human approval): this session already opened a ${prefix}* worktree ` +
+                `(${seen.join(', ')}), and this creates another one (${unseen.join(', ')}). One run ` +
+                `takes one issue to an open PR and stops there — starting a second feature in the ` +
+                `same session is a scope-boundary decision a human makes, not the run. Approve if ` +
+                `that's intended; otherwise finish (or hand off) the first one in a fresh session.`,
+              'second-feature-worktree',
+            );
+          }
+        }
+      }
     }
   }
   allow();

--- a/tools/loop-engine/hooks/hooks.json
+++ b/tools/loop-engine/hooks/hooks.json
@@ -83,7 +83,8 @@
         "hooks": [
           { "type": "command", "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/gate-before-merge.mjs\"", "timeout": 30 },
           { "type": "command", "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/gate-risky-commands.mjs\"", "timeout": 30 },
-          { "type": "command", "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/gate-worktree-create.mjs\"", "timeout": 15 }
+          { "type": "command", "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/gate-worktree-create.mjs\"", "timeout": 15 },
+          { "type": "command", "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/gate-verify-pipe.mjs\"", "timeout": 15 }
         ]
       }
     ],

--- a/tools/loop-engine/hooks/record-run-event.mjs
+++ b/tools/loop-engine/hooks/record-run-event.mjs
@@ -49,6 +49,25 @@ const PRE_SANITIZE_CAP = 2048;
 const capStr = (v) =>
   typeof v === 'string' && v.length > PRE_SANITIZE_CAP ? v.slice(0, PRE_SANITIZE_CAP) : v;
 
+// The key names (never the values) of a tool_input object, capped — a diagnostic fingerprint for
+// tools that carry neither `command` nor `file_path`.
+function inputKeys(toolInput) {
+  if (!toolInput || typeof toolInput !== 'object') return [];
+  return Object.keys(toolInput).slice(0, 20);
+}
+
+// Everything the platform sent that isn't a documented common field — used both for
+// instructions.loaded (whose event-specific fields aren't documented) and for an unattributable
+// subagent.stopped (see below: keeping the raw extras is the only way a later audit can discover an
+// identity field the platform supplies under a name we don't know yet).
+function restFields(input) {
+  const rest = {};
+  for (const [k, v] of Object.entries(input)) {
+    if (!COMMON_FIELDS.has(k)) rest[k] = capStr(v);
+  }
+  return rest;
+}
+
 function pickPayload(type, input, surfaceOf) {
   if (type === 'permission.requested' || type === 'permission.denied') {
     return {
@@ -63,10 +82,37 @@ function pickPayload(type, input, surfaceOf) {
       // classification impossible for very long commands. Aggregation should only count
       // surface==null interventions.
       surface: surfaceOf(input.tool_name, input.tool_input?.command),
+      // Bash carries `command` and Edit/Write carry `file_path`, but every other tool (measured in a
+      // real ledger: SendMessage, ScheduleWakeup) lands with tool_name and nothing else — a denial
+      // that can't be told apart from any other denial of the same tool afterwards. The key *names*
+      // of tool_input are enough to identify which shape it was, and unlike the values they can't
+      // carry a secret or blow up the ledger. Values stay excluded on purpose.
+      tool_input_keys: inputKeys(input.tool_input),
     };
   }
   if (type === 'subagent.started' || type === 'subagent.stopped') {
-    return { agent_id: input.agent_id, agent_type: input.agent_type };
+    // agent_type is recorded as null (absent), never '' — an empty string reads like "we captured a
+    // type and it happened to be blank", which is the opposite of what actually happened.
+    //
+    // Measured (glucofit-partners ledger, 7 days, 146 run files): of 2,307 subagent.stopped events,
+    // 1,896 carried agent_type '' and 411 carried a real type. Cross-checking agent_id against every
+    // subagent.started in the whole ledger is unambiguous — 405/405 distinct *typed* stop ids have a
+    // matching started; 1,901/1,901 distinct *untyped* stop ids have none. So the absence isn't
+    // truncation or a payload-shape mistake on our side: the platform fires SubagentStop for agent
+    // kinds whose SubagentStart never fires, and its stdin for those carries no agent_type. A hook
+    // cannot invent it. What a hook CAN do is stop pretending the two counts are comparable — hence
+    // attributable:false here, and a separate stopped_unattributed axis in bin/run-metrics.mjs so
+    // nothing downstream derives per-agent duration/success from a population it can't pair.
+    const agentType =
+      typeof input.agent_type === 'string' && input.agent_type ? input.agent_type : null;
+    const payload = { agent_id: input.agent_id, agent_type: agentType };
+    if (type === 'subagent.stopped' && agentType === null) {
+      payload.attributable = false;
+      // Carry whatever else the platform did send. If a future runtime starts supplying identity
+      // under a different key, it lands in the ledger and the next audit sees it instead of guessing.
+      payload.extra = restFields(input);
+    }
+    return payload;
   }
   if (type === 'run.started' || type === 'run.ended') {
     return { cwd: input.cwd, reason: input.reason, permission_mode: input.permission_mode };
@@ -79,11 +125,7 @@ function pickPayload(type, input, surfaceOf) {
   // instructions.loaded — the event-specific fields aren't documented: carry everything except the
   // common fields, still pre-truncating unknown long strings (sanitize's blocklist/cap defends the
   // content).
-  const rest = {};
-  for (const [k, v] of Object.entries(input)) {
-    if (!COMMON_FIELDS.has(k)) rest[k] = capStr(v);
-  }
-  return rest;
+  return restFields(input);
 }
 
 async function main() {

--- a/tools/loop-engine/lib/run-ledger.mjs
+++ b/tools/loop-engine/lib/run-ledger.mjs
@@ -22,9 +22,10 @@
 // 제어 입력(stall 판정·승격 신호 등)으로 승격하려면 protect 편입 또는 산출기 서명을 먼저 결정할
 // 것 — 머지 게이트의 진실은 여전히 verdict-state.json + Stop 훅이다.
 
+import { execFileSync } from 'node:child_process'
 import { randomUUID } from 'node:crypto'
-import { appendFileSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs'
-import { join } from 'node:path'
+import { appendFileSync, existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
 import { sanitizeRecord } from './sanitize.mjs'
 
 export function runsDir(root) {
@@ -80,4 +81,68 @@ export function appendRunEvent(root, { type, sessionId, runId, payload, writeCur
     }
   }
   return event
+}
+
+// ── verdict 이벤트 귀속 해소 (BAC-778) ───────────────────────────────────────────────────────
+// 문제(실측): 계측 훅(record-run-event.mjs)은 CLAUDE_PROJECT_DIR 아래 원장에 쓰는데 verdict-run.sh는
+// **cwd** 아래에 쓴다. 워크트리 격리 규약을 지키는 레포에선 이 둘이 상시로 갈린다 — 검증은 링크된
+// 워크트리에서 돌고 세션 이벤트는 메인 워크트리에 남는다. 게다가 워크트리엔 `.loop/runs/current`가
+// 없어 run-id까지 'unknown'으로 떨어진다. 결과: 세션 원장에 verdict.* 이벤트가 한 건도 없고
+// run-metrics의 Q1(first-pass)·Q2가 전 런 INSUFFICIENT_DATA가 된다. (glucofit-partners 7일 실측:
+// 메인 원장 = 3,096 이벤트 / 111 런 / verdict.* 0건. 같은 시점 워크트리 하나의 unknown.jsonl =
+// verdict.passed 14 + verdict.failed 2 — 이벤트는 산출되고 있었고, 원장이 갈려 있었을 뿐이다.)
+//
+// 해소는 **추측이 아니라 확증(corroboration)**으로 한다: 후보 루트 중 `<root>/.loop/runs/<run-id>.jsonl`이
+// **이미 존재하는** 곳에만 붙인다 — 그 파일 자체가 "훅이 이 세션의 이벤트를 여기 쓰고 있다"는 증거다.
+// 확증이 하나도 없으면 기존 동작(cwd + current 포인터 + unknown 버킷)이 한 글자도 안 바뀐다.
+//
+// run-id 우선순위: ① CLAUDE_CODE_SESSION_ID ② `.loop/runs/current` ③ 'unknown'.
+//   ①은 Bash 툴 호출 환경에 실제로 주입된다(실측 확인) — 훅이 stdin으로 받는 session_id와 같은 값이라
+//   세션 원장 파일명과 일치하고, current 포인터의 동시-세션 last-writer-wins 오귀속에 면역이다.
+// 루트 후보: CLAUDE_PROJECT_DIR → cwd → 메인 워크트리 루트.
+//   ⚠️ CLAUDE_PROJECT_DIR는 **훅 프로세스에만** 주입되고 Bash 툴 호출에는 없다(실측: UNSET) — 그래서
+//   `git rev-parse --git-common-dir`로 메인 워크트리를 유추하는 세 번째 후보가 필요하다. git 호출은
+//   best-effort(2초 타임아웃 — 실패하면 그 후보가 없는 것으로 친다).
+function mainWorktreeRoot(cwd) {
+  try {
+    const common = execFileSync('git', ['rev-parse', '--git-common-dir'], {
+      cwd,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: 2000,
+    }).trim()
+    if (!common) return null
+    const abs = resolve(cwd, common)
+    // 통상 형태는 `<메인 워크트리>/.git` — bare repo 등 그 외 형태는 메인 워크트리가 없다고 본다.
+    return abs.endsWith('/.git') ? dirname(abs) : null
+  } catch {
+    return null
+  }
+}
+
+export function resolveLedgerTarget({ cwd, env } = {}) {
+  const base = cwd ?? process.cwd()
+  const e = env ?? {}
+  const roots = []
+  const push = (d) => {
+    if (typeof d === 'string' && d && !roots.includes(d)) roots.push(d)
+  }
+  push(e.CLAUDE_PROJECT_DIR)
+  push(base)
+  push(mainWorktreeRoot(base))
+
+  const sid = runIdFrom(e.CLAUDE_CODE_SESSION_ID)
+  if (sid !== 'unknown') {
+    for (const r of roots) {
+      // 확증: 훅이 이미 이 세션 파일을 쓰고 있는 원장에만 붙는다.
+      if (existsSync(join(runsDir(r), `${sid}.jsonl`))) {
+        return { root: r, runId: sid, source: 'session-id' }
+      }
+    }
+  }
+  for (const r of roots) {
+    const rid = readCurrentRunId(r)
+    if (rid !== 'unknown') return { root: r, runId: rid, source: 'current-pointer' }
+  }
+  return { root: base, runId: 'unknown', source: 'unattributed' }
 }

--- a/tools/loop-engine/test/gate-verify-pipe.test.sh
+++ b/tools/loop-engine/test/gate-verify-pipe.test.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# Behavioral test for hooks/gate-verify-pipe.mjs (BAC-778).
+#
+# Contract: a verify-shaped command piped into another command, in an invocation that does nothing
+# to preserve the real exit status, is denied. Anything that keeps the status (pipefail / PIPESTATUS
+# / a redirect instead of a pipe) passes, and so does every command that isn't verify-shaped.
+# Detection fails open; once confirmed it fails closed. hermetic: no git, no docker, no network.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+HOOK="$HERE/../hooks/gate-verify-pipe.mjs"
+
+fail() { echo "FAIL: $1"; exit 1; }
+[ -f "$HOOK" ] || fail "gate-verify-pipe.mjs not found at $HOOK"
+
+DIR="$(mktemp -d "${TMPDIR:-/tmp}/tmp.XXXXXXXX")" || fail "mktemp -d failed"
+trap 'rm -rf "$DIR"' EXIT
+
+# run <command-string> [extra-json-fields] -> prints the hook's stdout
+run() {
+  node -e '
+    const [cmd] = process.argv.slice(1);
+    process.stdout.write(JSON.stringify({ tool_name: "Bash", tool_input: { command: cmd } }));
+  ' "$1" | CLAUDE_PROJECT_DIR="$DIR" node "$HOOK" 2>"$DIR/stderr"
+}
+expect_deny() {
+  local out
+  out="$(run "$1")" || fail "hook must always exit 0, got non-zero for: $1"
+  printf '%s' "$out" | grep -q '"permissionDecision":"deny"' \
+    || fail "expected deny for: $1 (got: ${out:-<empty>})"
+}
+expect_allow() {
+  local out
+  out="$(run "$1")" || fail "hook must always exit 0, got non-zero for: $1"
+  [ -z "$out" ] || fail "expected allow (no stdout) for: $1 (got: $out)"
+}
+
+# ── 1) 감사에서 실제로 나온 형태 — cd && timeout … pnpm verify 2>&1 | tail (RED) ────────────────
+# `2>&1`의 `&`가 문장 분리자로 오인되면 파이프라인 첫 단계가 verify가 아니게 되어 탐지가 조용히
+# 죽는다 — 이 케이스가 그 회귀를 잠근다(실측 형태 그대로).
+expect_deny 'cd /tmp/wt && timeout 590 pnpm verify 2>&1 | tail -200'
+echo "PASS: the audited form (cd && timeout … pnpm verify 2>&1 | tail) is denied"
+
+# ── 2) 최소 형태 + 러너/스크립트 변형 ────────────────────────────────────────────────────────
+expect_deny 'pnpm verify | tail -200'
+expect_deny 'pnpm run verify | head'
+expect_deny 'pnpm --filter @x/db verify:rls | tail -50'
+expect_deny 'tools/loop-engine/bin/verdict-run.sh -- pnpm verify | tail -20'
+echo "PASS: runner variants (run / --filter / :suffix) and a direct verdict-run.sh call are denied"
+
+# 기본 패턴은 이 하네스의 어휘(verify/verdict)에 한정 — 아무 스크립트나 잡지 않는다.
+expect_allow 'npm test | tail'
+echo "PASS: the default pattern is scoped to verify/verdict (npm test | tail is not this gate's business)"
+
+# ── 3) 상태를 보존하는 형태는 통과 ───────────────────────────────────────────────────────────
+expect_allow 'set -o pipefail; pnpm verify 2>&1 | tail -200; echo "EXIT:$?"'
+expect_allow 'pnpm verify 2>&1 | tail -200; echo "EXIT:${PIPESTATUS[0]}"'
+expect_allow 'pnpm verify > /tmp/v.log 2>&1; echo "EXIT:$?"; tail -200 /tmp/v.log'
+echo "PASS: pipefail / PIPESTATUS / redirect-plus-\$? forms are allowed"
+
+# ── 4) verify가 아닌 파이프라인, 파이프 없는 verify는 무관 ───────────────────────────────────
+expect_allow 'git log --oneline | head -20'
+expect_allow 'ls -la | grep verify'
+expect_allow 'pnpm verify'
+expect_allow 'cat notes.txt | grep verdict'
+echo "PASS: non-verify pipelines and un-piped verify are untouched"
+
+# ── 5) 파이프 뒤쪽에 verify가 오는 건 대상이 아니다(그 경우 \$?가 곧 verify의 상태다) ──────────
+expect_allow 'cat cmds.txt | xargs -I{} echo {}'
+echo "PASS: only the FIRST pipeline stage being verify-shaped trips the gate"
+
+# ── 6) Bash가 아닌 툴 / 빈 명령 / 깨진 stdin → allow (감지 단계 fail-open) ────────────────────
+OUT="$(printf '{"tool_name":"Edit","tool_input":{"file_path":"/tmp/x"}}' | node "$HOOK")" \
+  || fail "non-Bash tool must exit 0"
+[ -z "$OUT" ] || fail "non-Bash tool must allow silently, got: $OUT"
+OUT="$(printf 'not json at all {{{' | node "$HOOK")" || fail "broken stdin must exit 0"
+[ -z "$OUT" ] || fail "broken stdin must allow silently, got: $OUT"
+echo "PASS: non-Bash tools and unparseable stdin fail open"
+
+# ── 7) 킬스위치 ─────────────────────────────────────────────────────────────────────────────
+OUT="$(node -e 'process.stdout.write(JSON.stringify({tool_name:"Bash",tool_input:{command:"pnpm verify | tail"}}))' \
+  | LOOP_VERIFY_PIPE_GATE_OFF=1 node "$HOOK")" || fail "kill switch must exit 0"
+[ -z "$OUT" ] || fail "LOOP_VERIFY_PIPE_GATE_OFF=1 must disable the gate, got: $OUT"
+echo "PASS: LOOP_VERIFY_PIPE_GATE_OFF=1 disables the gate"
+
+# ── 8) verifyCommandPattern 설정이 기본값을 교체한다(제품 고유 어휘 하드코딩 금지) ──────────────
+CFG="$DIR/cfg"
+mkdir -p "$CFG/.claude"
+printf '{"verifyCommandPattern":"^gate$"}' > "$CFG/.claude/ship-flow.config.json"
+cfg_run() {
+  node -e 'process.stdout.write(JSON.stringify({tool_name:"Bash",tool_input:{command:process.argv[1]}}))' "$1" \
+    | CLAUDE_PROJECT_DIR="$CFG" node "$HOOK"
+}
+OUT="$(cfg_run 'pnpm gate | tail')"
+printf '%s' "$OUT" | grep -q '"permissionDecision":"deny"' \
+  || fail "configured verifyCommandPattern must be honored (pnpm gate | tail), got: ${OUT:-<empty>}"
+OUT="$(cfg_run 'pnpm verify | tail')"
+[ -z "$OUT" ] || fail "a configured pattern must fully REPLACE the default (pnpm verify no longer matches), got: $OUT"
+echo "PASS: .claude/ship-flow.config.json verifyCommandPattern replaces the built-in default"
+
+exit 0

--- a/tools/loop-engine/test/hooks-json-wiring.test.sh
+++ b/tools/loop-engine/test/hooks-json-wiring.test.sh
@@ -97,6 +97,7 @@ run_allow() {
 run_allow "gate-before-merge.mjs" '{"tool_name":"Bash","tool_input":{"command":"ls -la"}}'
 run_allow "gate-risky-commands.mjs" '{"tool_name":"Bash","tool_input":{"command":"ls -la"}}'
 run_allow "gate-worktree-create.mjs" '{"tool_name":"Bash","tool_input":{"command":"ls -la"}}'
+run_allow "gate-verify-pipe.mjs" '{"tool_name":"Bash","tool_input":{"command":"ls -la"}}'
 run_allow "warn-partial-checkout.mjs" '{"tool_name":"Bash","tool_input":{"command":"ls -la"}}'
 run_allow "protect-during-loop.mjs" '{"tool_name":"Write","tool_input":{"file_path":"/tmp/not-protected.txt"}}'
 run_allow "gate-stop-verdict.mjs" '{"session_id":"hooks-json-wiring-test"}'

--- a/tools/loop-engine/test/ledger-attribution.test.sh
+++ b/tools/loop-engine/test/ledger-attribution.test.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# Regression test for verdict-event attribution — lib/run-ledger.mjs resolveLedgerTarget() +
+# bin/ledger-append.mjs --auto-run-id + bin/verdict-run.sh (BAC-778).
+#
+# The hole this closes (measured in a consuming repo over 7 days): the instrumentation hook writes
+# under CLAUDE_PROJECT_DIR while verdict-run.sh writes under its own cwd. A repo that isolates work
+# in git worktrees splits those two apart on every single run — 3,096 events across 111 run files in
+# the main ledger with ZERO verdict.* events, while one worktree's .loop/runs/unknown.jsonl held 14
+# verdict.passed + 2 verdict.failed. Q1 (first-pass green) and Q2 therefore reported
+# INSUFFICIENT_DATA for every run: the loop's headline metric was unmeasurable from its own ledger.
+#
+# Contract locked here:
+#   - Attribution is by CORROBORATION, never by guessing: an event only moves to another root if
+#     that root already holds `<run-id>.jsonl` (proof the hook is writing this session there).
+#   - With no corroboration, the previous behaviour is byte-for-byte unchanged (cwd + the current
+#     pointer + the unknown bucket) — that's what test/run-ledger.test.sh already pins.
+# hermetic: mktemp + a real git worktree pair, no docker/network.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$HERE/../../.."
+LIB="$ROOT/tools/loop-engine/lib/run-ledger.mjs"
+APPEND="$ROOT/tools/loop-engine/bin/ledger-append.mjs"
+VRUN="$ROOT/tools/loop-engine/bin/verdict-run.sh"
+
+fail() { echo "FAIL: $1"; exit 1; }
+[ -f "$LIB" ] || fail "run-ledger.mjs not found at $LIB"
+[ -f "$APPEND" ] || fail "ledger-append.mjs not found at $APPEND"
+[ -x "$VRUN" ] || fail "verdict-run.sh not found/executable at $VRUN"
+
+DIR="$(mktemp -d "${TMPDIR:-/tmp}/tmp.XXXXXXXX")" || fail "mktemp -d failed"
+DIR="$(cd -P "$DIR" && pwd)"
+trap 'chmod -R u+w "$DIR" 2>/dev/null; rm -rf "$DIR"' EXIT
+
+# ── 0) 메인 워크트리 + 링크된 워크트리 (실제 실패 형상 재현) ──────────────────────────────────
+MAIN="$DIR/main"
+mkdir -p "$MAIN"
+git -C "$MAIN" init -q -b main
+printf '.loop/\n' > "$MAIN/.gitignore"
+echo x > "$MAIN/f.txt"
+git -C "$MAIN" add .
+git -C "$MAIN" -c user.email=t@t -c user.name=t commit -qm init
+WT="$DIR/wt"
+git -C "$MAIN" worktree add -q --detach "$WT" HEAD >/dev/null 2>&1 || fail "could not create the linked worktree fixture"
+
+SID="sess-abc-123"
+# 훅이 이미 메인 워크트리에 이 세션의 원장을 쓰고 있는 상태를 만든다(= 확증의 근거).
+mkdir -p "$MAIN/.loop/runs"
+printf '{"id":"x","type":"run.started","ts":"2026-08-24T00:00:00.000Z","aggregate_id":"%s","payload":{},"version":1}\n' "$SID" \
+  > "$MAIN/.loop/runs/$SID.jsonl"
+
+# ── 1) 워크트리에서 돈 verdict가 메인 워크트리의 *세션* 원장에 착지한다 ────────────────────────
+( cd "$WT" && CLAUDE_CODE_SESSION_ID="$SID" VERDICT_RUN_LEDGER_NESTED= "$VRUN" -- true >/dev/null 2>&1 )
+rc=$?
+[ "$rc" = "0" ] || fail "verdict-run -- true in the worktree must still exit 0, got $rc"
+grep -q '"type":"verdict.passed"' "$MAIN/.loop/runs/$SID.jsonl" \
+  || fail "a verdict run inside a linked worktree must land in the session ledger at the main worktree ($MAIN/.loop/runs/$SID.jsonl)"
+[ ! -f "$WT/.loop/runs/unknown.jsonl" ] \
+  || fail "the verdict must no longer be orphaned into the worktree's unknown bucket"
+echo "PASS: a verdict run inside a linked worktree attributes to the session ledger (the measured hole)"
+
+# ── 1b) 출처는 잃지 않는다 — payload.cwd가 어느 워크트리였는지 남긴다 ─────────────────────────
+node -e '
+  const fs = require("node:fs");
+  const [file, wt] = process.argv.slice(1);
+  const ev = fs.readFileSync(file, "utf8").trim().split("\n").map(JSON.parse)
+    .find((e) => e.type === "verdict.passed");
+  if (!ev) throw new Error("no verdict.passed event found");
+  if (ev.aggregate_id !== process.argv[3]) throw new Error("aggregate_id must be the session id, got " + ev.aggregate_id);
+  if (ev.payload.cwd !== wt) throw new Error("payload.cwd must record the worktree the verify ran in, got " + ev.payload.cwd);
+' "$MAIN/.loop/runs/$SID.jsonl" "$WT" "$SID" || fail "redirected verdict event must stay diagnosable (aggregate_id + payload.cwd)"
+echo "PASS: the redirected event keeps its provenance (aggregate_id=session, payload.cwd=worktree)"
+
+# ── 2) 확증이 없으면 아무것도 바뀌지 않는다 — cwd + unknown 버킷 (기존 계약 불변) ───────────────
+NOCORR="$DIR/nocorr"
+mkdir -p "$NOCORR"
+( cd "$NOCORR" && printf '{}' \
+  | CLAUDE_CODE_SESSION_ID="totally-unrelated-session" node "$APPEND" --type verdict.failed --auto-run-id ) \
+  || fail "uncorroborated append must still succeed"
+[ -f "$NOCORR/.loop/runs/unknown.jsonl" ] \
+  || fail "with no corroborating session ledger anywhere, the event must stay in cwd's unknown bucket"
+[ ! -f "$NOCORR/.loop/runs/totally-unrelated-session.jsonl" ] \
+  || fail "a session id must NEVER create a new ledger file on its own — corroboration only"
+echo "PASS: without corroboration the previous behaviour (cwd + unknown bucket) is unchanged"
+
+# ── 3) current 포인터는 세션 id가 확증되지 않을 때의 폴백으로 남는다 ──────────────────────────
+PTR="$DIR/ptr"
+mkdir -p "$PTR/.loop/runs"
+printf 'runptr\n' > "$PTR/.loop/runs/current"
+( cd "$PTR" && printf '{}' | CLAUDE_CODE_SESSION_ID="no-such-session" node "$APPEND" --type verdict.passed --auto-run-id ) \
+  || fail "current-pointer fallback append failed"
+[ -f "$PTR/.loop/runs/runptr.jsonl" ] \
+  || fail "an unconfirmable session id must fall back to the current pointer, not shadow it"
+echo "PASS: the current pointer stays the fallback when the session id can't be corroborated"
+
+# ── 4) 세션 id 확증이 current 포인터보다 우선한다(동시 세션 last-writer-wins 오귀속 차단) ───────
+# 같은 원장에 다른 세션이 마지막으로 쓴 포인터가 있어도, 내 세션 파일이 있으면 내 것으로 간다.
+BOTH="$DIR/both"
+mkdir -p "$BOTH/.loop/runs"
+printf 'other-session\n' > "$BOTH/.loop/runs/current"
+: > "$BOTH/.loop/runs/mine.jsonl"
+( cd "$BOTH" && printf '{}' | CLAUDE_CODE_SESSION_ID="mine" node "$APPEND" --type verdict.passed --auto-run-id ) \
+  || fail "session-id-priority append failed"
+grep -q '"aggregate_id":"mine"' "$BOTH/.loop/runs/mine.jsonl" \
+  || fail "a corroborated session id must win over a concurrent session's current pointer"
+[ ! -s "$BOTH/.loop/runs/other-session.jsonl" ] 2>/dev/null \
+  || fail "the event must not be misattributed to the pointer's session"
+echo "PASS: a corroborated session id beats the current pointer (concurrent-session misattribution closed)"
+
+# ── 5) --run-id 명시 경로는 루트 해소를 타지 않는다(호출자가 이미 정한 곳에 쓴다) ───────────────
+EXPL="$DIR/expl"
+mkdir -p "$EXPL"
+( cd "$EXPL" && printf '{}' | CLAUDE_CODE_SESSION_ID="$SID" node "$APPEND" --type verdict.passed --run-id fixed ) \
+  || fail "--run-id append failed"
+[ -f "$EXPL/.loop/runs/fixed.jsonl" ] || fail "--run-id must write to cwd with the given id"
+echo "PASS: an explicit --run-id is untouched by attribution resolution"
+
+# ── 6) run-metrics가 실제로 Q1/Q2를 산출한다 — 이 수정의 존재 이유 ────────────────────────────
+JSON="$(node "$ROOT/tools/loop-engine/bin/run-metrics.mjs" --runs-dir "$MAIN/.loop/runs" --json)" \
+  || fail "run-metrics on the repaired ledger must exit 0"
+node -e '
+  const m = JSON.parse(process.argv[1]);
+  const run = m.runs.find((r) => r.run_id === process.argv[2]);
+  if (!run) throw new Error("the session run must appear");
+  if (run.q2 === "INSUFFICIENT_DATA") throw new Error("Q2 must be computable now, got INSUFFICIENT_DATA");
+  if (run.first_pass !== true) throw new Error("first_pass must be true (the only verdict passed), got " + run.first_pass);
+  if (m.overall.q1 === "INSUFFICIENT_DATA") throw new Error("overall Q1 must be computable now");
+' "$JSON" "$SID" || fail "the repaired ledger must make Q1/first_pass computable (the whole point)"
+echo "PASS: Q1/first_pass are computable from the session ledger (was INSUFFICIENT_DATA for every run)"
+
+exit 0

--- a/tools/loop-engine/test/pr-reviewer-coverage.test.sh
+++ b/tools/loop-engine/test/pr-reviewer-coverage.test.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# Behavioral test for bin/check-pr-hygiene.mjs's reviewer-coverage check (BAC-778).
+#
+# Motivation (measured): an audited run summoned only 2 of its 3 mandated review agents and opened
+# the PR anyway; no gate caught it. Reviewer *names* are consumer-repo specific, so this plugin
+# takes them as `--reviewers` config and ships none of its own — exactly like `--pattern`.
+#
+# Contract: without --reviewers nothing changes (the tracker-reference behaviour that
+# test/check-pr-hygiene.test.sh already pins). With --reviewers, every named reviewer must appear in
+# the body with a result token on its line or within the next 2 lines; a bare mention is not a
+# result block. Exit 1 if any reviewer is missing, even when the tracker reference is present.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+CHECK="$HERE/../bin/check-pr-hygiene.mjs"
+
+fail() { echo "FAIL: $1"; exit 1; }
+[ -f "$CHECK" ] || fail "check-pr-hygiene.mjs not found at $CHECK"
+
+DIR="$(mktemp -d "${TMPDIR:-/tmp}/tmp.XXXXXXXX")" || fail "mktemp -d failed"
+trap 'rm -rf "$DIR"' EXIT
+
+REVIEWERS='code-reviewer,test-hunter,verifier-integrity-hunter'
+
+cat > "$DIR/all-three.md" <<'EOF'
+BAC-778 구현.
+
+## 리뷰
+### code-reviewer
+PASS — 컨벤션 위반 없음.
+### test-hunter
+블로커 없음 (behavioural 커버리지 확인).
+### verifier-integrity-hunter
+PASS — 테스트 약화·검증기 우회 흔적 없음.
+EOF
+
+cat > "$DIR/only-two.md" <<'EOF'
+BAC-778 구현.
+
+## 리뷰
+### code-reviewer
+PASS — 컨벤션 위반 없음.
+### test-hunter
+PASS — 커버리지 충분.
+EOF
+
+cat > "$DIR/mention-only.md" <<'EOF'
+BAC-778 구현.
+
+### code-reviewer
+PASS.
+### test-hunter
+PASS.
+
+verifier-integrity-hunter는 이번에 돌리지 않았고 다음 PR에서 볼 예정이다. 특별한 이유는 없다.
+그냥 시간이 없었다. 다음 문단은 관계 없는 내용이다.
+EOF
+
+# ── 1) 3종 결과 블록이 다 있으면 exit 0 ──────────────────────────────────────────────────────
+OUT="$(node "$CHECK" --body-file "$DIR/all-three.md" --reviewers "$REVIEWERS" --json)"; rc=$?
+[ "$rc" = "0" ] || fail "all three reviewer blocks must exit 0, got $rc: $OUT"
+node -e '
+  const r = JSON.parse(process.argv[1]);
+  if (r.reviewers.ok !== true) throw new Error("reviewers.ok must be true, got " + JSON.stringify(r.reviewers));
+  if (r.reviewers.missing.length !== 0) throw new Error("missing must be empty, got " + JSON.stringify(r.reviewers.missing));
+  if (r.matched !== "BAC-778") throw new Error("the tracker-ref check must still run, got " + JSON.stringify(r.matched));
+' "$OUT" || fail "all-three JSON shape wrong"
+echo "PASS: a PR body with result blocks for all three reviewers exits 0"
+
+# ── 2) 한 명이 통째로 빠지면 exit 1 + 누가 빠졌는지 이름을 낸다 (감사에서 나온 실제 형태) ────────
+OUT="$(node "$CHECK" --body-file "$DIR/only-two.md" --reviewers "$REVIEWERS" --json)"; rc=$?
+[ "$rc" = "1" ] || fail "a missing reviewer must exit 1, got $rc: $OUT"
+node -e '
+  const r = JSON.parse(process.argv[1]);
+  if (r.ok !== false) throw new Error("overall ok must be false");
+  if (JSON.stringify(r.reviewers.missing) !== JSON.stringify(["verifier-integrity-hunter"]))
+    throw new Error("missing must name exactly the absent reviewer, got " + JSON.stringify(r.reviewers.missing));
+  if (r.matched !== "BAC-778") throw new Error("a present tracker ref must not mask the reviewer failure");
+' "$OUT" || fail "only-two JSON shape wrong"
+echo "PASS: 2-of-3 reviewers exits 1 and names the missing one (the audited failure)"
+
+# ── 3) 결과 없는 단순 언급은 결과 블록이 아니다 ──────────────────────────────────────────────
+OUT="$(node "$CHECK" --body-file "$DIR/mention-only.md" --reviewers "$REVIEWERS" --json)"; rc=$?
+[ "$rc" = "1" ] || fail "a bare mention must not count as a result block, got $rc: $OUT"
+printf '%s' "$OUT" | grep -q 'verifier-integrity-hunter' \
+  || fail "the bare-mention reviewer must be reported missing, got: $OUT"
+echo "PASS: mentioning a reviewer's name in prose with no nearby verdict does not count"
+
+# ── 4) --reviewers 없으면 기존 계약 그대로 (opt-in) ──────────────────────────────────────────
+OUT="$(node "$CHECK" --body-file "$DIR/only-two.md" --json)"; rc=$?
+[ "$rc" = "0" ] || fail "without --reviewers the check must not run, got $rc: $OUT"
+node -e '
+  const r = JSON.parse(process.argv[1]);
+  if ("reviewers" in r) throw new Error("no --reviewers -> no reviewers key at all, got " + JSON.stringify(r));
+' "$OUT" || fail "opt-in contract broken"
+echo "PASS: without --reviewers the reviewer check is absent entirely (opt-in)"
+
+# ── 5) 리뷰어 이름은 하드코딩되지 않는다 — 임의의 이름 집합이 그대로 동작 ─────────────────────
+printf 'PROJ-1\n\nsecurity-bot\nAPPROVED\n' > "$DIR/custom.md"
+OUT="$(node "$CHECK" --body-file "$DIR/custom.md" --reviewers 'security-bot' --json)"; rc=$?
+[ "$rc" = "0" ] || fail "an arbitrary reviewer name must work, got $rc: $OUT"
+OUT="$(node "$CHECK" --body-file "$DIR/custom.md" --reviewers 'security-bot,perf-bot' --json)"; rc=$?
+[ "$rc" = "1" ] || fail "an absent arbitrary reviewer must exit 1, got $rc: $OUT"
+# 주석의 예시 언급은 허용 — 금지 대상은 *코드*에 박힌 기본 리뷰어 목록이다.
+grep -vE '^[[:space:]]*(//|\*|/\*)' "$CHECK" \
+  | grep -q 'code-reviewer\|test-hunter\|verifier-integrity-hunter' \
+  && fail "this plugin must not hardcode any consuming repo's reviewer names in code"
+echo "PASS: reviewer names come entirely from config — none are hardcoded in the plugin"
+
+# ── 6) --result-pattern으로 판정 어휘를 교체할 수 있다 ────────────────────────────────────────
+printf 'PROJ-2\n\nlint-bot\nVERDICT_GREEN\n' > "$DIR/tok.md"
+OUT="$(node "$CHECK" --body-file "$DIR/tok.md" --reviewers 'lint-bot' --json)"; rc=$?
+[ "$rc" = "1" ] || fail "an unrecognised result token must fail by default, got $rc: $OUT"
+OUT="$(node "$CHECK" --body-file "$DIR/tok.md" --reviewers 'lint-bot' --result-pattern 'VERDICT_(GREEN|RED)' --json)"; rc=$?
+[ "$rc" = "0" ] || fail "--result-pattern must replace the default token vocabulary, got $rc: $OUT"
+echo "PASS: --result-pattern replaces the default result vocabulary"
+
+# ── 7) 이름이 다른 이름의 부분문자열이어도 오탐하지 않는다 ────────────────────────────────────
+printf 'PROJ-3\n\nmeta-code-reviewer\nPASS\n' > "$DIR/sub.md"
+OUT="$(node "$CHECK" --body-file "$DIR/sub.md" --reviewers 'code-reviewer' --json)"; rc=$?
+[ "$rc" = "1" ] || fail "'meta-code-reviewer' must not satisfy 'code-reviewer', got $rc: $OUT"
+echo "PASS: a reviewer name embedded in a longer name does not satisfy coverage"
+
+exit 0

--- a/tools/loop-engine/test/subagent-event-shape.test.sh
+++ b/tools/loop-engine/test/subagent-event-shape.test.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# Regression test for the subagent event shape + its fold (BAC-778):
+#   hooks/record-run-event.mjs (SubagentStart/SubagentStop payload) and bin/run-metrics.mjs.
+#
+# What was measured, and why the fix is a shape change rather than a "populate the field" change
+# (glucofit-partners ledger, 7 days, 146 run files):
+#   - subagent.stopped: 2,307 events, of which 1,896 carried agent_type "" and 411 a real type.
+#   - subagent.started: 472 events — stopped outnumbered started ~5x, so "stopped count" looked like
+#     a subagent population it could not support.
+#   - Cross-checking agent_id across the WHOLE ledger settles the cause: 405/405 distinct typed stop
+#     ids have a matching started; 1,901/1,901 distinct untyped stop ids have none. The platform
+#     fires SubagentStop for agent kinds whose SubagentStart never fires, and its stdin for those
+#     carries no agent_type at all. A hook cannot invent it.
+# So the contract locked here is honesty, not fabrication: absent -> null (never ""),
+# attributable:false, whatever else the platform sent kept under `extra` so a later audit can find
+# an identity field we don't know about yet, and a fold that never mixes paired with unpaired stops.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$HERE/../../.."
+HOOK="$ROOT/tools/loop-engine/hooks/record-run-event.mjs"
+METRICS="$ROOT/tools/loop-engine/bin/run-metrics.mjs"
+
+fail() { echo "FAIL: $1"; exit 1; }
+[ -f "$HOOK" ] || fail "record-run-event.mjs not found at $HOOK"
+[ -f "$METRICS" ] || fail "run-metrics.mjs not found at $METRICS"
+
+DIR="$(mktemp -d "${TMPDIR:-/tmp}/tmp.XXXXXXXX")" || fail "mktemp -d failed"
+trap 'rm -rf "$DIR"' EXIT
+
+emit() { # $1=project-dir  $2=stdin-json
+  printf '%s' "$2" | CLAUDE_PROJECT_DIR="$1" node "$HOOK" >/dev/null 2>"$DIR/stderr" \
+    || fail "record-run-event.mjs threw (stderr: $(cat "$DIR/stderr"))"
+}
+
+# ── 1) 타입 있는 started/stopped — 그대로 기록된다 ────────────────────────────────────────────
+P="$DIR/p"
+mkdir -p "$P"
+emit "$P" '{"session_id":"s1","hook_event_name":"SubagentStart","agent_id":"a1","agent_type":"code-reviewer"}'
+emit "$P" '{"session_id":"s1","hook_event_name":"SubagentStop","agent_id":"a1","agent_type":"code-reviewer"}'
+node -e '
+  const fs = require("node:fs");
+  const evs = fs.readFileSync(process.argv[1], "utf8").trim().split("\n").map(JSON.parse);
+  const started = evs.find((e) => e.type === "subagent.started");
+  const stopped = evs.find((e) => e.type === "subagent.stopped");
+  if (started.payload.agent_type !== "code-reviewer") throw new Error("started agent_type wrong: " + JSON.stringify(started.payload));
+  if (stopped.payload.agent_type !== "code-reviewer") throw new Error("stopped agent_type wrong: " + JSON.stringify(stopped.payload));
+  if ("attributable" in stopped.payload) throw new Error("a typed stop must NOT be flagged unattributable");
+' "$P/.loop/runs/s1.jsonl" || fail "typed subagent events must record their agent_type unchanged"
+echo "PASS: a typed SubagentStart/Stop pair records agent_type unchanged"
+
+# ── 2) agent_type 부재 → null(빈 문자열 아님) + attributable:false + extra 보존 ────────────────
+# 빈 문자열은 "타입을 잡았는데 그게 비어 있었다"로 읽힌다 — 실제로 일어난 일과 정반대다.
+Q="$DIR/q"
+mkdir -p "$Q"
+emit "$Q" '{"session_id":"s2","hook_event_name":"SubagentStop","agent_id":"a9","agent_type":"","some_future_id":"ff-77"}'
+node -e '
+  const fs = require("node:fs");
+  const e = JSON.parse(fs.readFileSync(process.argv[1], "utf8").trim());
+  if (e.payload.agent_type !== null) throw new Error("absent agent_type must be null, got " + JSON.stringify(e.payload.agent_type));
+  if (e.payload.attributable !== false) throw new Error("an untyped stop must carry attributable:false, got " + JSON.stringify(e.payload));
+  if (!e.payload.extra || e.payload.extra.some_future_id !== "ff-77")
+    throw new Error("unknown platform fields must be preserved under extra, got " + JSON.stringify(e.payload.extra));
+' "$Q/.loop/runs/s2.jsonl" || fail "untyped subagent.stopped must be recorded honestly"
+echo "PASS: an untyped SubagentStop records agent_type=null + attributable:false + extra (no fabricated type)"
+
+# ── 3) permission.denied는 command 없는 툴에서도 진단 가능해야 한다 ───────────────────────────
+# Bash는 command를, Edit/Write는 file_path를 싣지만 나머지 툴(실측: SendMessage·ScheduleWakeup)은
+# tool_name 하나만 남아 사후에 서로 구별되지 않았다. 값이 아니라 *키 이름*만 남긴다(시크릿·용량 무관).
+R="$DIR/r"
+mkdir -p "$R"
+emit "$R" '{"session_id":"s3","hook_event_name":"PermissionDenied","tool_name":"Bash","tool_input":{"command":"rm -rf /","timeout":5}}'
+emit "$R" '{"session_id":"s3","hook_event_name":"PermissionDenied","tool_name":"SendMessage","tool_input":{"agent_id":"x","message":"hello"}}'
+node -e '
+  const fs = require("node:fs");
+  const evs = fs.readFileSync(process.argv[1], "utf8").trim().split("\n").map(JSON.parse);
+  const bash = evs.find((e) => e.payload.tool_name === "Bash");
+  const send = evs.find((e) => e.payload.tool_name === "SendMessage");
+  if (bash.payload.command !== "rm -rf /") throw new Error("a Bash denial must record its command, got " + JSON.stringify(bash.payload.command));
+  const keys = send.payload.tool_input_keys;
+  if (!Array.isArray(keys) || !keys.includes("agent_id") || !keys.includes("message"))
+    throw new Error("a command-less denial must record tool_input key NAMES, got " + JSON.stringify(keys));
+  if (JSON.stringify(send.payload).includes("hello"))
+    throw new Error("tool_input VALUES must never be carried by the key fingerprint");
+' "$R/.loop/runs/s3.jsonl" || fail "permission.denied must stay diagnosable for every tool shape"
+echo "PASS: permission.denied keeps Bash commands and, for command-less tools, a values-free tool_input key fingerprint"
+
+# ── 4) fold — 짝 맞은 stop과 귀속 불가 stop을 절대 섞지 않는다 ────────────────────────────────
+F="$DIR/f"
+mkdir -p "$F"
+cat > "$F/runS.jsonl" <<'EOF'
+{"id":"s1","type":"run.started","ts":"2026-08-24T00:00:00.000Z","aggregate_id":"runS","payload":{},"version":1}
+{"id":"s2","type":"subagent.started","ts":"2026-08-24T00:01:00.000Z","aggregate_id":"runS","payload":{"agent_id":"a1","agent_type":"fork"},"version":1}
+{"id":"s3","type":"subagent.started","ts":"2026-08-24T00:02:00.000Z","aggregate_id":"runS","payload":{"agent_id":"a2","agent_type":"Explore"},"version":1}
+{"id":"s4","type":"subagent.stopped","ts":"2026-08-24T00:03:00.000Z","aggregate_id":"runS","payload":{"agent_id":"a1","agent_type":"fork"},"version":1}
+{"id":"s5","type":"subagent.stopped","ts":"2026-08-24T00:04:00.000Z","aggregate_id":"runS","payload":{"agent_id":"zz","agent_type":null,"attributable":false},"version":1}
+{"id":"s6","type":"subagent.stopped","ts":"2026-08-24T00:05:00.000Z","aggregate_id":"runS","payload":{"agent_id":"yy","agent_type":null,"attributable":false},"version":1}
+EOF
+JSON="$(node "$METRICS" --runs-dir "$F" --json)" || fail "run-metrics with subagent events must exit 0"
+node -e '
+  const m = JSON.parse(process.argv[1]);
+  const r = m.runs.find((x) => x.run_id === "runS");
+  if (r.subagents.started !== 2) throw new Error("started must be 2, got " + r.subagents.started);
+  if (r.subagents.stopped_paired !== 1) throw new Error("stopped_paired must be 1 (only a1 has a started), got " + r.subagents.stopped_paired);
+  if (r.subagents.stopped_unattributed !== 2) throw new Error("stopped_unattributed must be 2, got " + r.subagents.stopped_unattributed);
+  if (m.overall.subagents.stopped_paired !== 1 || m.overall.subagents.stopped_unattributed !== 2)
+    throw new Error("overall subagent split wrong: " + JSON.stringify(m.overall.subagents));
+' "$JSON" || fail "subagent fold must split paired from unattributed stops"
+OUT="$(node "$METRICS" --runs-dir "$F")"
+printf '%s' "$OUT" | grep -q "stopped_unattributed=2" \
+  || fail "text output must surface stopped_unattributed so nothing downstream reads the raw stop count as a population, got: $OUT"
+echo "PASS: run-metrics splits subagent stops into paired vs unattributed (no unsupported count implied)"
+
+exit 0

--- a/tools/loop-engine/test/worktree-session-scope.test.sh
+++ b/tools/loop-engine/test/worktree-session-scope.test.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# Behavioral test for the session-scope half of hooks/gate-worktree-create.mjs (BAC-778).
+#
+# Contract: the FIRST feature worktree of a session is allowed; a SECOND one escalates to
+# permissionDecision "ask" (the human-approval prompt = the gate vocabulary's REQUIRE). Non-feature
+# branches (lessons/chore/fix/…) never count and never escalate. The pre-existing origin/* deny rule
+# is unchanged and still wins — a denied command must not consume the session's budget.
+#
+# "One session" is the payload's session_id and nothing else. With no session_id there is no
+# escalation at all: undeterminable must not become "everything is the same session" (that would
+# REQUIRE on the second feature worktree ever created in a repo).
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+HOOK="$HERE/../hooks/gate-worktree-create.mjs"
+
+fail() { echo "FAIL: $1"; exit 1; }
+[ -f "$HOOK" ] || fail "gate-worktree-create.mjs not found at $HOOK"
+
+DIR="$(mktemp -d "${TMPDIR:-/tmp}/tmp.XXXXXXXX")" || fail "mktemp -d failed"
+trap 'rm -rf "$DIR"' EXIT
+PROJ="$DIR/proj"
+mkdir -p "$PROJ"
+
+# run <project-dir> <session-id-or-empty> <command>
+run() {
+  node -e '
+    const [sid, cmd] = process.argv.slice(1);
+    const p = { tool_name: "Bash", tool_input: { command: cmd } };
+    if (sid) p.session_id = sid;
+    process.stdout.write(JSON.stringify(p));
+  ' "$2" "$3" | CLAUDE_PROJECT_DIR="$1" node "$HOOK" 2>"$DIR/stderr"
+}
+expect_allow() {
+  local out; out="$(run "$1" "$2" "$3")" || fail "hook must exit 0"
+  [ -z "$out" ] || fail "expected allow for [$3], got: $out"
+}
+expect_decision() { # $4 = deny|ask
+  local out; out="$(run "$1" "$2" "$3")" || fail "hook must exit 0"
+  printf '%s' "$out" | grep -q "\"permissionDecision\":\"$4\"" \
+    || fail "expected $4 for [$3], got: ${out:-<empty>}"
+}
+
+WT_ADD='git fetch origin && git worktree add -b %s /tmp/%s origin/main'
+
+# ── 1) 세션의 첫 feature 워크트리는 통과 ──────────────────────────────────────────────────────
+expect_allow "$PROJ" "sess-A" "$(printf "$WT_ADD" feature/bac-1 wt1)"
+echo "PASS: the first feature/* worktree of a session is allowed"
+
+# ── 2) 같은 세션의 두 번째 feature 워크트리 → ask(REQUIRE) ────────────────────────────────────
+expect_decision "$PROJ" "sess-A" "$(printf "$WT_ADD" feature/bac-2 wt2)" "ask"
+echo "PASS: a SECOND feature/* worktree in the same session escalates to ask (REQUIRE)"
+
+# ── 2b) 같은 브랜치 재시도는 중복 계산하지 않는다(실패 후 재시도 시나리오) ─────────────────────
+expect_allow "$PROJ" "sess-B" "$(printf "$WT_ADD" feature/retry wtr)"
+expect_allow "$PROJ" "sess-B" "$(printf "$WT_ADD" feature/retry wtr)"
+echo "PASS: retrying the same branch name does not consume a second slot"
+
+# ── 3) 다른 세션은 독립 예산 ─────────────────────────────────────────────────────────────────
+expect_allow "$PROJ" "sess-C" "$(printf "$WT_ADD" feature/bac-3 wt3)"
+echo "PASS: a different session_id gets its own budget"
+
+# ── 4) lessons/chore 계열은 면제 — 몇 개를 만들든 에스컬레이트하지 않는다 ──────────────────────
+for b in lessons/harness-1 chore/bump-deps fix/typo docs/adr-99 lessons/harness-2; do
+  expect_allow "$PROJ" "sess-D" "$(printf "$WT_ADD" "$b" "$(basename "$b")")"
+done
+# 그리고 그것들은 feature 예산을 갉아먹지도 않는다 — 이 세션의 첫 feature는 여전히 통과여야 한다.
+expect_allow "$PROJ" "sess-D" "$(printf "$WT_ADD" feature/first wtd)"
+expect_decision "$PROJ" "sess-D" "$(printf "$WT_ADD" feature/second wtd2)" "ask"
+echo "PASS: lessons/chore/fix/docs branches are exempt and don't consume the feature budget"
+
+# ── 5) session_id가 없으면 에스컬레이션 자체가 없다(판정 불가를 판정으로 바꾸지 않는다) ─────────
+expect_allow "$PROJ" "" "$(printf "$WT_ADD" feature/anon-1 wta1)"
+expect_allow "$PROJ" "" "$(printf "$WT_ADD" feature/anon-2 wta2)"
+echo "PASS: with no session_id there is no escalation (undeterminable stays undeterminable)"
+
+# ── 6) 기존 origin/* deny 규칙은 그대로이고, deny된 명령은 예산을 소비하지 않는다 ───────────────
+E="$DIR/proj-e"
+mkdir -p "$E"
+expect_decision "$E" "sess-E" 'git worktree add -b feature/local-base /tmp/wte main' "deny"
+expect_decision "$E" "sess-E" 'git worktree add -b feature/no-ref /tmp/wte2' "deny"
+# 위 둘이 예산을 먹었다면 아래 첫 feature가 ask가 됐을 것이다.
+expect_allow "$E" "sess-E" "$(printf "$WT_ADD" feature/real wte3)"
+echo "PASS: the origin/* deny rule still wins, and a denied command doesn't consume the session budget"
+
+# ── 7) DWIM 형태(commit-ish 생략 대신 origin/* 명시 + -b 생략)도 브랜치명을 basename에서 얻는다 ─
+D="$DIR/proj-d"
+mkdir -p "$D"
+expect_allow "$D" "sess-F" 'git worktree add /tmp/feature/dwim-1 origin/main'
+expect_allow "$D" "sess-F" 'git worktree add /tmp/feature/dwim-2 origin/main'
+echo "PASS: a DWIM path whose basename isn't feature-prefixed doesn't escalate (branch = basename)"
+
+# ── 8) featureBranchPrefix 설정이 기본값을 교체한다 ──────────────────────────────────────────
+C="$DIR/proj-c"
+mkdir -p "$C/.claude"
+printf '{"featureBranchPrefix":"work/"}' > "$C/.claude/ship-flow.config.json"
+expect_allow "$C" "sess-G" "$(printf "$WT_ADD" feature/ignored-now wtg1)"
+expect_allow "$C" "sess-G" "$(printf "$WT_ADD" feature/ignored-too wtg2)"
+expect_allow "$C" "sess-G" "$(printf "$WT_ADD" work/one wtg3)"
+expect_decision "$C" "sess-G" "$(printf "$WT_ADD" work/two wtg4)" "ask"
+echo "PASS: .claude/ship-flow.config.json featureBranchPrefix replaces the built-in default"
+
+# ── 9) 킬스위치 ─────────────────────────────────────────────────────────────────────────────
+K="$DIR/proj-k"
+mkdir -p "$K"
+for n in 1 2 3; do
+  OUT="$(node -e '
+    process.stdout.write(JSON.stringify({tool_name:"Bash",session_id:"sess-K",tool_input:{command:process.argv[1]}}));
+  ' "$(printf "$WT_ADD" "feature/k$n" "wtk$n")" | LOOP_WORKTREE_SESSION_GATE_OFF=1 CLAUDE_PROJECT_DIR="$K" node "$HOOK")" \
+    || fail "kill switch must exit 0"
+  [ -z "$OUT" ] || fail "LOOP_WORKTREE_SESSION_GATE_OFF=1 must disable the escalation, got: $OUT"
+done
+echo "PASS: LOOP_WORKTREE_SESSION_GATE_OFF=1 disables the session escalation"
+
+exit 0

--- a/tools/loop-memory/.claude-plugin/plugin.json
+++ b/tools/loop-memory/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "loop-memory",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "pgvector semantic recall for verified dev-loop lessons (and, optionally, ADR/glossary/research knowledge). Opt-in: installs disabled by default — this is a database dependency, not core loop mechanics.",
   "author": {
     "name": "paulkim-lansik"
@@ -10,7 +10,7 @@
   "license": "MIT",
   "keywords": ["memory", "pgvector", "recall", "semantic-search", "lessons"],
   "defaultEnabled": false,
-  "dependencies": [{ "name": "loop-engine", "version": "^0.8.0" }],
+  "dependencies": [{ "name": "loop-engine", "version": "^0.9.0" }],
   "userConfig": {
     "openai_api_key": {
       "type": "string",

--- a/tools/ship-flow/.claude-plugin/plugin.json
+++ b/tools/ship-flow/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ship-flow",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Delivery-loop skills — land and release already-verified work through a repo's real gates. Tracker- and branch-model-agnostic: reads a consuming repo's own config instead of hardcoding one repo's setup.",
   "author": {
     "name": "paulkim-lansik"
@@ -10,6 +10,6 @@
   "license": "MIT",
   "keywords": ["delivery", "git-flow", "hotfix", "ship", "release"],
   "dependencies": [
-    { "name": "loop-engine", "version": "^0.8.0" }
+    { "name": "loop-engine", "version": "^0.9.0" }
   ]
 }


### PR DESCRIPTION
Four findings from a 7-day audit of a consuming repo's own `.loop/runs/` (3,096 events across 111 run files). **Every claim below was checked against that real ledger before code was written** — one of the four findings did not reproduce, and it is reported as such rather than "fixed".

## ⚠️ Needs a follow-up PR elsewhere (read first)

`tools/ship-flow/.claude-plugin/plugin.json` declares `loop-engine ^0.8.0`, which **excludes 0.9.0**. That range needs widening to `^0.9.0`. It is deliberately **not** changed here: concurrent work owns `tools/ship-flow/**` in this window, and editing it would guarantee a conflict on a line that matters. Please land that one-liner with (or before) this merge.

## G1a — verdict events never reached the session ledger

The instrumentation hook writes under `CLAUDE_PROJECT_DIR`; `bin/verdict-run.sh` writes under its own **cwd**. Any repo that isolates work in git worktrees splits those two apart on *every* run.

| where | what was there |
|---|---|
| main worktree `.loop/runs/` | 3,096 events / 111 run files / **0** `verdict.*` |
| one worktree's `unknown.jsonl`, same window | 14 `verdict.passed` + 2 `verdict.failed` |

The events were being produced all along — the ledger was split, and the run-id fell to `unknown` because `.loop/runs/current` only exists at the project root. Consequence: `bin/run-metrics.mjs` reported `q2` and `first_pass` as `INSUFFICIENT_DATA` for every single run. The loop's headline metric was unmeasurable from its own ledger.

**Fix**: `lib/run-ledger.mjs` → `resolveLedgerTarget()`, used by `ledger-append.mjs --auto-run-id`. It resolves ledger root *and* run-id by **corroboration** — an event only moves to another root if that root **already holds `<run-id>.jsonl`** (proof the hook is writing this session there). Never by guessing, never by creating a file speculatively.

Two things verified empirically rather than assumed:
- `CLAUDE_CODE_SESSION_ID` **is** in the Bash tool's env and equals the `session_id` hooks receive (confirmed: the matching `<sid>.jsonl` existed in the ledger). It is preferred over the `current` pointer, which is immune to that pointer's concurrent-session last-writer-wins.
- `CLAUDE_PROJECT_DIR` is **NOT** in the Bash tool's env (printed it: `UNSET`). That is why the main worktree also has to be inferred, via `git rev-parse --git-common-dir`.

With no corroboration, prior behaviour (cwd + `current` + `unknown` bucket) is unchanged byte-for-byte — pinned by the untouched base `test/run-ledger.test.sh`. `verdict-run.sh` also records `payload.cwd` so a redirected event doesn't lose which worktree it ran in.

## G1b — subagent stops: a platform behaviour, made honest instead of faked

Measured: 2,307 `subagent.stopped` vs 472 `subagent.started`; 1,896 stops carried `agent_type: ""`. Cross-checking `agent_id` across the whole ledger settles the cause and rules out a payload bug on our side:

- **405 / 405** distinct *typed* stop ids have a matching `subagent.started`.
- **1,901 / 1,901** distinct *untyped* stop ids have **none**.

The platform fires `SubagentStop` for agent kinds whose `SubagentStart` never fires, and its stdin for those carries no `agent_type`. **A hook cannot populate this.** So the recorded shape is made honest instead: absent → `agent_type: null` (never `""`, which reads as "we captured a type and it was blank"), `attributable: false`, and an `extra` bag preserving whatever else the platform *did* send — the only way a later audit discovers an identity field under a name we don't know yet. `run-metrics.mjs` gains a `subagents` axis splitting `started` / `stopped_paired` / `stopped_unattributed`, so per-agent duration/success can only be derived from the pairable population.

## G1c — the Bash-denial finding did not reproduce

All 24 `Bash` `permission.denied` events in the audit window carry `command`, and `pickPayload` has recorded it since the file's first commit (`34cfa17`). Reported as not-reproduced rather than silently "fixed".

The **real** gap the sample shows: every *other* tool (`SendMessage`, `ScheduleWakeup`) lands with `tool_name` and nothing else — indistinguishable from any other denial of the same tool afterwards. Denials now carry `tool_input_keys`: the key **names** only, never the values, so it cannot carry a secret or grow the ledger.

## G2 — new gate `hooks/gate-verify-pipe.mjs` (PreToolUse/Bash)

Four audited runs did:

```
[15:31] cd <worktree> && timeout 590 pnpm verify 2>&1 | tail -200
[15:32] echo "exit code of last pnpm verify: $?"     →  0
```

That `0` is unrelated to verify **twice over**: a pipeline's `$?` is the last stage's (`tail`), and the tool resets the shell between calls so the second `$?` belongs to a brand-new shell's own `echo`. Those runs happened to be green, so the evidence was worthless rather than wrong — and the same sessions used the correct `> log 2>&1; echo EXIT:$?` form elsewhere.

Denies that shape unless the same invocation preserves the status (`pipefail` / `PIPESTATUS` / a redirect instead of a pipe). Reuses `hooks/command-tokenizer.mjs` (no second parser) and follows `gate-before-merge.mjs`'s fail-open-on-detection / fail-closed-once-certain structure. One parser detail worth flagging: `2>&1`'s `&` must not be read as a statement separator, or detection dies on the single most common real form — that regression is locked by a test using the audited command verbatim. Verify vocabulary is config (`verifyCommandPattern`), defaulting to this harness's own `verify`/`verdict`; kill switch `LOOP_VERIFY_PIPE_GATE_OFF=1`.

## G3 — second feature worktree in one session escalates

`gate-worktree-create.mjs` now returns `permissionDecision: "ask"` (Claude Code's human-approval prompt = the gate vocabulary's **REQUIRE**) for a *second* `feature/*` worktree in one session — the mechanical half of a boundary violation where an audited run opened its PR and then began an entirely new issue. The existing `origin/*` deny rule is unchanged, still wins, and **a denied command does not consume the budget**. Non-feature branches (`lessons/*`, `chore/*`, …) are exempt. Prefix is config (`featureBranchPrefix`); kill switch `LOOP_WORKTREE_SESSION_GATE_OFF=1`.

**Limits of "one session" — stated in the file header, and real:**
- It is the payload's `session_id` and nothing else. **No `session_id` → no escalation at all.** Undeterminable must not become "everything is one session", which would REQUIRE on the second feature worktree ever created in a repo.
- A subagent has its own session id, so it neither counts toward nor sees the parent's budget.
- A `--resume`/`--continue` that starts a new session id starts a new budget; deleting the state file resets it.
- `EnterWorktree` / `Agent isolation:"worktree"` never reach a Bash hook (same blind spot the `origin/*` rule already has).
- It counts *attempts*, deduped by branch name: a `git worktree add` that later fails on its own still consumes the budget.

## G4 — PR reviewer coverage (opt-in)

`check-pr-hygiene.mjs` gains `--reviewers a,b,c` (+ `--result-pattern`): each named reviewer must appear in the body with a result token on its line or within the next 2 lines — a bare mention in prose is not a result block. Motivated by an audited run that summoned 2 of 3 mandated review agents with no gate catching it. Names are consumer-repo config; a self-test asserts the plugin's *code* hardcodes none. Without `--reviewers` the existing tracker-reference contract is untouched (`reviewers` key not even present).

## Verification — real output, nothing self-reported

```
$ bash tools/loop-engine/test/run.sh
loop-engine selftest: 47/47 passed                      (exit 0)

$ bash tools/loop-engine/bin/verifier-pinned-review.sh --base a6e80b7
verifier-pinned-review: PASS — the base ('a6e80b7…') tools/loop-engine/test/
suite still passes against this PR's new bin/ code.     (exit 0)

$ claude plugin validate --strict .                     ✔ Validation passed (exit 0)
$ claude plugin validate --strict tools/loop-engine     ✔ Validation passed (exit 0)
```

5 new self-test files (`ledger-attribution`, `subagent-event-shape`, `gate-verify-pipe`, `worktree-session-scope`, `pr-reviewer-coverage`); suite 42 → 47. No existing test was weakened or narrowed — the only edit to an existing test file adds one `run_allow` line for the new hook.

loop-engine 0.8.0 → **0.9.0**.