### PR TITLE
fix(ship-flow): settle workflow invocation name + progressive-disclose ship-feature (0.3.2)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -19,7 +19,7 @@
       "name": "ship-flow",
       "source": "./tools/ship-flow",
       "description": "Delivery-loop skills — ship-feature (plan-to-PR autonomous loop), hotfix, retrospect, grill-with-docs, deps-audit, to-issues/to-prd, tdd, harness-maturity-audit, improve-codebase-architecture, resolving-merge-conflicts, plus review agents and audit/research workflows — parameterized by a consuming repo's own tracker/branch-model config instead of hardcoded to one repo. dependencies: loop-engine.",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "keywords": ["delivery", "git-flow", "hotfix", "ship", "release"]
     },
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,44 @@ Explicit-version channel — see [README § Development status](README.md#develo
 not a SHA channel. Entries below `## loop-engine 0.2.0` and earlier predate the multi-plugin split
 and refer to `loop-engine` only (see the un-prefixed version numbers).
 
+## ship-flow 0.3.2
+
+Skill-layer hygiene closing the 2026-08-20 harness maturity audit's remaining findings. No behaviour
+was removed — the reductions below are progressive disclosure, and every property asserted by
+`ship-flow-executable-contract.test.sh`, `verdict-wrap-required.test.sh`,
+`skill-guard-prose-wiring.test.sh`, `lesson-codification-bac756.test.sh` and
+`runtime-verify-evidence-bac749.test.sh` stayed inline in `SKILL.md` by construction.
+
+- **Workflow invocation name settled (audit finding 11).** The audit flagged
+  `harness-maturity-audit/SKILL.md`'s `Workflow({ name: 'ship-flow:harness-audit' })` as disagreeing
+  with `workflows/harness-audit.js`'s own `meta.name: 'harness-audit'`, and could not test which was
+  right. It is the **workflow file's header comment** that was wrong, not the call site: Claude Code
+  namespaces plugin-provided workflows as `<plugin-name>:<meta.name>` (docs:
+  `code.claude.com/docs/en/workflows.md` — "Plugin workflows are namespaced by the plugin name"), and
+  the first-party `claude-security` plugin does exactly this — `workflows/scan.js` declares
+  `meta.name: "scan"` while its skill invokes `Workflow({ name: "claude-security:scan" })`. The
+  comment now states the rule and warns against "fixing" the mismatch by prefixing `meta.name`.
+- **`ship-feature/SKILL.md`: 4771 → 4067 words** (hard cap 5000; headroom 229 → 933). Background,
+  rationale and worked examples moved into three bundled reference files linked from the point of
+  use, following the pattern `tdd/` and `improve-codebase-architecture/` already use:
+  `RISK-GATE.md` (what the rule set covers, why agent input may only raise a classification, the two
+  channels of `DENY_AND_LOG`), `AC-CONTRACTS.md` (full AC syntax, field semantics, examples, why the
+  one-contract floor exists), and `PUBLISH-HANDOFF.md` (why the Builder session doesn't publish its
+  own work, and why a heredoc is unsafe for untrusted-derived text). The 2000-word soft target is not
+  reachable without deleting codified behaviour: ~2100 words are the act-moment step sequence and
+  ~440 are the non-negotiable invariants.
+- **`publisher` is now referenced as `ship-flow:publisher`** in `ship-feature/SKILL.md`, matching the
+  three review agents and `ship-flow:planner` (namespaced in 0.3.0). No known collision exists today;
+  the point is that `code-reviewer`'s collision with `pr-review-toolkit:code-reviewer` arrived
+  unannounced, and a generic noun like `publisher` is the same shape of risk. The namespaced form
+  resolves identically either way, so there is no downside to aligning it.
+- **`improve-codebase-architecture/DEEPENING.md` wired into `SKILL.md`.** The audit called it
+  orphaned; it was in fact reachable, but only via `INTERFACE-DESIGN.md` (which *is* linked from
+  `SKILL.md`) off a niche "want to explore alternative interfaces?" branch. Its content — the four
+  dependency categories, seam discipline, replace-don't-layer testing — is core to step 3's grilling
+  loop, which decides "what sits behind the seam, what tests survive", so it is now linked there
+  directly. Kept rather than deleted for that reason.
+
 ## ship-flow 0.3.1 · loop-memory 0.3.1
 
 - Dependency range only: both declared `loop-engine ^0.8.0`, which `0.9.0` (below) falls outside of.

--- a/tools/ship-flow/.claude-plugin/plugin.json
+++ b/tools/ship-flow/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ship-flow",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Delivery-loop skills — land and release already-verified work through a repo's real gates. Tracker- and branch-model-agnostic: reads a consuming repo's own config instead of hardcoding one repo's setup.",
   "author": {
     "name": "paulkim-lansik"

--- a/tools/ship-flow/skills/improve-codebase-architecture/SKILL.md
+++ b/tools/ship-flow/skills/improve-codebase-architecture/SKILL.md
@@ -84,6 +84,8 @@ Do NOT propose interfaces yet. After the file is written, ask the user: "Which o
 
 Once the user picks a candidate, drop into a grilling conversation. Walk the design tree with them — constraints, dependencies, the shape of the deepened module, what sits behind the seam, what tests survive.
 
+Classify the candidate's dependencies before proposing a shape — the category decides whether a port is warranted and how the deepened module gets tested across its seam. See [DEEPENING.md](DEEPENING.md) for the four dependency categories, seam discipline (one adapter = hypothetical seam), and the replace-don't-layer testing strategy.
+
 Side effects happen inline as decisions crystallize:
 
 - **Naming a deepened module after a concept not in `CONTEXT.md`?** Add the term to `CONTEXT.md` — same discipline as `/grill-with-docs` (see [CONTEXT-FORMAT.md](../grill-with-docs/CONTEXT-FORMAT.md)). Create the file lazily if it doesn't exist.

--- a/tools/ship-flow/skills/ship-feature/AC-CONTRACTS.md
+++ b/tools/ship-flow/skills/ship-feature/AC-CONTRACTS.md
@@ -1,0 +1,64 @@
+# AC contracts — syntax reference
+
+The one-line acceptance-criterion format that makes `ship-feature` step 3's runtime-verify gate
+machine-checkable instead of self-reported (ADR-0104). `SKILL.md` step 1 states the requirement;
+this file is the format. Read it while writing the plan.
+
+## Syntax
+
+Quoted verbatim — this matches `ac-verify.sh`'s parser exactly. An optional leading markdown list
+marker (`- `) is tolerated.
+
+```
+AC: <description> | verify: <command> | artifacts: <path1>,<path2> | expect: <substring>
+```
+
+- Only `AC: <description>` is required.
+- `verify:`, `artifacts:`, and `expect:` are each **optional**, may appear in **any combination**,
+  and in **any order**.
+- Fields are separated by ` | ` (space-pipe-space).
+- `artifacts:` paths are **comma-separated**, not space-separated — a path may itself contain
+  spaces, so spaces cannot be the separator.
+
+## Field semantics
+
+| Field | What `ac-verify.sh` does with it |
+|---|---|
+| `verify:` | Runs the command as a subprocess; a zero exit code passes |
+| `artifacts:` | Checks each listed path exists after the run |
+| `expect:` | Checks the `verify:` command's output contains this substring |
+
+Each is a deterministic subprocess judgment, which is the point: the gate's result doesn't depend on
+the agent's own account of whether the feature works.
+
+## Examples
+
+A behavioural check with an expected substring in the output:
+
+```
+AC: login rejects a wrong password | verify: pnpm --filter api test -- auth.spec.ts | expect: 401
+```
+
+A check that a build actually produced something:
+
+```
+AC: the CLI builds a standalone binary | verify: pnpm build | artifacts: dist/cli,dist/cli.map
+```
+
+Description only — legitimate for criteria a human has to eyeball, as long as the plan carries at
+least one contracted AC elsewhere:
+
+```
+AC: the empty-state illustration is not clipped on a 320px viewport
+```
+
+## The floor, and why it exists
+
+For a `standard` or `risky` track — anything with a runtime surface; `docs-only` is exempt because
+step 3 is already skipped for it — **the plan as a whole must express at least one AC with a
+machine-checkable contract** (a `verify:` field, and/or `artifacts:`/`expect:`).
+
+Not every AC needs one. But **zero across the whole plan** means step 3's `ac-verify.sh` gate has
+nothing to evaluate, so it would pass vacuously — a green gate proving nothing. That is why the
+`ship-flow:planner` agent fail-closed-checks this before any code exists, and why step 3 fails
+closed rather than skipping when a `standard`/`risky` plan has no contracted AC.

--- a/tools/ship-flow/skills/ship-feature/PUBLISH-HANDOFF.md
+++ b/tools/ship-flow/skills/ship-feature/PUBLISH-HANDOFF.md
@@ -1,0 +1,66 @@
+# Publish handoff — why step 5 hands off, and why by file
+
+Background for `SKILL.md` step 5's handoff to the `ship-flow:publisher` agent. The step itself
+states what to do; this file states why, so the pattern isn't "simplified" back into the shape it
+was written to replace.
+
+## Why this session doesn't publish its own work
+
+ADR-0003 (this plugin's repo, issue #15). From step 0 through step 4 the Builder session has been
+reading untrusted content — tracked-issue bodies, linked pages, dependency changelogs, web search
+results — while holding full write access to a worktree. A session in that position must not *also*
+be the one executing the external action that publishes the result of that work. Splitting the two
+means a prompt injection that lands in the Builder's context cannot, by itself, reach `git push`,
+`gh pr create`, or the tracker.
+
+`ship-flow:publisher` exists to be the narrow half of that split: it executes literal commands it
+was handed and nothing else. It does not read repository files on its own initiative, fetch
+content, or compose PR/comment text. That is why step 5 has to hand it *finished strings* — a
+publisher that has to go read the diff to write a PR body is just the Builder again with a
+different name.
+
+Composing the text is not an external state change, which is why the Builder session may still do
+it. Only the publishing act moves.
+
+## Why the handoff is file-based, not a heredoc
+
+The obvious way to pass a multi-line PR body into a shell command is a heredoc assigned to a
+variable:
+
+```bash
+BODY=$(cat <<'EOF'
+… PR body …
+EOF
+)
+```
+
+This is unsafe here, and the quoted delimiter (`<<'EOF'`) does not fix it. Quoting the delimiter
+suppresses parameter and command expansion *inside* the body — it does **not** stop the heredoc from
+ending early. The heredoc terminates at the first line that is exactly the delimiter word, and
+everything after that line is read back by the shell as real commands.
+
+The PR body is derived from content this session read out of tracked issues and the web. Untrusted
+text that happens to contain a line reading `EOF` — placed there deliberately or by accident —
+therefore closes the heredoc and turns the remainder into executed shell. There is no delimiter
+choice that removes this: whatever word is picked, the attacker-supplied text can contain it.
+
+Writing the text to a file with the **Write tool** has no equivalent collision. The file's bytes are
+never parsed as shell; the command line only ever carries a path.
+
+## The safe pattern
+
+1. `mktemp -d` — a fresh directory, never a predictable fixed path (a fixed path is writable by any
+   other process on the machine between the write and the read).
+2. Write the PR title, the PR body, and the tracked-issue comment text to **separate files** in it,
+   using the Write tool.
+3. Hand `ship-flow:publisher` the file paths plus the exact commands to run.
+
+Commands use the CLI's own file flags where they exist — `gh pr create --body-file <path>`,
+`gh issue comment --body-file <path>` — and `"$(cat <path>)"` interpolated into a **double-quoted**
+variable where they don't. `agents/publisher.md`'s "What you do" section carries the exact form and
+the same reasoning from the executing side.
+
+The same rule covers the retry path. A `--force-with-lease` push after a rebase is still an external
+action taken by a session holding untrusted-input history, so it goes through `ship-flow:publisher`
+too, with the branch name passed as a literal value and interpolated only inside double quotes —
+never bare, never through a heredoc.

--- a/tools/ship-flow/skills/ship-feature/RISK-GATE.md
+++ b/tools/ship-flow/skills/ship-feature/RISK-GATE.md
@@ -1,0 +1,73 @@
+# Risk gate — background
+
+Why the gate is shaped the way it is, and what the rule set typically covers. `SKILL.md`'s
+[Risk gate](SKILL.md) section carries the part needed at the moment of running the classifier (the
+command, the three exit codes, the TRACK routing table); this file is the reasoning behind it. Read
+it when a classification looks wrong, when deciding whether to pass `--agent-*` input, or when this
+repo is layering its own rules on top.
+
+## Why the agent doesn't score its own risk
+
+The three-valued decision rule itself is mechanical: `reversibility=none` or an unclassified
+dimension → `REQUIRE`; reversible but `blast=high OR cost=high` → `DENY_AND_LOG`; anything else →
+`AUTO`.
+
+The gap that matters is **who assigns blast/reversibility/cost**. Inside this skill that would
+otherwise be the same agent doing the work, which turns self-scoring into a rubber stamp — an agent
+that wants to proceed can always find a reading of its own change that scores low. So classification
+is derived **from the change itself** (paths, commands, stage) by the classifier first, and agent
+input is folded in as `final = max(rule, agent)`: agent input is **only allowed to raise** a
+classification, never lower it. Pass `--agent-blast-radius` / `--agent-reversibility` /
+`--agent-cost` when the agent genuinely knows something the paths don't show (e.g. a small diff that
+changes a payment amount); never to argue a rule-matched change back down.
+
+## The two channels of `DENY_AND_LOG` (exit 11)
+
+`DENY_AND_LOG` means different things depending on where the classifier is consulted, and this is
+deliberate:
+
+- **On the verdict channel** (what `ship-feature` uses): log the evidence — run the same
+  classification again with `--render-md` and paste the markdown block into the PR — and proceed.
+  Human review happens at the PR/merge boundary that already exists, so the run doesn't stall
+  waiting on someone.
+- **On a command-execution channel** (a `PreToolUse` hook, where one is wired): block the command
+  instead. There is no later boundary there — the command either runs or it doesn't.
+
+Treating exit 11 as "stop and wait for a human" on the verdict channel is a common misreading; that
+is what exit 10 (`REQUIRE`) is for.
+
+## What the rule set typically covers
+
+Rule sets vary per repo, but the surfaces that normally carry a rule are:
+
+- schema migrations (`reversibility=none`)
+- row-level security, or whatever this repo's equivalent tenant-isolation schema is
+- auth and guards
+- outbound send/call (anything that reaches a real user or a third party)
+- the harness/constitution layer — `.claude/**`, this repo's CLAUDE.md, `docs/adr/**`, loop-engine
+  tooling
+- CI and deploy configuration
+- workspace-root config
+- 11+ files touched
+
+**Below that threshold**, with **≤10 files, 0 commands, and no rule match**, a low-risk app-code
+baseline applies (`low/full/low` → AUTO). Everything else unmatched — an unmatched *command*, or 11+
+files with no classification — is **fail-closed REQUIRE**. Silence is not AUTO; an unclassified
+change is an unknown one.
+
+**Merge, deploy, release, and send are never classified as anything but REQUIRE.** `--stage
+merge|deploy|release|send`, and merge/deploy *commands*, are always `reversibility=none` regardless
+of any other input, including agent input. This is the one classification no rule set can relax.
+
+## Layering this repo's own rules
+
+If this repo ships its own `risk-rules.json` on top of loop-engine's defaults, `classify-risk.sh`
+picks it up automatically — there's no flag to pass. A repo's own rules add to the defaults; they
+are not a replacement, so a change can match both.
+
+## The track is an output, not a separate axis
+
+`TRACK:` is not something the agent chooses alongside the risk classification — it is printed *by*
+the classification, and it routes the rest of the sequence. Skipping a step because of the track is
+legitimate; skipping one for any other reason is not. Either way a skipped step leaves a one-line
+reason in the PR body, so the decision is auditable after the fact rather than invisible.

--- a/tools/ship-flow/skills/ship-feature/SKILL.md
+++ b/tools/ship-flow/skills/ship-feature/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ship-feature
-description: This plugin's autonomous-by-default feature delivery sequence and single entrypoint — the agent isolates a worktree, plans, TDDs, runtime-verifies, self-reviews, opens the PR and STOPS for the human to merge, then turns verified lessons into a harness-improvement PR. Risk gating at each step is decided by a deterministic classifier, not by the agent's own scoring. Use when the user delegates a task, feature, bug, or tracked issue to take from plan to an open PR following the standard flow (plan → tdd → runtime-verify → review → PR → improve), or asks to "ship"/"deliver"/"land" a feature.
+description: This plugin's autonomous-by-default feature delivery sequence and single entrypoint — isolate a worktree, plan, TDD, runtime-verify, self-review, open the PR and STOP for the human to merge, then turn verified lessons into a harness-improvement PR. Risk gating is decided by a deterministic classifier, not the agent's own scoring. Use when the user delegates a task, feature, bug, or tracked issue to take from plan to an open PR (plan → tdd → runtime-verify → review → PR → improve), or asks to "ship"/"deliver"/"land" a feature.
 ---
 
 # ship-feature — this plugin's single entrypoint (autonomous, human only where the gate calls for it)
@@ -11,25 +11,26 @@ description: This plugin's autonomous-by-default feature delivery sequence and s
 > identifiers, file paths, branch names, and quoted tool output stay verbatim; never translate them.** Key
 > absent or unreadable → fall back to the language the user is writing in; never error on this.
 
-The procedure for taking one unit of work (a feature, a bug, a tracked issue) from **plan to an open
-PR, and from a merged PR to a harness-improvement PR** with the agent running autonomously the whole
-way. Each step's *content* is owned by the skill/agent it delegates to — this skill only fixes the
-**order, the gates, and where a human steps in**.
+Takes one unit of work (a feature, a bug, a tracked issue) from **plan to an open PR, and from a
+merged PR to a harness-improvement PR**, with the agent running autonomously the whole way. Each
+step's *content* belongs to the skill/agent it delegates to — this skill fixes only the **order, the
+gates, and where a human steps in**.
+
+Bundled references (read at the point each is needed): [RISK-GATE.md](RISK-GATE.md) ·
+[AC-CONTRACTS.md](AC-CONTRACTS.md) · [PUBLISH-HANDOFF.md](PUBLISH-HANDOFF.md).
 
 > **Git procedure (branch model, worktrees, merge, rebase) lives in this repo's own CLAUDE.md (or
 > equivalent constitution doc), not here.** If this repo was set up via this plugin's `setup` skill,
-> that doc was generated from `templates/CLAUDE.md.template` and already covers this. This skill
-> references it rather than duplicating it — a duplicated copy drifts the moment the branch model
-> changes.
+> that doc came from `templates/CLAUDE.md.template` and already covers it. Duplicating it here would
+> drift the moment the branch model changes.
 
 ## Config
 
 Reads `.claude/ship-flow.config.json` at the consuming repo's root (written by this plugin's `setup`
-skill — see `hotfix`'s SKILL.md for the field list). If it doesn't exist yet, ask the user for
+skill — `hotfix`'s SKILL.md has the field list). If it doesn't exist yet, ask the user for
 `branchModel`, `integrationBranch`/`releaseBranch`, and `verifyCommand` before proceeding — don't guess.
-`trackerName`, if set, names this repo's issue tracker (Linear is the worked example throughout this
-file, since that's what this skill was originally built against — substitute this repo's actual tracker
-and its equivalent mechanics: create/update issue, assignee, blocking-issue links, status transitions).
+`trackerName` names this repo's issue tracker; Linear is the worked example below, so substitute this
+repo's actual tracker and its equivalents (create/update issue, assignee, blocking links, status).
 
 ### `pluginBinPrefix` — how the commands below become runnable
 
@@ -42,7 +43,7 @@ and never substitute a description of a command for the command.
 | `pluginBinPrefix` | Resulting command | When |
 |---|---|---|
 | `""` (absent → default) | `classify-risk.sh --from-git …` | Live session: a plugin's `bin/` is on PATH |
-| `node tools/plugin-path.mjs exec bin/` | `node tools/plugin-path.mjs exec bin/classify-risk.sh --from-git …` | This repo has its own resolver wrapper |
+| `node tools/plugin-path.mjs exec bin/` | …prefixed with that, same flags | If this repo ships its own resolver wrapper |
 | `node "$LOOP_ENGINE_PATH/bin/plugin-path.mjs" exec bin/` | …same shape, loop-engine's bundled resolver | CI / headless, nothing on PATH (BAC-753) |
 
 **Argument form is not re-derivable — use exactly what's written.** Only `verdict-run.sh` takes a `--`
@@ -51,8 +52,7 @@ separator (it needs one, to fence off the command it wraps). `classify-risk.sh`,
 `classify-risk.sh --path` is repeated once per path, not given a space-separated list.
 
 If a substituted command fails to resolve, **stop and say so.** Falling back to this repo's raw verify
-command is the exact failure this section exists to prevent — it silently drops the verdict contract,
-the risk gate, and the AC gate at once.
+command silently drops the verdict contract, the risk gate, and the AC gate at once.
 
 ## Execution mode — autonomous by default
 
@@ -61,11 +61,9 @@ The agent runs step 0 → PR **without stopping**. There are exactly **three** p
 1. **The merge/deploy boundary** — it opens a `feature/* → integrationBranch` (or the trunk-based
    equivalent) PR and **stops**. Landing on a shared branch is `reversibility=none`, so a human reviews
    and merges — the agent never approves its own code onto a shared branch. **Release
-   (`integrationBranch → releaseBranch`) is out of this skill's scope** — a human decides that
-   separately, and this plugin's `hotfix` skill handles that two-stage flow (including its own
-   merge/deploy stop points) if needed.
-2. **Any step where the risk gate returns REQUIRE** — see [Risk gate](#risk-gate--the-rules-classify-not-the-agent)
-   below. The agent stops *before* running that step and waits for human approval.
+   (`integrationBranch → releaseBranch`) is out of this skill's scope** (see step 5).
+2. **Any step where the risk gate returns REQUIRE** — see [Risk gate](#risk-gate--the-rules-classify-not-the-agent).
+   The agent stops *before* running that step and waits for human approval.
 3. **Genuinely stuck, ambiguous, or unable to self-recover** — only when the agent can't resolve a gate
    on its own or a real judgment call is needed.
 
@@ -82,12 +80,8 @@ answers "go with your recommendation". Before interrupting, apply this test:
 > that already exists.
 
 Ask only when one of those is genuinely no: no defensible recommendation (a real product/priority call
-the agent has no basis for), or an irreversible consequence — already covered by point 2 and point 1
-above. "This feels like it deserves a check-in" is not a qualifying reason; a `Decisions taken` line is.
-
-> "Autonomous" means *the agent*, not *no human in the loop*: nobody is watching every step, but an
-> intelligent agent is making judgment calls throughout the loop, which is what makes the runtime-verify
-> step's model-produced verdict trustworthy.
+the agent has no basis for), or an irreversible consequence — already covered by points 1 and 2.
+"This feels like it deserves a check-in" is not a qualifying reason; a `Decisions taken` line is.
 
 ## Invariants (skipping these breaks the contract — non-negotiable)
 
@@ -95,49 +89,37 @@ above. "This feels like it deserves a check-in" is not a qualifying reason; a `D
   the release branch (trunk-based) — never check a work branch out there. Before the first edit:
   `git fetch origin` → `git worktree add -b <branch> <sibling-path-outside-repo> origin/<base>`. **Don't
   base a new worktree on a local branch** — the server is the source of truth.
-- **Reward-hack guard — if this repo has one, it's always armed, structurally.** If loop-engine@paul-loop
+- **Reward-hack guard — if this repo has one, it's always armed, structurally.** Where loop-engine@paul-loop
   (or an equivalent) provides a reward-hack guard hook on working branches, it arms by branch condition
-  automatically — this skill doesn't turn it on or off, and there's nothing to disarm before handing off
+  automatically — this skill never turns it on or off, and there's nothing to disarm before handing off
   to a human. If a legitimate edit to a protected file (test/config/verifier files) gets denied, open a
-  reasoned window per that guard's convention, make the edit, close the window, and record the reason in
-  the PR body.
-- **This repo's verify command is the one automatic gate.** A `feature/* → integrationBranch` PR
-  typically doesn't trigger CI in a git-flow setup that skips CI at that stage (a common cost-control
-  pattern — check `ciSkipOnIntegrationPR` in the config) — if so, nothing catches a skipped local gate
-  before the change lands on the integration branch. If this repo also gates its own harness/consumer
-  wiring with a separate command (e.g. a `verify:loop`-style script), that needs to be green too whenever
-  harness-consumer files were touched — step 6 especially.
+  reasoned window per that guard's convention, make the edit, close the window, and record why in the
+  PR body.
+- **This repo's verify command is the one automatic gate.** A `feature/* → integrationBranch` PR often
+  doesn't trigger CI (a common cost-control pattern — check `ciSkipOnIntegrationPR` in the config); if
+  so, nothing catches a skipped local gate before the change lands. If this repo also gates its
+  harness/consumer wiring separately (e.g. a `verify:loop`-style script), that has to be green too
+  whenever harness-consumer files were touched — step 6 especially.
 - **Verify (runtime) means observing the running app**, not re-running the verify command — that already
-  happened inside step 2. Step 3 asks "did the app actually get built/started and exercised at the
-  changed surface," not "did the test suite pass again."
+  happened in step 2. Step 3 asks "did the app actually get built/started and exercised at the changed
+  surface," not "did the test suite pass again."
 - **A human merges.** The agent gets to an open PR and no further. No local `git merge`/`git pull` toward
-  a shared branch, no direct push — if this repo has a merge guardrail hook and/or server-side branch
-  protection, they'll block it anyway.
-- **The agent doesn't self-score risk.** Classification comes from a deterministic rule set first; the
-  agent's own input can only push a classification **up**, never down (below). Self-grading turns the
-  gate into decoration.
-- **Harness improvements land as PRs only.** This session doesn't directly edit and commit to this
-  repo's CLAUDE.md / `.claude/**` — step 6 submits only accepted lessons, as a **separate PR**, and
-  stops there.
-- **Issues live in this repo's tracker.** Use whatever this repo's `trackerName` config says (Linear is
-  the worked example below); don't fall back to ad-hoc GitHub issues if a real tracker is configured.
-- **Verification results are quoted, not paraphrased.** Test runs, gate verdicts, review findings —
-  report these by pasting the actual output (or LOG file) verbatim, the same way step 5 pastes the
-  risk-verdict markdown block into the PR body rather than transcribing it. A hand-summarized paraphrase
-  can silently launder a partial/failing result into an apparent pass; the raw output is the evidence,
-  not a description of it.
+  a shared branch, no direct push — a merge guardrail hook and/or branch protection will block it anyway.
+- **The agent doesn't self-score risk.** Classification comes from a deterministic rule set first; agent
+  input can only push it **up**, never down. Self-grading turns the gate into decoration.
+- **Harness improvements land as PRs only.** This session never directly edits and commits this repo's
+  CLAUDE.md / `.claude/**` — step 6 submits only accepted lessons, as a **separate PR**, and stops there.
+- **Issues live in this repo's tracker.** Use whatever `trackerName` says; don't fall back to ad-hoc
+  GitHub issues if a real tracker is configured.
+- **Verification results are quoted, not paraphrased.** Paste actual output (or the LOG file) verbatim
+  for test runs, gate verdicts and review findings, the same way step 5 pastes the risk-verdict block
+  into the PR body. A hand-summarized paraphrase can silently launder a partial/failing result into an
+  apparent pass; the raw output is the evidence, not a description of it.
 
 ## Risk gate — the rules classify, not the agent
 
-If this plugin (via loop-engine@paul-loop) provides a deterministic risk classifier, its decision rule is
-three-valued: `reversibility=none` or an unclassified dimension → `REQUIRE` (wait for human approval);
-reversible but `blast=high OR cost=high` → `DENY_AND_LOG` (deny by default without waiting on a human,
-but log the verdict evidence into the PR — human review happens at the PR/merge boundary instead); anything
-else → `AUTO`. The gap that matters is **who assigns blast/reversibility/cost** — inside this skill,
-that would otherwise be the same agent doing the work, which turns self-scoring into a rubber stamp. So
-classification is derived **from the change itself** (paths/commands/stage) by the classifier first, and
-agent input is folded in as `final = max(rule, agent)` — **only allowed to raise** the classification,
-never lower it:
+Classification is derived from the change itself (paths/commands/stage), and agent input is folded in
+as `final = max(rule, agent)` — **only allowed to raise** it, never lower it.
 
 ```bash
 {{pluginBinPrefix}}classify-risk.sh --from-git --stage <plan|implement|pr|improve> \
@@ -145,45 +127,37 @@ never lower it:
   [--agent-blast-radius low|medium|high --agent-reversibility full|partial|none --agent-cost low|medium|high]
 # exit 0  = AUTO         → proceed autonomously
 # exit 10 = REQUIRE      → stop before running that step, get human approval
-# exit 11 = DENY_AND_LOG → on the verdict channel (here): log evidence (--render-md) into the PR and
-#                          proceed; on a command-execution channel (a PreToolUse hook, if wired): block
-#                          the command instead — the two channels intentionally mean different things
+# exit 11 = DENY_AND_LOG → here (verdict channel): log evidence (--render-md) into the PR and proceed
 ```
 
-(Substitute `{{pluginBinPrefix}}` per the [Config](#pluginbinprefix--how-the-commands-below-become-runnable)
-table above. If this repo layers its own `risk-rules.json` on top of loop-engine's defaults,
-`classify-risk.sh` picks it up automatically.)
+**Merge, deploy, release, and send are always REQUIRE**, regardless of any other input. Anything
+unmatched — an unmatched *command*, or 11+ files with no classification — is **fail-closed REQUIRE**;
+silence is not AUTO.
 
-- **Surface the rules typically cover**: schema migrations (`reversibility=none`) · row-level-security or
-  equivalent tenant-isolation schema · auth/guards · outbound send/call · the harness/constitution layer
-  (`.claude/**`, this repo's CLAUDE.md, `docs/adr/**`, loop-engine tooling) · CI/deploy · workspace-root
-  config · 11+ files touched. Below that threshold, with **≤10 files and 0 commands and no rule match**,
-  a low-risk app-code baseline applies (`low/full/low` → AUTO); everything else unmatched (an unmatched
-  *command*, or 11+ files with no classification) is **fail-closed REQUIRE** — silence isn't AUTO.
-- **Merge, deploy, and release are never classified as anything but REQUIRE** — `--stage
-  merge|deploy|release|send` and merge/deploy *commands* are always `reversibility=none` regardless of
-  other input.
-- **The track is a classification output**, not a separate axis. Whatever `TRACK:` line the classifier
-  prints is the routing decision:
+**The track is a classification output**, not a separate axis. Whatever `TRACK:` line the classifier
+prints is the routing decision:
 
-  | TRACK | Meaning | Steps |
-  |---|---|---|
-  | `risky` | Matched a rule | Full sequence + whatever `DEEP_GATES:` the output names |
-  | `standard` | No rule match | Full sequence, deep gates only if this repo's own verify table says they're affected |
-  | `docs-only` | No runtime surface touched | Steps 2-3 can be skipped |
+| TRACK | Meaning | Steps |
+|---|---|---|
+| `risky` | Matched a rule | Full sequence + whatever `DEEP_GATES:` the output names |
+| `standard` | No rule match | Full sequence, deep gates only if this repo's own verify table says they're affected |
+| `docs-only` | No runtime surface touched | Steps 2-3 can be skipped |
 
-  Skipping a step always leaves a one-line reason in the PR body (so it's auditable after the fact).
+Skipping a step always leaves a one-line reason in the PR body, so it's auditable after the fact.
+
+See [RISK-GATE.md](RISK-GATE.md) for what the rule set covers, why the agent may only raise a
+classification, the two channels of `DENY_AND_LOG`, and layering this repo's own `risk-rules.json`.
 
 ## Sequence (0 → PR is autonomous, merge is human, post-merge is `improve`)
 
 ### 0. Worktree isolation — `git worktree`
 If this repo tracks issues externally (Linear, GitHub Issues, etc.), claim the issue to yourself first
-— before creating the worktree — by assigning it and moving it into an in-progress state. If this repo
-runs concurrent sessions regularly, claiming first is what stops two sessions from picking up the same
-issue (worktree isolation alone only prevents git conflicts, not duplicate starts).
+— before creating the worktree — by assigning it and moving it into an in-progress state. Where
+concurrent sessions are common, claiming first is what stops two sessions picking up the same issue
+(worktree isolation alone prevents git conflicts, not duplicate starts).
 
 `git fetch origin && git worktree add -b <type>/<slug> <sibling-path-outside-repo> origin/<base>`. Check
-`git worktree list` first if concurrent work is common in this repo. A fresh worktree has no installed
+`git worktree list` first if concurrent work is common here. A fresh worktree has no installed
 dependencies — install them. Every following step happens inside this worktree. (macOS: if a later
 `git worktree remove` fails with a permission-denied ACL error, `chmod -R -N <path>` first — see
 hotfix's cleanup step for the full note.)
@@ -205,60 +179,42 @@ planned paths directly: `{{pluginBinPrefix}}classify-risk.sh --no-gate --path <p
 steps.
 → **Gate:** success criteria (what "done" verifiably means) has to be written down before moving on.
 
-**Express acceptance criteria as one-line AC contracts** — this is what makes step 3's gate below
-machine-checkable instead of self-reported (ADR-0104). Syntax (quoted verbatim — matches
-`ac-verify.sh`'s parser exactly, an optional leading markdown list marker like `- ` is tolerated):
-
-```
-AC: <description> | verify: <command> | artifacts: <path1>,<path2> | expect: <substring>
-```
-
-Only `AC: <description>` is required — `verify:`, `artifacts:`, and `expect:` are each optional, may
-appear in any combination or order, and are separated by ` | `. `artifacts:` paths are
-**comma-separated** (not space-separated — a path may itself contain spaces). Example:
+**Express acceptance criteria as one-line AC contracts** — this is what makes step 3's gate
+machine-checkable instead of self-reported (ADR-0104):
 
 ```
 AC: login rejects a wrong password | verify: pnpm --filter api test -- auth.spec.ts | expect: 401
 ```
 
-For a `standard` or `risky` track (anything with a runtime surface — `docs-only` is exempt, since
-step 3 is already skipped for it per the TRACK table above), **the plan as a whole must express at
-least one AC with a machine-checkable contract** (a `verify:` and/or `artifacts:`/`expect:` field) —
-not every AC needs one, but zero across the whole plan means step 3 (Runtime verify) will fail closed.
+Full syntax, field semantics, and more examples: [AC-CONTRACTS.md](AC-CONTRACTS.md). For a `standard`
+or `risky` track (`docs-only` is exempt — step 3 is already skipped for it), **the plan as a whole must
+express at least one AC with a machine-checkable contract**; zero across the whole plan means step 3
+fails closed.
 
 **Validate the finished plan before any code exists** — hand it to this plugin's `ship-flow:planner`
-agent (namespaced name, same reason as step 4). It fail-closed-checks the three things that go wrong
-before TDD rather than during it: acceptance criteria that are vibes rather than checks, criteria with
-no test seam to attach to, and — the one that matters most here — **zero AC contracts on a
-`standard`/`risky` plan**, which is exactly what makes step 3's `ac-verify.sh` gate vacuous. A BLOCK
-loops back into this step; it does not call a human. Skip it only when `grill-with-docs` already ran
-(that pass applies the same scrutiny), and say so in the PR body.
+agent (namespaced, same reason as step 4). It fail-closed-checks what goes wrong *before* TDD rather
+than during it: acceptance criteria that are vibes rather than checks, criteria with no test seam, and
+**zero AC contracts on a `standard`/`risky` plan** — the one that makes step 3's `ac-verify.sh` gate
+vacuous. A BLOCK loops back into this step; it does not call a human. Skip it only when
+`grill-with-docs` already ran (that pass applies the same scrutiny), and say so in the PR body.
 
-**If the plan itself exceeds one session's budget** (the scope is too large to pin down a single
-verifiable "done"), don't jump straight to implementation — split the issue into a map of decision
-tickets first: one separate tracked issue per still-open question (blocked-by links pointing at
-whichever decision has to resolve first), and work through the sharpest one first. That's just a
-planning artifact — each resolved decision ticket re-enters this skill from step 0 properly, with the
-full risk gate, worktree isolation, and verify still applying (splitting the plan doesn't bypass the
-gate).
-
-> **Token efficiency**: if exploring the codebase needs 3+ rounds of grep/read, delegate to an
-> Explore-type agent instead of doing it in the main context — keep raw file dumps and grep output out
-> of the main conversation.
+**If the plan itself exceeds one session's budget** (too large to pin down a single verifiable "done"),
+don't jump to implementation — split the issue into decision tickets first: one tracked issue per
+still-open question, blocked-by links pointing at whichever resolves first, sharpest one worked first.
+Each resolved ticket re-enters this skill from step 0 — splitting the plan doesn't bypass the gate.
 
 ### 2. Implementation — invoke the `ship-flow:tdd` skill (red → green)
 Implement the plan red→green by **invoking this plugin's `ship-flow:tdd` skill by that exact
 namespaced name** — not by writing tests in this session's own style and calling it TDD. Security/
 invariant paths (RLS, authorization, or whatever this repo's equivalent is) need **behavior-proof
-tests**, not just coverage. This repo's verify command is this
-loop's convergence criterion — run it wrapped, always, never raw:
-`{{pluginBinPrefix}}verdict-run.sh -- <verifyCommand>` (BAC-745 — `--` is required here, and only
-here). This holds
-even if `verifyCommand` is itself already a verdict-contract script (e.g. a repo's own `verdict` wrapper)
-— `verdict-run.sh` detects an already-emitted `=== VERDICT ===` block and passes it through unchanged
-rather than double-wrapping, so wrapping unconditionally is always safe. Read the gate off the printed
-`VERDICT:`/`EXIT:` lines, not a bare shell exit code — the block is the actual contract (state file +
-ledger event), an exit code alone skips both.
+tests**, not just coverage. This repo's verify command is this loop's convergence criterion — run it
+wrapped, always, never raw: `{{pluginBinPrefix}}verdict-run.sh -- <verifyCommand>` (BAC-745 — `--` is
+required here, and only here). This holds even if `verifyCommand` is itself already a verdict-contract
+script (e.g. a repo's own `verdict` wrapper) — `verdict-run.sh` detects an already-emitted
+`=== VERDICT ===` block and passes it through unchanged rather than double-wrapping, so wrapping
+unconditionally is always safe. Read the gate off the printed `VERDICT:`/`EXIT:` lines, not a bare
+shell exit code — the block is the actual contract (state file + ledger event), an exit code alone
+skips both.
 → **Gate:** `VERDICT: PASS` + whatever `DEEP_GATES:` step 1 identified (re-checked against the actual
 diff with `--from-git`). `VERDICT: FAIL` loops back autonomously.
 
@@ -269,25 +225,24 @@ diff with `--from-git`). `VERDICT: FAIL` loops back autonomously.
 ### 3. Runtime verify
 Build and run the app, drive the changed surface (CLI/API/GUI — whatever applies) through it, and
 confirm **what was intended actually works**. This produces runtime evidence, not a re-run of the test
-suite. When step 1's plan has any AC contracts, this is now formalized via
+suite. When step 1's plan has any AC contracts, this is formalized via
 `{{pluginBinPrefix}}ac-verify.sh <plan-file>` (ADR-0104 — positional plan file, no `--`) — deterministic
-subprocess judgment (verify exit code, artifact existence, output substring) per contracted AC,
-composing with — not replacing — the observe-the-running-app check above.
+subprocess judgment per contracted AC, composing with (not replacing) the observe-the-running-app check.
 → **Gate:** PASS. FAIL → **loop back to step 2**. SKIP (no runtime surface exists) passes with a
 one-line reason.
 
-> If a GUI surface needs driving and a browser-automation MCP is unavailable or its profile is
-> contended by another concurrent session, fall back to a standalone script that imports this repo's
-> own test framework's browser driver directly (e.g. Playwright) and launches a fresh headless browser
-> — independent of any shared MCP browser profile. Run it from inside the package that has that
-> dependency installed (a script outside it won't resolve the same `node_modules`).
+> If a GUI surface needs driving and a browser-automation MCP is unavailable (or its profile is
+> contended by a concurrent session), fall back to a standalone script that imports this repo's own
+> test framework's browser driver (e.g. Playwright) and launches a fresh headless browser, independent
+> of any shared MCP profile. Run it from inside the package that has that dependency installed — a
+> script outside it won't resolve the same `node_modules`.
 
-> When a browser is involved, prefer an accessibility-tree snapshot (+ diff against the prior state) as
-> the observation evidence over a screenshot — most repos already have a tool for this (e.g. a
+> When a browser is involved, prefer an accessibility-tree snapshot (+ diff against the prior state)
+> over a screenshot as the observation evidence — most repos already have a tool for this (e.g. a
 > `take_snapshot`-style MCP call); reach for a screenshot only when something genuinely needs visual
-> confirmation, not as the default. Never attach a browser-automation MCP that drives the user's own
-> logged-in browser (their cookies, their accounts) to this autonomous step — a prompt injection on the
-> page under test would then reach the user's real accounts, not a sandboxed session.
+> confirmation. Never attach a browser-automation MCP that drives the user's own logged-in browser
+> (their cookies, their accounts) to this autonomous step — a prompt injection on the page under test
+> would then reach the user's real accounts, not a sandboxed session.
 
 ### 4. Review and fix
 Run this plugin's review agents — **by their namespaced names, `ship-flow:code-reviewer`,
@@ -295,52 +250,48 @@ Run this plugin's review agents — **by their namespaced names, `ship-flow:code
 load-bearing: a bare `code-reviewer` collides with `pr-review-toolkit:code-reviewer`, a different agent
 with a different checklist that many repos also have installed, and the wrong one resolving looks
 identical from the outside. If this repo also runs a separate general-purpose PR-review tool, run
-both — treat this plugin's agents as complementary, not a replacement. Fix what they flag autonomously.
+both — these agents are complementary, not a replacement. Fix what they flag autonomously.
 
 **A review agent that ends in a watchdog timeout, a stall, or any other non-completion is a BLOCK, not
 "no findings".** A subagent that never produced a verdict has reviewed nothing; treating its silence as
 a clean pass is how a run reports itself as reviewed when it wasn't. Re-summon it (one at a time if a
-shared local resource caused it) and get a real verdict before step 5.
+shared local resource caused the stall) and get a real verdict before step 5.
 → **Gate:** every summoned review agent returned a completed verdict, and Critical/Important findings
 resolved. Re-run the step-2 gate after fixing, then re-review.
 
-> **Token efficiency**: review agents run in their own context — don't pull their raw internal
-> deliberation into the main context, just the findings summary.
-
 ### 5. Open the PR → `integrationBranch` (or `releaseBranch` if trunk-based) and **stop** — hand off to a human
 Right before opening the PR, get the final verdict against the real diff:
-`{{pluginBinPrefix}}classify-risk.sh --from-git --stage pr --action "PR→<base>" --render-md` — paste the output markdown
-block (verdict table + its audit marker, if the classifier emits one) **verbatim into the PR body**
-rather than transcribing it by hand. If it's REQUIRE, put the reason at the very top of the PR body —
-what a human needs to see is exactly why the gate called for them. This session still composes that PR
-body (summary, verification evidence, gate verdict, any SKIP reasons, and the `Decisions taken` section
-from [Execution mode](#execution-mode--autonomous-by-default)) and the tracked-issue comment text.
-**Write both in `outputLanguage`** (the banner at the top of this file) — this step is the measured
-drift point: by now the context is dominated by this English skill body, and a run that worked in the
-user's language all the way through step 4 reports its PR in English here. Pasted evidence (the verdict
-block, gate output, command names, the branch name) stays verbatim — only your own prose is translated.
-Composing text is not an external state change, which is why this session may still do it.
+`{{pluginBinPrefix}}classify-risk.sh --from-git --stage pr --action "PR→<base>" --render-md` — paste the
+output markdown block (verdict table + its audit marker, if the classifier emits one) **verbatim into
+the PR body** rather than transcribing it. If it's REQUIRE, put the reason at the very top of the PR
+body — what a human needs to see is exactly why the gate called for them. This session still composes
+the PR body (summary, verification evidence, gate verdict, any SKIP reasons, and the `Decisions taken`
+section from [Execution mode](#execution-mode--autonomous-by-default)) and the tracked-issue comment.
+**Write both in `outputLanguage`** (the banner at the top of this file) — this is the measured drift
+point: by now the context is dominated by this English skill body, and runs that worked in the user's
+language through step 4 report the PR in English here. Pasted evidence (verdict block, gate output,
+command names, branch name) stays verbatim — only your own prose is translated.
 
 **This session does not run the `git push`, PR-open, or tracked-issue comment itself** (ADR-0003, issue
-#15 — this session has been reading untrusted issue/web content and holding full worktree access since
-step 0-4, so it must not also be the one executing the external action that publishes the result of that
-work). Instead, hand off to this plugin's `publisher` agent — but the handoff itself has to be file-based,
-not a Bash heredoc: **write the PR title, PR body, and tracked-issue comment text with the Write tool**,
-each to its own file inside a fresh `mktemp -d` directory (never a predictable fixed path), and give
-`publisher` the file paths plus the exact commands to run — `git push -u origin <branch>`, `gh pr create`
-(or this repo's tracker-appropriate equivalent) with `--title` read from the title file and `--body-file`
-pointed at the body file, and the tracked-issue comment command with `--body-file` pointed at the comment
-file. Never assemble these values with a Bash heredoc assigned to a shell variable (`VAR=$(cat <<'EOF' …
-EOF)`) — a quoted delimiter only suppresses expansion inside the body, it does not stop the heredoc from
-ending early if the underlying content (which can be derived from untrusted issue/web text) contains a
-line that is exactly the delimiter word, and everything after that line is then read back as real shell
-commands. See `publisher.md`'s "What you do" for the exact safe pattern (native `--*-file` flags where the
-CLI has them, `"$(cat <path>)"` into a double-quoted variable where it doesn't) and its full explanation
-of why that pattern has no equivalent collision. `publisher` only executes what it's handed — it doesn't
-read repository files on its own initiative, fetch content, or write its own PR/comment text — and reports
-back the PR URL and each command's exit code. **Stop here** — a human reviews and merges. If this PR
-doesn't trigger CI, the PR body is the only verification record a human will see, so make sure step 2's
-gate results are actually in it.
+#15). Hand off to this plugin's `ship-flow:publisher` agent, and make the handoff **file-based, never a
+Bash heredoc**:
+
+1. `mktemp -d` — a fresh directory, never a predictable fixed path.
+2. **Write the PR title, PR body, and tracked-issue comment text with the Write tool**, each to its own
+   file in that directory.
+3. Give `ship-flow:publisher` the file paths plus the exact commands to run — `git push -u origin
+   <branch>`, `gh pr create` (or this repo's tracker-appropriate equivalent) with `--title` from the
+   title file and `--body-file` pointed at the body file, and the tracked-issue comment command with
+   `--body-file` pointed at the comment file.
+
+Never assemble these values with a Bash heredoc (`VAR=$(cat <<'EOF' … EOF)`) — a quoted delimiter does
+**not** stop the heredoc ending early on untrusted content, and everything after that line is read back
+as real shell commands. [PUBLISH-HANDOFF.md](PUBLISH-HANDOFF.md) has the full reasoning and the safe
+pattern; `agents/publisher.md`'s "What you do" has it from the executing side. `ship-flow:publisher`
+only executes what it's handed — it never reads repository files on its own initiative, fetches
+content, or writes its own PR/comment text — and reports back the PR URL and each command's exit code.
+**Stop here** — a human reviews and merges. If this PR doesn't trigger CI, the PR body is the only
+verification record a human sees, so make sure step 2's gate results are in it.
 
 **Hard termination — the run ends when the PR URL exists.** "Stop here" is not "pause and find more work".
 Once the PR is open, this session does **not**, absent a fresh human instruction naming the new work:
@@ -353,10 +304,10 @@ not standing approval, not a PR opened later in the same session, and not a retr
 `gh pr merge` is a result to report, not a loop to go around again: that's one irreversible action
 attempted twice on one approval.
 
-→ **After a human merges:** clean up the worktree/branch (remove any dedicated deep-gate resources first
-if this repo uses per-worktree isolated containers for them, confirm no stash leftovers) + update the
-tracked issue (status, merge SHA) → **step 6**. Release (`integrationBranch → releaseBranch`) is a
-separate decision — `hotfix` or this repo's own release procedure.
+→ **After a human merges:** clean up the worktree/branch (remove any dedicated deep-gate resources
+first, confirm no stash leftovers) + update the tracked issue (status, merge SHA) → **step 6**.
+Release (`integrationBranch → releaseBranch`) is a separate decision — `hotfix`, or this repo's own
+release procedure.
 
 ### 6. `improve` — lessons → skeptical review → harness-improvement PR (post-merge, also stops at a PR)
 Record what the verifier actually confirmed as fixed as a lesson (this plugin's `retrospect` skill, if
@@ -381,25 +332,25 @@ merge, not an edit — autonomy covers getting to the PR; that door is the human
 CLAUDE.md/`.claude/**` from this session.
 
 ## Token efficiency
+- **Delegate exploration.** If understanding the codebase needs 3+ rounds of grep/read, hand it to an
+  Explore-type agent — keep raw file dumps and grep output out of the main context. Same for review
+  agents: pull in their findings summary, not their internal deliberation.
 - **Delegate mechanical, judgment-free work** (lint/type-error fix loops, straightforward renames) to a
-  cheaper model — there's no reason to spend a top-tier model on repetitive fixes that don't need
-  judgment.
+  cheaper model.
 - **Check context size at step boundaries.** Crossing the step 2→3 or 3→4 gate after accumulating long
-  test output or long review results is a good point to consider delegating or compacting — worktree
-  isolation makes single sessions run long.
+  test or review output is a good point to consider delegating or compacting — worktree isolation makes
+  single sessions run long.
 
 ## Failures and conflicts (handled autonomously)
 - Gate red → loop back on that step autonomously. Only call a human if the agent can't resolve it itself.
 - Human-side merge reports out-of-date/CONFLICTING → in the worktree, **standalone** `git fetch origin
-  <base>` → **standalone** `git rebase origin/<base>` → re-verify. Then hand the retry push off to
-  `publisher` the same way step 5 does (ADR-0003) — this is still the Builder session, still holding the
-  same untrusted-input history from steps 0-4, so it must not run the push itself. Give `publisher` the
-  branch name as a literal value and the exact command to run: `git push --force-with-lease origin
-  "$BRANCH"` with `$BRANCH` assigned from that literal (never bare/unquoted interpolation) — the same
-  defensive quoting step 5 uses for the branch name, never a Bash heredoc. `<base>` is **that PR's base**
-  (the integration branch, or the release branch for a release PR). **Run each command as its own
-  independent call** — chaining `git merge`/`git pull` with anything else is liable to trip a merge
-  guardrail hook regardless of direction, if this repo has one.
+  <base>` → **standalone** `git rebase origin/<base>` → re-verify. Then hand the retry push to
+  `ship-flow:publisher` the same way step 5 does (ADR-0003) — still the Builder session, still holding
+  untrusted-input history from steps 0-4, so it must not run the push itself. Give it the branch name
+  as a literal and the exact command: `git push --force-with-lease origin "$BRANCH"`, `$BRANCH`
+  assigned from that literal (never bare/unquoted interpolation), never a Bash heredoc. `<base>` is
+  **that PR's base**. **Run each command as its own independent call** — chaining `git merge`/`git pull`
+  with anything else is liable to trip a merge guardrail hook regardless of direction.
 - **Stacked PR (this branch is itself another open PR's base) + squash-merge**: once this PR merges,
   the branch it was on is gone as a target — the stacked PR's base doesn't auto-retarget, so its commits
   can land in a dead branch instead of the integration branch even though GitHub shows it as merged. If

--- a/tools/ship-flow/workflows/harness-audit.js
+++ b/tools/ship-flow/workflows/harness-audit.js
@@ -2,8 +2,18 @@
 // Kept as a named workflow (rather than an inline script pasted into a skill) so a run that
 // finishes the investigate phase but gets interrupted before synthesis can be resumed instead
 // of re-run from scratch. The wrapping skill (harness-maturity-audit) is a thin caller: it
-// invokes Workflow({ name: 'harness-audit' }) and owns saving the report and any follow-up
-// hand-off (e.g. to an issue-creation skill) once this workflow returns.
+// invokes Workflow({ name: 'ship-flow:harness-audit' }) and owns saving the report and any
+// follow-up hand-off (e.g. to an issue-creation skill) once this workflow returns.
+//
+// On the name: `meta.name` below is the BARE name; the INVOCATION name is plugin-namespaced.
+// Claude Code namespaces plugin-provided workflows as `<plugin-name>:<meta.name>` (docs:
+// code.claude.com/docs/en/workflows.md — "Plugin workflows are namespaced by the plugin name"),
+// which is also what first-party plugins do: the official claude-security plugin declares
+// `meta.name: "scan"` in workflows/scan.js and its skill invokes `Workflow({ name:
+// "claude-security:scan" })`. So the two are SUPPOSED to differ — do not "fix" this by
+// prefixing `meta.name`. (An alternative invocation form exists, `Workflow({ scriptPath:
+// "${CLAUDE_PLUGIN_ROOT}/workflows/<file>.js" })`, used by the official code-modernization
+// plugin; it bypasses name resolution entirely and is not what this plugin uses.)
 
 export const meta = {
   name: 'harness-audit',


### PR DESCRIPTION
Closes the four remaining skill-layer findings from the 2026-08-20 harness maturity audit. `ship-flow` 0.3.1 → 0.3.2. Scope is confined to `tools/ship-flow/**` plus the three release manifests.

## 1. Workflow invocation name — settled with primary evidence

The audit flagged this as **unresolved**: `harness-maturity-audit/SKILL.md` calls `Workflow({ name: 'ship-flow:harness-audit' })` while `workflows/harness-audit.js` self-declares `meta.name: 'harness-audit'`, and no `Workflow` tool was available in that session to test it.

**The call site was already correct; the workflow file's header comment was the stale one.**

- **Official docs** — `code.claude.com/docs/en/workflows.md`: *"Plugin workflows are namespaced by the plugin name. A plugin called `acme-tools` containing a script whose `meta.name` is `release-audit` runs as `/acme-tools:release-audit`."*
- **First-party precedent** — Anthropic's `claude-security` plugin ships the identical shape: `workflows/scan.js` declares `meta.name: "scan"` (bare) and `skills/claude-security/jobs/scan-codebase.md` invokes `Workflow({ name: "claude-security:scan" })`.
- **Corroboration** — this session's own skill listing surfaces the plugin's workflows as `ship-flow:harness-audit`, `ship-flow:trends-research`, `ship-flow:adversarial-review`, all from bare `meta.name` values.

So `meta.name` and the invocation name are *supposed* to differ. The header comment now says so explicitly and warns against "fixing" it by prefixing `meta.name` — the tempting wrong move that would actually break resolution. It also notes the alternative `scriptPath:` form (used by the first-party `code-modernization` plugin), which bypasses name resolution entirely and is not what this plugin uses.

The other two workflows are never invoked from any skill, so they offered no convention of their own to compare against.

## 2. `ship-feature/SKILL.md` — 4771 → 4067 words

Hard cap 5000, so headroom goes from **229 → 933 words**. Reduction is entirely progressive disclosure, following the pattern `tdd/` (5 reference files) and `improve-codebase-architecture/` (3) already use. Three new bundled files, each linked from the point of use:

| File | What moved | Words |
|---|---|---|
| `RISK-GATE.md` | What the rule set covers, why agent input may only *raise* a classification, the two channels of `DENY_AND_LOG`, layering a repo's own `risk-rules.json` | 645 |
| `AC-CONTRACTS.md` | Full AC syntax, field semantics, three worked examples, why the one-contract floor exists | 403 |
| `PUBLISH-HANDOFF.md` | Why the Builder session doesn't publish its own work (ADR-0003), why a quoted heredoc delimiter does not make the pattern safe | 603 |

What stayed inline is what an agent needs *at the moment of acting*: the executable command literals, the three exit codes, the TRACK routing table, the step sequence and its gates, and every invariant.

**Regression guards were checked before moving any text.** `ship-flow-executable-contract.test.sh`, `verdict-wrap-required.test.sh`, `skill-guard-prose-wiring.test.sh`, `lesson-codification-bac756.test.sh` and `runtime-verify-evidence-bac749.test.sh` assert ~28 distinct strings against this file's prose. All of them are still inline — no test was loosened, and no guarded property was relocated. There was no genuine conflict between the two goals: everything the guards protect is act-moment content that belonged inline anyway.

**The 2000-word soft target is not reachable** without deleting behaviour that was codified deliberately. Of the remaining 4067 words, ~2100 are the act-moment step sequence and ~440 are the non-negotiable invariants — much of that prose was strengthened *because* a forensic audit of 12 real runs found the weaker form was being ignored. Cutting further would re-open findings this plugin already closed.

## 3. `publisher` → `ship-flow:publisher`

Aligned. There is no known collision today, so this is consistency rather than a live bug — but the `code-reviewer` / `pr-review-toolkit:code-reviewer` collision that forced the v0.3.0 namespacing arrived unannounced, and `publisher` is a generic enough noun to be the same shape of risk. The namespaced form resolves identically either way, so aligning costs nothing and removes the failure mode in advance. `ship-feature` now namespaces every agent it invokes.

## 4. `DEEPENING.md` — wired in, not removed

The audit's "orphaned" call was **half wrong**, which is why this needed verifying rather than acting on:

- `INTERFACE-DESIGN.md` **is** linked from `SKILL.md:92`.
- `DEEPENING.md` is **not** linked from `SKILL.md` — but it *is* linked three times from `INTERFACE-DESIGN.md`.

So it was reachable, just buried one level down behind a niche *"want to explore alternative interfaces for the deepened module?"* branch. Its content — the four dependency categories, seam discipline (*one adapter = hypothetical seam*), and the replace-don't-layer testing strategy — is core to step 3's grilling loop, which is described as deciding *"the shape of the deepened module, what sits behind the seam, what tests survive"*. That is exactly what `DEEPENING.md` answers, so it is now linked directly from step 3. Wiring in beat deleting because the content is load-bearing for the skill's main flow, not vestigial.

## Verification

```
$ bash tools/loop-engine/test/run.sh
loop-engine selftest: 48/48 passed

$ claude plugin validate --strict .
✔ Validation passed

$ claude plugin validate --strict tools/ship-flow
✔ Validation passed

$ node tools/loop-engine/bin/check-docs-hygiene.mjs
WARN  skill-word-cap — tools/ship-flow/skills/ship-feature/SKILL.md: 4067단어 — 공식 target 2000 초과
check-docs-hygiene: OK (3건 WARN, 0건 FAIL)

$ node tools/loop-engine/bin/check-module-size.mjs
PASS: module-size ratchet — 위반 없음
```

The `ship-feature` WARN improves from 4771 to 4067; `retrospect` (2504) and `setup` (2025) are unchanged and out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VNR8Xbi414uHHzUFzmmMDp
