### PR TITLE
feat(ship-flow): project per PRD + assignee on close-out (0.4.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -19,7 +19,7 @@
       "name": "ship-flow",
       "source": "./tools/ship-flow",
       "description": "Delivery-loop skills — ship-feature (plan-to-PR autonomous loop), hotfix, retrospect, grill-with-docs, deps-audit, to-issues/to-prd, tdd, harness-maturity-audit, improve-codebase-architecture, resolving-merge-conflicts, plus review agents and audit/research workflows — parameterized by a consuming repo's own tracker/branch-model config instead of hardcoded to one repo. dependencies: loop-engine.",
-      "version": "0.3.2",
+      "version": "0.4.0",
       "keywords": ["delivery", "git-flow", "hotfix", "ship", "release"]
     },
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,52 @@ Explicit-version channel — see [README § Development status](README.md#develo
 not a SHA channel. Entries below `## loop-engine 0.2.0` and earlier predate the multi-plugin split
 and refer to `loop-engine` only (see the un-prefixed version numbers).
 
+## ship-flow 0.4.0
+
+`to-prd` and `to-issues` now produce a project per body of work, instead of accumulating every PRD and
+every issue under whatever long-lived project a repo already had.
+
+- **`to-prd` creates a new project for each PRD (was: only "if no project exists yet").** The old
+  wording was conditional, and the condition was almost never false — any repo that has been running a
+  while has *some* project — so in practice the skill never created one. Measured in the consuming
+  repo: a project named `… 보일러플레이트 설계` held two PRD documents for entirely unrelated bodies of
+  work (product analytics instrumentation, and hospital-admin account provisioning) plus issues for
+  message scheduling, call timelines, and test-DB reset. The project's name had stopped describing its
+  contents, and neither PRD had a grouping of its own. The skill now creates the project as step 3 and
+  names the two narrow exceptions (the PRD amends an existing PRD's scope; the repo's tracker doc pins
+  PRDs somewhere) rather than leaving reuse to judgement.
+- **`to-prd` attaches supporting material to the project** — tracker documents for prose, links for
+  artifacts that live outside it (ADRs, PRs, published artifacts, dashboards). The project becomes the
+  single place to land for a body of work, rather than a bare issue list. Only material that already
+  exists gets attached; the skill does not block on artifacts not yet produced.
+- **`to-prd` reports the project identifier**, because `to-issues` cannot recover it otherwise.
+- **`to-issues` resolves a target project explicitly, as a new step 5, and stops if it cannot.**
+  Previously project routing was one clause inside "check this repo's tracker-integration doc" — so
+  when that doc pinned a fixed project (as the consuming repo's did), every issue went there, and when
+  it said nothing, issues were filed with no project at all. Measured: 51 of the first 250 issues
+  carrying the repo's own label had no project. Resolution order is now PRD's project → user-named →
+  the repo's standing non-PRD project → **ask**. Both silent failures are called out by name, because
+  each looks like success at the moment of filing.
+
+Alongside it, finished issues now end up owned by someone.
+
+- **`ship-feature` step 0 says who to assign the claim to.** It already said to "claim the issue to
+  yourself", but an agent has no account on the tracker, so "yourself" resolved to nothing and the
+  assignee was routinely left empty. It now names the target explicitly — the human whose account the
+  session is authenticated as — and spells out why an empty assignee is invisible until much later:
+  the tracker's merge automation closes the issue without setting one, so it lands in Done owned by
+  nobody. Measured in the consuming repo: the completed issues carrying its own label include roughly
+  200 with no assignee at all.
+- **`retrospect` gains a tracker close-out backstop.** Claiming at step 0 only helps runs that went
+  through `ship-feature`; issues closed by hand or by merge automation still arrive unowned. Before
+  reporting, retrospect now assigns the session's user to any issue *this session finished* that is
+  done with an empty assignee — scoped deliberately to this session's own work, because a blanket
+  sweep would attribute other people's issues to whoever happened to run it. A backlog it declines to
+  touch gets surfaced in the report instead.
+
+Nothing here is repo-specific: "which project" is still resolved from the consuming repo's own
+tracker-integration doc, and Linear remains the worked example rather than a requirement.
+
 ## ship-flow 0.3.2
 
 Skill-layer hygiene closing the 2026-08-20 harness maturity audit's remaining findings. No behaviour

--- a/tools/ship-flow/.claude-plugin/plugin.json
+++ b/tools/ship-flow/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ship-flow",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "description": "Delivery-loop skills — land and release already-verified work through a repo's real gates. Tracker- and branch-model-agnostic: reads a consuming repo's own config instead of hardcoding one repo's setup.",
   "author": {
     "name": "paulkim-lansik"

--- a/tools/ship-flow/skills/retrospect/SKILL.md
+++ b/tools/ship-flow/skills/retrospect/SKILL.md
@@ -224,7 +224,26 @@ challenge gate as any promotion candidate. Verify it actually landed, too: after
 evidence, run `lessons stats`/`lessons promote` and confirm the id is back among the open candidates —
 don't take the act of re-recording alone as proof the lesson reopened.
 
+## Tracker close-out — the issue must end up owned
+
+Before reporting, check the tracked issue(s) this session finished. **If an issue is in a done state
+with no assignee, set the assignee to the human driving this session** — the account the tracker is
+authenticated as (Linear's `me` is the worked example), never an agent identity, never left empty.
+
+This is a backstop for the claim in `ship-feature` step 0, not a replacement for it. It exists because
+the two ways an issue reaches Done have different failure modes: closing it by hand is easy to do
+without touching the assignee, and letting merge automation close it never sets one at all. Either way
+the issue lands in Done owned by nobody, which afterwards reads as "nobody did this" rather than "this
+was done" — and by then no one remembers which session it belonged to.
+
+Only touch issues this session actually worked. A blanket sweep over every unassigned done issue in
+the tracker would attribute other people's work to this session's user; if you notice a backlog of
+them, say so in the report and leave the decision to the user.
+
 ## Reporting
 
 State what was recorded/recalled and the loop-efficiency trend. When promoting, name the recurring
 blocker and propose the concrete skill or guideline — don't auto-edit guidelines from a single run.
+
+If the tracker close-out above changed anything — or found a backlog of unassigned done issues it
+deliberately left alone — say so here.

--- a/tools/ship-flow/skills/ship-feature/SKILL.md
+++ b/tools/ship-flow/skills/ship-feature/SKILL.md
@@ -151,10 +151,16 @@ classification, the two channels of `DENY_AND_LOG`, and layering this repo's own
 ## Sequence (0 → PR is autonomous, merge is human, post-merge is `improve`)
 
 ### 0. Worktree isolation — `git worktree`
-If this repo tracks issues externally (Linear, GitHub Issues, etc.), claim the issue to yourself first
-— before creating the worktree — by assigning it and moving it into an in-progress state. Where
-concurrent sessions are common, claiming first is what stops two sessions picking up the same issue
-(worktree isolation alone prevents git conflicts, not duplicate starts).
+If this repo tracks issues externally (Linear, GitHub Issues, etc.), claim the issue first — before
+creating the worktree — by assigning it and moving it into an in-progress state. Where concurrent
+sessions are common, claiming first is what stops two sessions picking up the same issue (worktree
+isolation alone prevents git conflicts, not duplicate starts).
+
+**Assign it to the human driving this session — not to nobody, not to an agent identity.** You have no
+tracker account of your own; the one you are authenticated as is theirs, so assigning to the
+authenticated account is what puts their name on it (Linear's `me` is the worked example). An empty
+assignee here is the common failure and stays invisible for a long time: merge automation closes the
+issue without ever setting one, so it lands in Done owned by nobody.
 
 `git fetch origin && git worktree add -b <type>/<slug> <sibling-path-outside-repo> origin/<base>`. Check
 `git worktree list` first if concurrent work is common here. A fresh worktree has no installed

--- a/tools/ship-flow/skills/to-issues/SKILL.md
+++ b/tools/ship-flow/skills/to-issues/SKILL.md
@@ -76,9 +76,30 @@ Ask the user:
 
 Iterate until the user approves the breakdown.
 
-### 5. Publish the issues to the issue tracker
+### 5. Resolve the target project
 
-For each approved slice, publish a new issue to this repo's issue tracker. Check this repo's own tracker-integration doc, if it has one, for the exact conventions it expects (team/project routing, required fields) — apply this repo's own required labels/conventions, if any. Use the issue body template below.
+Every issue you create belongs to a project (Linear's Project is the worked example; other trackers
+may call it an epic or a milestone). **Resolve which one before you create anything**, in this order:
+
+1. **The project of the PRD this plan came from.** If the source is a PRD, `to-prd` created a project
+   for it and reported the identifier — use that one. If you were handed the PRD document rather than
+   the identifier, read the document's parent project off the tracker.
+2. **What the user named**, if they specified a project.
+3. **The repo's standing project for non-PRD work**, if its tracker-integration doc names one — the
+   home for bugfixes, ops hygiene, and chores that have no PRD behind them.
+
+**If none of the three resolves, stop and ask the user.** Do not file the issues with no project, and
+do not fall back to whichever long-lived project happens to exist. Both failures look like success at
+the moment of filing and are tedious to unpick later: project-less issues become indistinguishable
+from ones that were *meant* to be unfiled, and a default catch-all silently accumulates work its name
+doesn't describe.
+
+If the slices clearly span more than one body of work, that's a signal the breakdown in step 3 mixed
+two plans together — raise it with the user rather than splitting the issues across projects.
+
+### 6. Publish the issues to the issue tracker
+
+For each approved slice, publish a new issue to this repo's issue tracker, **in the project resolved in step 5**. Check this repo's own tracker-integration doc, if it has one, for the exact conventions it expects (team routing, required fields) — apply this repo's own required labels/conventions, if any. Use the issue body template below.
 
 These issues are considered ready for AFK agents — if this repo's tracker has a triage-state or label vocabulary for that, apply it here (check the tracker-integration doc if unsure which value to use) unless instructed otherwise.
 

--- a/tools/ship-flow/skills/to-prd/SKILL.md
+++ b/tools/ship-flow/skills/to-prd/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: to-prd
-description: Turn the current conversation context into a PRD and publish it as a document in this repo's issue tracker (creating the project first if none exists yet). Use when user wants to create a PRD from the current context.
+description: Turn the current conversation context into a PRD, create a dedicated project for it on this repo's issue tracker, and publish the PRD as a document under that project. Use when user wants to create a PRD from the current context.
 ---
 
 # to-prd — publish a PRD from conversation context
@@ -21,9 +21,47 @@ This skill takes the current conversation context and codebase understanding and
 
 Check with the user that these seams match their expectations.
 
-3. Write the PRD using the template below, then publish it as a **document in the project** (not as an issue):
-   - Determine the target project on this repo's issue tracker (Linear's Project is the worked example — other trackers may call the equivalent grouping an epic, milestone, or something else). **If no project exists yet for this work, create the project first**, then create the PRD document under it.
-   - Create the PRD as a **project document**, if this repo's tracker has a document/PRD concept — Linear's Document feature is the worked example. If the tracker has no separate document concept, the closest equivalent (e.g. a pinned top-level issue) is fine. The PRD document doesn't need this repo's issue-workflow labels, if it uses them — those apply to issues, not documents. Any actionable label marking work ready to pick up belongs on the slice issues produced later by `to-issues`, which reference this PRD document as their source.
+3. **Create a new project for this PRD.** A PRD defines a distinct body of work, and that body of work
+   gets its own grouping on the tracker — Linear's Project is the worked example; other trackers may
+   call it an epic, a milestone, or something else.
+
+   **Create it new. Do not file the PRD under an existing project because one happens to be there.**
+   That is the failure this step exists to prevent: reusing whatever long-lived project the repo
+   already has turns it into a catch-all whose name stops describing its contents, and the PRDs inside
+   it lose any grouping of their own. If you find yourself reaching for an existing project, the
+   question to ask is not "does a project exist?" but "is this PRD an amendment to *that specific*
+   PRD's scope?" — and only a yes justifies reuse.
+
+   Two legitimate exceptions, both narrow: the PRD genuinely amends an existing PRD's scope (then
+   reuse that PRD's project), or this repo's tracker-integration doc explicitly pins PRDs somewhere.
+   Anything else — create the project.
+
+   Give the project a name that describes *this* body of work, a summary, and a description saying
+   what is in and out of scope.
+
+4. Write the PRD using the template below and publish it as a **document under the project created in
+   step 3** (not as an issue) — Linear's Document feature is the worked example. If the tracker has no
+   separate document concept, the closest equivalent (e.g. a pinned top-level issue) is fine.
+
+   The PRD document doesn't need this repo's issue-workflow labels, if it uses them — those apply to
+   issues, not documents. Any actionable label marking work ready to pick up belongs on the slice
+   issues produced later by `to-issues`, which reference this PRD document as their source.
+
+5. **Attach the supporting material to the project**, so the project is the one place someone lands to
+   find everything about this body of work:
+   - **Documents** for prose that lives in the tracker — research notes, design write-ups, decision
+     records drafted during this conversation.
+   - **Links** for artifacts that live outside it — ADRs and design docs in the repo, pull requests,
+     published artifacts, dashboards, external specs. Where the tracker's link list is append-only
+     (Linear's is), adding a link never removes an existing one.
+
+   Only attach what already exists. Don't invent artifacts to fill the list, and don't block on
+   material that hasn't been produced yet — `to-issues` and the implementation runs will add more
+   links as they go.
+
+6. **Report the project identifier** in your final message, alongside the PRD document reference.
+   `to-issues` needs it: the slice issues it creates must land in this same project, and it has no way
+   to recover the identifier if you don't hand it over.
 
 <prd-template>
 


### PR DESCRIPTION
## 무엇이 문제였나

`to-prd`는 "프로젝트가 **없으면** 만들어라"였는데, 그 조건은 거의 항상 거짓이다 — 조금이라도 운영된 레포엔 프로젝트가 *어딘가* 있다. 그래서 실제로는 한 번도 새로 만들지 않았다.

소비 레포 실측 (2026-08-25):

| 증상 | 실측 |
|---|---|
| catch-all 프로젝트 | `… 보일러플레이트 설계` 안에 **서로 무관한 기획의 PRD 문서 2건**(PostHog 계측 / 병원 관리자 계정 발급) + 발송 스케줄링·leads 통화 타임라인·테스트 DB 리셋 이슈 혼재. 프로젝트 이름이 내용물을 설명하지 못함 |
| 프로젝트 미지정 | 라벨 이슈 1페이지(250건) 중 **51건** |
| assignee 미지정 | 완료 이슈 중 **200건대** |

assignee 쪽은 원인이 둘이고 둘 다 조용하다 — `ship-feature` 0단계가 "claim the issue **to yourself**"라고만 해서 트래커 계정이 없는 에이전트에겐 대상이 없었고, 머지 자동화가 이슈를 닫을 땐 assignee를 설정하지 않는다.

## 변경

- **`to-prd`** — PRD마다 **새 프로젝트를 만든다**(3단계). 재사용의 좁은 예외 2가지를 명시(기존 PRD의 범위를 수정 / 레포 트래커 문서가 PRD 위치를 못박음)해서 판단에 맡기지 않음. 산출물을 프로젝트에 붙이고(문서 = 산문, 링크 = 레포 밖 아티팩트), **프로젝트 식별자를 보고**한다 — `to-issues`가 달리 복구할 방법이 없어서.
- **`to-issues`** — 새 5단계에서 타깃 프로젝트를 명시적으로 해석: PRD의 프로젝트 → 사용자 지정 → 레포의 상설 non-PRD 프로젝트 → **묻는다**. 두 조용한 실패(프로젝트 없이 발행 / 아무 catch-all로 폴백)를 이름 붙여 금지.
- **`ship-feature` 0단계** — claim 대상을 명시: 세션을 모는 **사람**(트래커가 인증된 계정). 빈 assignee가 왜 늦게까지 안 보이는지도 적음.
- **`retrospect`** — 마무리 백스톱. 이번 세션이 끝낸 이슈가 assignee 없이 done이면 채운다. **이 세션 작업분에만** 한정 — 전량 sweep은 남의 작업을 귀속시킨다.

## 제네릭성

레포 고유 값은 안 들어갔다. "어느 프로젝트"는 여전히 소비 레포의 트래커 문서에서 해석하고, Linear는 요구사항이 아니라 worked example로 남는다. 상설 non-PRD 프로젝트는 *레포* 규약이지 플러그인 규약이 아니다.

## 검증

- `loop-engine` selftest **48/48**
- 소비 레포 쪽 규약 갱신은 별도 PR (glucofit-partners)

## 머지 순서 주의

`ship-flow` 0.3.2를 올리는 #59와 같은 파일(CHANGELOG)을 건드린다. #59가 먼저 착지하면 리베이스 필요 — 0.4.0은 그대로 유효.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VNR8Xbi414uHHzUFzmmMDp