### PR TITLE
fix(loop-engine): 리워드핵 가드의 실효 루트를 편집 대상의 워크트리로 (BAC-785, 0.9.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "loop-engine",
       "source": "./tools/loop-engine",
       "description": "Core loop mechanics: verdict-run (machine-readable PASS/FAIL contract), loop-fix (closed verify->fix loop), lessons (verified-fix memory), classify-risk, require-tests, plugin-path (resolve sibling plugin install paths), check-docs-hygiene/check-pr-hygiene/check-module-size (repo hygiene gates). No framework opinions beyond \"the verifier is the ceiling, never the agent's self-report\".",
-      "version": "0.10.0",
+      "version": "0.10.1",
       "keywords": ["verifier", "tdd", "loop", "verdict", "lessons"]
     },
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,37 @@ Explicit-version channel — see [README § Development status](README.md#develo
 not a SHA channel. Entries below `## loop-engine 0.2.0` and earlier predate the multi-plugin split
 and refer to `loop-engine` only (see the un-prefixed version numbers).
 
+## loop-engine 0.10.1
+
+The reward-hack guard was structurally never armed in the workflow its consuming repo mandates.
+
+- **`hooks/protect-during-loop.mjs` judged arming and glob matching at `CLAUDE_PROJECT_DIR` (BAC-785).**
+  In a worktree-isolated session that is the *main* worktree, parked on an unprotected branch — so
+  `guardState(root)` returned `unprotected-branch` and the hook `exit(0)`'d **before stdin was even
+  parsed**, reaching a verdict before it knew what file was being touched. A second, independent break
+  sat behind it: even when armed, `relative(root, filePath)` produced `../<sibling-worktree>/…`, which
+  the hook explicitly let through. Measured in a consuming repo: five protected paths
+  (`.claude/settings.json`, `**/*.test.sh`, `package.json`, …) were edited across one task with no
+  `.loop/guard-off` window and no denial.
+- **The effective root is now derived from what is being touched**: the target's own worktree, else the
+  session cwd's worktree, else `root`. Re-rooting only happens for a worktree of the *same* repository
+  (`--git-common-dir`, resolved and realpath'd — a main worktree prints it relative, a linked one
+  absolute, and on macOS `/var` is a symlink to `/private/var`), so an unrelated repo stays out of
+  scope. This is the pattern `hooks/gate-before-merge.mjs` already used for direction inference.
+- **Re-rooting can never disarm.** It exists to find protection `root` missed, not to escape protection
+  `root` had: a session on an armed worktree running a Bash command with cwd back in the main worktree
+  would otherwise have been handed a way out.
+- **A worktree nested inside the root** (an untracked `.worktrees/…`, a layout consuming repos allow)
+  counts as a separate worktree. Detected filesystem-only, so an ordinary in-root edit still spawns no
+  extra git.
+- **The plugin's own install path is protected again in these sessions.** That absolute-prefix
+  self-protection sits behind the arming check, so it was off for the same reason — the session-cwd
+  fallback is what restores it.
+- New `lib/protect-globs.mjs` exports `isInsideRoot` / `resolveWorktreeRoot`; new
+  `test/protect-worktree-root.test.sh` pins 19 cases (5 of them red against 0.9.0), including
+  ancestor-walk resolution for a file under a not-yet-created directory — a protected `**/*.test.sh`
+  written into a fresh directory was the one reward-hack path left open.
+
 ## ship-flow 0.5.0
 
 Adds a new skill: **`diagnosing-bugs`**, ported from `mattpocock/skills` (upstream renamed it from
@@ -94,7 +125,6 @@ Genericity repair, a false-alarm fix in the heartbeat, and coverage for four pre
 ⚠️ **Dependency ranges**: `ship-flow` and `loop-memory` both declare `loop-engine ^0.9.0`, which
 `0.10.0` falls outside of. They need `^0.10.0` in a companion bump, following the convention of every
 prior loop-engine minor.
-
 ## loop-memory 0.4.0
 
 Hook liveness is now recorded always-on, so "the hooks fired" stops being an anecdote (issue #35).

--- a/tools/loop-engine/.claude-plugin/plugin.json
+++ b/tools/loop-engine/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "loop-engine",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Core loop mechanics: verdict-run (machine-readable PASS/FAIL contract), loop-fix (closed verify->fix loop), lessons (verified-fix memory), classify-risk, require-tests, check-docs-hygiene/check-pr-hygiene/check-module-size (repo hygiene gates). verifier=ceiling — the agent's self-judgement never substitutes for it.",
   "author": {
     "name": "paulkim-lansik"

--- a/tools/loop-engine/hooks/protect-during-loop.mjs
+++ b/tools/loop-engine/hooks/protect-during-loop.mjs
@@ -19,6 +19,11 @@
 // that hits a protected glob. Pure reads (cat/grep/pnpm test/etc.) pass through. The real boundary is
 // PR review, not this hook.
 //
+// Rooting: arming and glob matching are judged at the *target's* worktree, not the session's
+// CLAUDE_PROJECT_DIR (BAC-785) — see the effective-root block below. On the Bash channel "the target"
+// can only mean the session's cwd (what a shell touches is undecidable), so that channel is rooted at
+// cwd's worktree — a coarser net, in keeping with it being a guardrail and not a boundary.
+//
 // fail-open: internal error / non-git / detached -> allow (never wedge the session).
 
 import { existsSync, readFileSync } from 'node:fs';
@@ -36,19 +41,22 @@ const pluginPath = fileURLToPath(new URL('..', import.meta.url)).replace(/\/$/, 
 let GUARD_OFF_TTL_MS;
 let globToRegExp;
 let guardState;
+let isInsideRoot;
 let loadPatterns;
-let state;
+let resolveWorktreeRoot;
 try {
-  ({ GUARD_OFF_TTL_MS, globToRegExp, guardState, loadPatterns } = await import(
-    '../lib/protect-globs.mjs'
-  ));
-  state = guardState(root);
+  ({ GUARD_OFF_TTL_MS, globToRegExp, guardState, isInsideRoot, loadPatterns, resolveWorktreeRoot } =
+    await import('../lib/protect-globs.mjs'));
 } catch (e) {
   console.error(`[protect-during-loop] judge module load failed (fail-open): ${String(e?.message ?? e)}`);
   process.exit(0);
 }
-if (!state.armed) process.exit(0);
 
+// stdin is parsed BEFORE the arming verdict (BAC-785). It used to be the other way round:
+// `guardState(root)` ran first and `if (!state.armed) process.exit(0)` reached a verdict before the
+// target path was even known. In a worktree-isolated session root is the MAIN worktree, parked on an
+// unprotected branch — so the guard disarmed itself for every edit the session made, in the exact
+// workflow the consuming repo mandates.
 let payload;
 try {
   payload = JSON.parse(readFileSync(0, 'utf8'));
@@ -58,10 +66,62 @@ try {
 const tool = payload?.tool_name;
 const input = payload?.tool_input ?? {};
 
-const globFile = join(root, '.loop', 'protect.globs');
+const str = (v) => (typeof v === 'string' && v ? v : '');
+// `cwd` is documented as a field on every hook event; process.cwd() backs it up so behaviour doesn't
+// hinge on a premise no captured PreToolUse payload in this repo confirms. Both candidates still have
+// to pass the same-repository check below, so neither can re-root anywhere wrong.
+const sessionDir = str(payload?.cwd) || process.cwd();
+const target = tool === 'Bash' ? sessionDir : str(input?.file_path);
+
+// Effective root: the target's own worktree -> the session's worktree -> root.
+let effRoot = root;
+let rerooted = null;
+try {
+  rerooted = resolveWorktreeRoot(root, target);
+  if (rerooted) {
+    effRoot = rerooted.top;
+  } else if (target && target !== sessionDir && !isInsideRoot(root, target)) {
+    // The target belongs to no worktree of this repo — the plugin's own install path being the case
+    // that matters. Without this step the absolute-prefix self-protection further down stays off in
+    // exactly the sessions it exists for, because arming would still be judged at `root`.
+    // (Skipped when target IS sessionDir — the Bash channel — since that call just failed above.)
+    const viaSession = resolveWorktreeRoot(root, sessionDir);
+    if (viaSession) effRoot = viaSession.top;
+  }
+} catch (e) {
+  // Keep root (fail-open, unchanged behaviour) — but say so. What this hides is precisely the bug
+  // BAC-785 fixes: the guard quietly falling back to root and disarming itself. Its sibling catches
+  // both log; a silent one here would make a regression into this bug class indistinguishable from
+  // normal operation. Only reachable when the target is outside root, so it can't spam every call.
+  console.error(`[protect-during-loop] worktree re-root failed (fail-open): ${String(e?.message ?? e)}`);
+}
+
+let state;
+try {
+  state = guardState(effRoot);
+  // Re-rooting must never DISARM. It exists to find protection `root` missed, not to escape
+  // protection `root` had: with the session on an armed worktree, a Bash command whose cwd points at
+  // the main worktree used to be denied, and re-rooting to that unprotected branch would hand back a
+  // way out. Costs one extra branch lookup, and only on the rare unarmed-after-re-root path.
+  if (!state.armed && effRoot !== root) state = guardState(root);
+} catch (e) {
+  console.error(`[protect-during-loop] arming verdict failed (fail-open): ${String(e?.message ?? e)}`);
+  process.exit(0);
+}
+if (!state.armed) process.exit(0);
+
+const globFile = join(effRoot, '.loop', 'protect.globs');
 if (!existsSync(globFile)) process.exit(0);
 
-const patterns = loadPatterns(globFile);
+let patterns;
+try {
+  patterns = loadPatterns(globFile);
+} catch (e) {
+  // Unreadable glob file (permissions, a truncated write) -> allow. This file declares fail-open as
+  // its contract; an uncaught throw here would exit non-zero and wedge the tool call instead.
+  console.error(`[protect-during-loop] protect.globs unreadable (fail-open): ${String(e?.message ?? e)}`);
+  process.exit(0);
+}
 const matchesGlob = (tok) => patterns.some((p) => globToRegExp(p).test(tok));
 
 const TTL_MIN = Math.round(GUARD_OFF_TTL_MS / 60000);
@@ -143,7 +203,10 @@ if (filePath === pluginPath || filePath.startsWith(`${pluginPath}/`)) {
   );
 }
 
-const rel = relative(root, filePath).split('\\').join('/');
+// A target-based re-root already carries git's own repo-relative path. When only the *session*
+// fallback moved effRoot (the target resolved to no worktree), rel stays measured from `root`: the
+// target isn't inside effRoot, and measuring it from there would over-block a nested foreign repo.
+const rel = (rerooted ? rerooted.rel : relative(root, filePath)).split('\\').join('/');
 // Paths outside the repo (another repo, /tmp, $HOME, etc. — the plugin path is already handled above)
 // aren't protected -> allow (`../` and absolute paths are excluded from matching).
 if (rel === '..' || rel.startsWith('../') || rel.startsWith('/')) process.exit(0);

--- a/tools/loop-engine/lib/protect-globs.mjs
+++ b/tools/loop-engine/lib/protect-globs.mjs
@@ -14,8 +14,8 @@
 //      옵트아웃 창 — tdd RED 단계·정당한 config 편집의 우회 경로. 빈 파일·만료는 무효=무장 유지)
 //   5. 그 외 → ARMED (feature/* 등 작업 브랜치 상시 무장 — 에이전트의 산문 기억에 의존하지 않는다)
 import { execFileSync } from 'node:child_process';
-import { existsSync, readFileSync, statSync } from 'node:fs';
-import { join } from 'node:path';
+import { existsSync, readFileSync, realpathSync, statSync } from 'node:fs';
+import { basename, dirname, isAbsolute, join, relative, resolve } from 'node:path';
 
 // 옵트아웃 창은 짧게 — 영구 OFF(38일 화석화·워크트리 6개 전부 비무장)가 이 이슈의 병인이다.
 export const GUARD_OFF_TTL_MS = 30 * 60 * 1000;
@@ -68,6 +68,8 @@ export function currentBranch(root) {
 export function guardState(root, now = Date.now()) {
   if (existsSync(join(root, '.loop', 'looping'))) {
     // 센티넬 = loop-fix 루프의 핫패스(툴콜마다 훅 발화) — git 스폰을 아끼려 브랜치는 조회하지 않는다.
+    // (BAC-785 이후: 대상이 root 밖이면 호출자가 이미 재루팅으로 git을 스폰한 뒤다. 이 절약은 root
+    // 안 편집에서만 온전하다 — 그래도 아끼지 않을 이유는 없다.)
     return { armed: true, mode: 'sentinel', branch: '' };
   }
   const branch = currentBranch(root);
@@ -86,4 +88,115 @@ export function guardState(root, now = Date.now()) {
     }
   }
   return { armed: true, mode: 'branch', branch };
+}
+
+// ── 실효 루트 해석 (BAC-785) ──────────────────────────────────────────────────────────────────────
+// 무장 판정과 glob 매칭의 루트가 세션의 CLAUDE_PROJECT_DIR로 고정돼 있으면, 워크트리 격리 세션에서
+// 그건 메인 워크트리(비보호 브랜치)를 가리킨다 — 즉 이 레포가 규약으로 강제하는 바로 그 작업 방식에서
+// 가드가 한 번도 무장되지 않는다. 그래서 루트를 "무엇을 만지는가"에서 도출한다.
+
+/** 경로가 root 안(자기 자신 포함)인가. root 밖일 때만 재루팅을 시도한다. */
+export function isInsideRoot(root, p) {
+  const rel = relative(root, resolve(p)).split('\\').join('/');
+  return rel === '' || (rel !== '..' && !rel.startsWith('../') && !isAbsolute(rel));
+}
+
+function gitOut(args, cwd) {
+  return execFileSync('git', ['-C', cwd, ...args], {
+    encoding: 'utf8',
+    timeout: 3000,
+    stdio: ['ignore', 'pipe', 'ignore'],
+  });
+}
+
+/**
+ * 저장소 식별자 — 링크드 워크트리끼리는 같은 값이 나온다. 실패는 null.
+ * `--git-common-dir`은 메인 워크트리에서 상대(`.git`), 링크드에서 절대 경로를 낸다. 게다가 macOS의
+ * /var는 /private/var 심링크라 같은 디렉토리가 두 철자를 가진다 — 그래서 호출 cwd 기준으로 resolve한
+ * 뒤 realpath까지 해야 비교가 성립한다(gate-before-merge.mjs가 같은 이유로 같은 정규화를 한다).
+ */
+function repoId(dir) {
+  try {
+    return realpathSync(resolve(dir, gitOut(['rev-parse', '--git-common-dir'], dir).trim()));
+  } catch {
+    return null;
+  }
+}
+
+/** root와 대상 사이(대상 쪽 끝부터)에 `.git` 엔트리를 가진 디렉토리가 있는가 — 중첩 워크트리/레포. */
+function nestedRepoBelow(root, abs) {
+  const top = resolve(root);
+  const rel = relative(top, dirname(abs)).split('\\').join('/');
+  if (!rel || rel === '..' || rel.startsWith('../') || isAbsolute(rel)) return false;
+  const segs = rel.split('/');
+  for (let i = segs.length; i > 0; i--) {
+    if (existsSync(join(top, ...segs.slice(0, i), '.git'))) return true;
+  }
+  return false;
+}
+
+// repoId(root)는 프로세스 수명 동안 불변인데 한 번의 훅 호출에서 최대 두 번 조회된다(대상 시도 +
+// 세션 cwd 폴백). 핫패스라 memoize한다 — undefined = 아직 미조회, null = 조회했고 실패.
+let rootIdCache;
+function rootRepoId(root) {
+  if (rootIdCache === undefined) rootIdCache = repoId(root);
+  return rootIdCache;
+}
+
+/**
+ * 대상 경로가 속한 *root와 같은 저장소의* 워크트리 → `{ top, rel }`. 그 외 전부 null.
+ * null = 재루팅하지 않는다(root 안 · 다른 저장소 · 비-git · 조회 실패). 범위를 같은 저장소로 좁히는
+ * 건 의도다 — 무관한 레포까지 보호하도록 넓히면 스코프 확장이고, 기존 동작(비보호) 유지가 안전하다.
+ */
+export function resolveWorktreeRoot(root, target) {
+  if (!target) return null;
+  const abs = resolve(target);
+  // root 안이라도 그 아래 중첩된 워크트리(`.worktrees/…`)면 별개 브랜치·별개 `.loop`다 — 소비 레포
+  // 규약이 명시 허용하는 배치라 "root 안 = 재루팅 불필요"로 단락시키면 거기서 가드가 통째로 꺼진다.
+  // 판정은 git 스폰 없이 파일시스템만으로 한다: 이 경로는 툴콜마다 도는 핫패스라, 평범한 root 안
+  // 편집에서 git 호출이 늘어나면 안 된다.
+  if (isInsideRoot(root, abs) && !nestedRepoBelow(root, abs)) return null;
+  let dir = abs;
+  let suffix = '';
+  let isDir = false;
+  try {
+    isDir = statSync(abs).isDirectory();
+  } catch {
+    // 미존재 → 파일로 취급(아직 쓰이지 않은 새 파일)
+  }
+  if (!isDir) {
+    dir = dirname(abs);
+    // suffix의 초기값이 basename(abs)라는 게 계약의 일부다. 빼면 존재하는 파일에서 rel이 ''이 되어
+    // 어떤 glob도 매칭되지 않고 — 가장 흔한 케이스만 조용히 뚫린다.
+    suffix = basename(abs);
+  }
+  // 아직 만들어지지 않은 디렉토리 아래의 새 파일: `git -C <미존재 경로>`는 exit 128이다. 존재하는
+  // 최초의 조상까지 올라가며 지나친 구간을 suffix 앞에 붙인다. 보호 대상인 `**/*.test.sh`를 *새
+  // 디렉토리에* 만드는 경로가 정확히 리워드핵 벡터라 여기서 포기하면 안 된다. 상한은 두지 않는다 —
+  // 아래 repoId 동일성 검사가 걸러내므로 위로 새는 재루팅이 원리적으로 불가능하다.
+  while (!existsSync(dir)) {
+    const parent = dirname(dir);
+    if (parent === dir) return null;
+    suffix = suffix ? `${basename(dir)}/${suffix}` : basename(dir);
+    dir = parent;
+  }
+  let top;
+  let prefix;
+  try {
+    // 워크트리 루트에서 `--show-prefix`는 빈 줄이라, `.trim()` 후 split 하면 배열이 1칸이 되어
+    // `lines[1]`이 사라진다. 실질 방어자는 split 순서가 아니라 아래의 `?? ''`다 — 둘 다 두는 건
+    // 값이 undefined인 채 rel에 문자열 연결되는(=조용히 틀린 경로) 사고를 두 겹으로 막기 위해서다.
+    const lines = gitOut(['rev-parse', '--show-toplevel', '--show-prefix'], dir).split('\n');
+    top = (lines[0] ?? '').trim();
+    prefix = (lines[1] ?? '').trim();
+  } catch {
+    return null;
+  }
+  if (!top) return null;
+  const id = repoId(dir);
+  if (id === null || id !== rootRepoId(root)) return null;
+  // rel을 relative()로 만들지 않는 이유: `--show-toplevel`은 물리 경로(/private/var/...)를 내는데
+  // payload의 대상 경로는 심링크 철자(/var/...)일 수 있어 문자열 비교가 깨진다. prefix+suffix는 git이
+  // 직접 계산한 값이라 그 문제가 없다.
+  return { top, rel: `${prefix}${suffix}` };
 }

--- a/tools/loop-engine/test/protect-worktree-root.test.sh
+++ b/tools/loop-engine/test/protect-worktree-root.test.sh
@@ -1,0 +1,229 @@
+#!/usr/bin/env bash
+# Behavioral test for protect-during-loop.mjs's *rooting* (BAC-785).
+#
+# The guard decides "am I armed?" and "does this path match .loop/protect.globs?" against a root.
+# That root used to be CLAUDE_PROJECT_DIR, which in a worktree-isolated session is the MAIN worktree
+# (HEAD = an unprotected branch). Two independent breaks followed:
+#   B1 arming  — guardState(root) saw `develop` and exit(0)'d BEFORE stdin was even parsed, so the
+#                verdict was reached before the target path was known.
+#   B2 matching — relative(root, filePath) produced `../<sibling-worktree>/…`, which the hook then
+#                explicitly let through.
+# Net effect: on the very workflow the consuming repo mandates (one worktree per task), the
+# reward-hack guard was never armed and never matched. This file pins the fix: the effective root is
+# derived from what is being touched — target's worktree, else the session cwd's worktree, else root.
+#
+# The cases do NOT stop at the first failure. Several AC contracts share this one command, so their
+# exit codes DO flip together (fail-closed) — what accumulating buys is diagnosis, not independence:
+# each contract greps for its own `PASS:` line, and a fail-fast `exit 1` on case 1 would erase every
+# later line and leave the log unable to say which invariant actually broke.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+HOOK="$HERE/../hooks/protect-during-loop.mjs"
+# A real file inside the plugin's own install path — the hook protects that path by absolute prefix
+# (code, not a glob), since .loop/protect.globs is repo-relative and can never cover outside the repo.
+PLUGIN_FILE="$HERE/../lib/protect-globs.mjs"
+
+fail() { echo "FAIL: $1"; exit 1; }   # fixture failures only — those make every case meaningless
+[ -f "$HOOK" ] || fail "protect-during-loop.mjs not found at $HOOK"
+[ -f "$PLUGIN_FILE" ] || fail "plugin file not found at $PLUGIN_FILE"
+
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/tmp.XXXXXXXX")" || fail "mktemp -d failed"
+trap 'rm -rf "$WORK"' EXIT
+
+g() { git -c user.email=t@example.com -c user.name=t -C "$@"; }
+
+# ── fixture ───────────────────────────────────────────────────────────────────────────────────────
+# repo = the session root, parked on an unprotected branch (what CLAUDE_PROJECT_DIR points at).
+REPO="$WORK/repo"
+mkdir -p "$REPO/.loop"
+git init -q -b develop "$REPO" || fail "git init failed"
+printf '**/*.test.sh\n.claude/settings.json\n' > "$REPO/.loop/protect.globs"
+echo x > "$REPO/a.test.sh"
+echo x > "$REPO/README.md"
+# Root-anchored glob targets. Without these every case matches via `**/*.test.sh`, which is prefix
+# agnostic — so a re-root that computes the repo-relative path wrongly (an empty or `undefined`
+# prefix) still matches and every case stays green. These two pin `--show-prefix + suffix` itself.
+mkdir -p "$REPO/.claude" "$REPO/pkg/.claude"
+echo '{}' > "$REPO/.claude/settings.json"
+echo '{}' > "$REPO/pkg/.claude/settings.json"
+# protect.globs must be COMMITTED: `git worktree add` only checks out tracked files, so an untracked
+# glob file would leave the linked worktree with no protection at all and fake-green every case.
+g "$REPO" add -A || fail "git add failed"
+g "$REPO" commit -qm init || fail "git commit failed"
+
+# wt = the task worktree on a working branch (where the agent actually edits).
+WT="$WORK/wt"
+g "$REPO" worktree add -q -b feature/x "$WT" || fail "git worktree add failed"
+[ -f "$WT/.loop/protect.globs" ] || fail "fixture: protect.globs missing in the linked worktree"
+
+# A worktree nested INSIDE the root. The consuming repo's convention allows this layout ("an
+# untracked .worktrees/"), and "the target is under root" must not be taken to mean "no re-rooting
+# needed" — it is a different branch with its own .loop.
+NESTED="$REPO/.worktrees/feat"
+g "$REPO" worktree add -q -b feature/nested "$NESTED" || fail "git worktree add (nested) failed"
+
+# A second, unrelated repository — re-rooting must not reach into it.
+OTHER="$WORK/other"
+mkdir -p "$OTHER/.loop"
+git init -q -b feature/y "$OTHER" || fail "git init (other) failed"
+printf '**/*.test.sh\n' > "$OTHER/.loop/protect.globs"
+echo x > "$OTHER/b.test.sh"
+g "$OTHER" add -A && g "$OTHER" commit -qm init || fail "git commit (other) failed"
+
+# A path belonging to no repository at all.
+echo x > "$WORK/loose.test.sh"
+
+# ── runner ────────────────────────────────────────────────────────────────────────────────────────
+FAILURES=()
+
+# run <root> <cwd|""> <tool> <arg>
+run() {
+  node -e '
+    const [tool, arg, cwd] = process.argv.slice(1);
+    const p = {
+      tool_name: tool,
+      tool_input: tool === "Bash" ? { command: arg } : { file_path: arg },
+    };
+    if (cwd) p.cwd = cwd;
+    process.stdout.write(JSON.stringify(p));
+  ' "$3" "$4" "$2" | CLAUDE_PROJECT_DIR="$1" node "$HOOK" 2>>"$WORK/stderr"
+}
+
+# run_from <hook-process-cwd> <root> <tool> <arg> — no `cwd` field in the payload at all, so the
+# hook has to fall back to its own process cwd.
+run_from() {
+  node -e '
+    const [tool, arg] = process.argv.slice(1);
+    process.stdout.write(JSON.stringify({ tool_name: tool, tool_input: { file_path: arg } }));
+  ' "$3" "$4" | (cd "$1" && CLAUDE_PROJECT_DIR="$2" node "$HOOK" 2>>"$WORK/stderr")
+}
+
+# check <desc> <deny|allow> <root> <cwd|""> <tool> <arg>
+check() {
+  local desc="$1" want="$2"
+  shift 2
+  local out got
+  out="$(run "$@")" || { echo "FAILED: $desc — hook exited non-zero (must always exit 0)"; FAILURES+=("$desc"); return; }
+  got=allow
+  printf '%s' "$out" | grep -q '"permissionDecision":"deny"' && got=deny
+  if [ "$got" = "$want" ]; then
+    echo "PASS: $desc"
+  else
+    echo "FAILED: $desc — expected $want, got $got${out:+ | output: $out}"
+    FAILURES+=("$desc")
+  fi
+}
+
+# verdict <desc> <deny|allow> <hook-stdout>
+verdict() {
+  local got=allow
+  printf '%s' "$3" | grep -q '"permissionDecision":"deny"' && got=deny
+  if [ "$got" = "$2" ]; then
+    echo "PASS: $1"
+  else
+    echo "FAILED: $1 — expected $2, got $got"
+    FAILURES+=("$1")
+  fi
+}
+
+# ── 1) the bug: a protected file in a sibling worktree, judged from the session root ──────────────
+check "a protected file in a sibling worktree is denied" deny \
+  "$REPO" "$WT" Edit "$WT/a.test.sh"
+
+# ── 2) the main worktree stays a human QA space — no re-rooting for paths inside the root ─────────
+check "a protected file in the session root stays allowed on develop" allow \
+  "$REPO" "$REPO" Edit "$REPO/a.test.sh"
+
+# ── 3) the escape hatch works, rooted at the worktree being edited ────────────────────────────────
+echo 'BAC-785: legitimate edit' > "$WT/.loop/guard-off"
+check "a guard-off inside the target worktree opens the window" allow \
+  "$REPO" "$WT" Edit "$WT/a.test.sh"
+rm -f "$WT/.loop/guard-off"
+
+# ── 4) …and cannot be borrowed from another worktree ──────────────────────────────────────────────
+echo 'BAC-785: unrelated window' > "$REPO/.loop/guard-off"
+check "a guard-off in the session root does not open a window in the target worktree" deny \
+  "$REPO" "$WT" Edit "$WT/a.test.sh"
+rm -f "$REPO/.loop/guard-off"
+
+# ── 5) a different repository is out of scope — re-rooting is same-repo only ──────────────────────
+check "a protected file in a different repository is not re-rooted" allow \
+  "$REPO" "$WT" Edit "$OTHER/b.test.sh"
+
+# ── 6) the Bash channel is rooted the same way ────────────────────────────────────────────────────
+check "Bash mutation of a protected file with cwd in a sibling worktree is denied" deny \
+  "$REPO" "$WT" Bash "rm -f a.test.sh"
+
+# ── 7) …but only for protected paths ──────────────────────────────────────────────────────────────
+check "a non-protected file in a sibling worktree stays allowed" allow \
+  "$REPO" "$WT" Edit "$WT/README.md"
+
+# ── 8) fail-open preserved for paths in no worktree of this repo ──────────────────────────────────
+check "a path outside every worktree stays allowed" allow \
+  "$REPO" "$WT" Edit "$WORK/loose.test.sh"
+
+# ── 9) a new file under a directory that does not exist yet — the reward-hack vector ──────────────
+# `**/*.test.sh` is protected, so "write a new fake-green test into a fresh directory" must not be
+# the one path that stays open. Resolving the worktree needs an ancestor walk: `git -C <missing dir>`
+# exits 128.
+check "a new file under a not-yet-created directory in a sibling worktree is denied" deny \
+  "$REPO" "$WT" Write "$WT/newdir/n.test.sh"
+
+# ── 10) verifier=ceiling: the plugin's own install path belongs to no worktree, so arming has to
+#        fall back to the session cwd or this self-protection stays off exactly as B1 left it ──────
+check "a plugin-install-path file is denied when the session cwd is a working worktree" deny \
+  "$REPO" "$WT" Edit "$PLUGIN_FILE"
+
+# ── 11) …while a human on the unprotected branch is still not wedged ──────────────────────────────
+check "a plugin-install-path file stays allowed when the session cwd is the unprotected session root" allow \
+  "$REPO" "$REPO" Edit "$PLUGIN_FILE"
+
+# ── control: with the root already pointing at the worktree the guard has always worked. If this
+#    one fails the fixture is broken (globs, branch, payload shape) and the REDs above prove nothing.
+check "(control) a protected file is denied when the session root IS the worktree" deny \
+  "$WT" "$WT" Edit "$WT/a.test.sh"
+
+# ── 13) a worktree nested inside the root is still a separate worktree ────────────────────────────
+check "a protected file in a worktree nested inside the session root is denied" deny \
+  "$REPO" "$NESTED" Edit "$NESTED/a.test.sh"
+
+# ── 14/15) the repo-relative path itself has to be right, not just glob-shaped ────────────────────
+# `.claude/settings.json` is root-anchored: it must match at the worktree top and NOT one level down.
+# An empty prefix would deny 15; an `undefined` prefix would allow 14.
+check "a root-anchored protected path is denied at the worktree top" deny \
+  "$REPO" "$WT" Edit "$WT/.claude/settings.json"
+check "a root-anchored protected path does not match one directory down" allow \
+  "$REPO" "$WT" Edit "$WT/pkg/.claude/settings.json"
+
+# ── 16) positive control for the OTHER repo fixture ───────────────────────────────────────────────
+# Case 5 is the only one that fails when the same-repository restriction is dropped, so its evidence
+# is only worth anything while $OTHER is genuinely armed and genuinely protected. Without this, a
+# silently broken fixture (unprotected branch, missing globs) leaves case 5 green and blind.
+check "(control) the other repository's own guard is armed and protecting" deny \
+  "$OTHER" "$OTHER" Edit "$OTHER/b.test.sh"
+
+# ── 17/18) the process.cwd() fallback, for payloads carrying no cwd field ─────────────────────────
+verdict "a payload with no cwd falls back to the hook's own cwd and denies the plugin path" deny \
+  "$(run_from "$WT" "$REPO" Edit "$PLUGIN_FILE")"
+verdict "a payload with no cwd stays allowed when the hook runs in the unprotected session root" allow \
+  "$(run_from "$REPO" "$REPO" Edit "$PLUGIN_FILE")"
+
+# ── 19) re-rooting must never DISARM ──────────────────────────────────────────────────────────────
+# Session on an armed worktree, cwd pointing back at the unprotected main worktree. Re-rooting there
+# would hand back exactly the escape this whole change removes.
+check "re-rooting to an unprotected branch cannot disarm a session rooted on a working branch" deny \
+  "$WT" "$REPO" Bash "rm -f a.test.sh"
+
+# The hook writes to stderr only on a fail-open path it could not otherwise report. Any output here
+# means one of the allow verdicts above was an internal error wearing a pass's clothes.
+if [ -s "$WORK/stderr" ]; then
+  echo "FAILED: the hook wrote to stderr — a fail-open path was taken: $(head -c 300 "$WORK/stderr")"
+  FAILURES+=("hook stderr non-empty")
+fi
+
+if [ "${#FAILURES[@]}" -gt 0 ]; then
+  echo "FAIL: ${#FAILURES[@]} case(s) failed: ${FAILURES[*]}"
+  exit 1
+fi
+echo "PASS: guard arming and glob matching are rooted at the target's own worktree (19 cases)"
+exit 0


### PR DESCRIPTION
## 무엇이 깨져 있었나

`hooks/protect-during-loop.mjs`는 무장 판정과 glob 매칭을 전부 `root = CLAUDE_PROJECT_DIR ?? cwd()` 기준으로 했다. 워크트리 격리 세션(소비 레포의 규약이 **강제**하는 작업 방식)에서 root는 **메인 워크트리**이고 그건 비보호 브랜치에 파킹돼 있다. 두 개의 독립 파손이 겹쳐 있었다:

- **B1 (무장)** — `guardState(root)`가 `unprotected-branch`를 보고 `process.exit(0)` 한다. 이 판정은 **stdin 파싱보다 앞**이라 *대상 파일이 무엇인지 알기도 전에* 가드가 꺼진다.
- **B2 (매칭)** — 설령 무장돼도 `relative(root, filePath)`가 `../<형제-워크트리>/…`가 되고, 훅이 그걸 **명시적으로 통과**시킨다.

### 실측 증거

소비 레포의 한 작업(BAC-782)에서 `.claude/settings.json` · `tools/loop-memory-config-check.mjs` · `tools/harness-test/fixtures/**` · `**/*.test.sh` · `package.json` 을 전부 편집했다. 다섯 경로 모두 `.loop/protect.globs` 등재 대상이고 `.loop/guard-off`는 존재한 적이 없다. **가드는 한 번도 발화하지 않았다.**

실제 레포 배치(hermetic 픽스처 아님)로 수정 전/후 대조:

```
root=/Users/paul/dev/glucofit-partners (HEAD=develop)
wt  =/Users/paul/dev/glucofit-partners-lessons-audit (HEAD=chore/lessons-harness-audit)
대상=.claude/settings.json

설치본 0.9.0 → (빈 출력 = 조용히 통과)
이 PR        → {"permissionDecision":"deny", ... '.claude/settings.json' matches .loop/protect.globs}
```

> "몇 개의 런이 가드 없이 돌았나"는 **git 히스토리로 답할 수 없다** — 소비 레포의 `.gitignore`가 `.loop/*`를 무시하므로 `git log`의 0건은 증거가 아니고, 원장 파일도 없다. 위 직접 증거가 답할 수 있는 전부다.

## 무엇을 고쳤나

**실효 루트를 "무엇을 만지는가"에서 도출한다**: `대상이 속한 워크트리` → `세션 cwd가 속한 워크트리` → `root`. stdin 파싱이 무장 판정보다 앞으로 왔다.

- 재루팅은 **같은 저장소**일 때만(`--git-common-dir`을 호출 cwd 기준 resolve 후 realpath — 메인 워크트리는 상대(`.git`), 링크드는 절대를 내고 macOS의 `/var`는 `/private/var` 심링크다). 다른 레포는 범위 밖으로 남는다. 이건 새 발명이 아니라 `hooks/gate-before-merge.mjs`가 이미 쓰던 패턴이다.
- **재루팅은 무장을 *해제*하지 못한다.** 재루팅의 존재 이유는 root가 놓친 보호를 찾는 것이지 root가 가진 보호를 빠져나가는 게 아니다.
- **root 안에 중첩된 워크트리**(`.worktrees/…`, 소비 레포 규약이 명시 허용하는 배치)도 별개 워크트리로 센다. **git 스폰 없이 파일시스템만으로** 판정하므로 평범한 root 안 편집의 핫패스 비용은 그대로다.
- **플러그인 자기보호가 이 세션들에서 되살아난다.** 그 절대경로 prefix deny는 무장 검사 *뒤*에 있어 같은 이유로 꺼져 있었다 — 세션 cwd 폴백이 그걸 복구한다.
- `rel`은 대상 기반 재루팅에서만 `--show-prefix + suffix`로 산출한다(git이 직접 계산한 값이라 심링크 철자 문제가 없다). cwd 폴백으로만 루트가 바뀐 상태에서는 `root` 기준을 유지한다 — 형제 워크트리 안에 중첩된 *외부* 레포를 과잉 차단하지 않기 위해서.

## 검증 (전부 그대로 인용)

```
$ bash tools/loop-engine/test/protect-worktree-root.test.sh
PASS: guard arming and glob matching are rooted at the target's own worktree (19 cases)
exit=0

$ bash tools/loop-engine/bin/verdict-run.sh -- bash tools/loop-engine/test/run.sh
VERDICT: PASS
EXIT: 0
SUMMARY: passed=49 failed= skipped= duration_ms=91612

$ bash tools/loop-engine/bin/ac-verify.sh <plan>
VERDICT: PASS
EXIT: 0
SUMMARY: passed=8 failed=0 skipped=0 duration_ms=107092

$ bash tools/loop-engine/bin/verifier-pinned-review.sh --base origin/main
verifier-pinned-review: PASS — the base ('origin/main') tools/loop-engine/test/ suite still passes against this PR's new bin/ code.
```

**RED 먼저**: 신규 테스트를 base(`0a10f4a`) 구현에 얹으면 **1·4·6·9·10 다섯 건이 FAILED**, control은 PASS. 리뷰 에이전트 3종이 각각 독립적으로 격리 클론에서 재현했다.

## 게이트 판정

### Gate verdict — classify-risk (ADR-0061 · 3-tier)

| Field | Value |
|---|---|
| GATE | **DENY_AND_LOG** |
| TRACK | standard |
| FINAL | blast_radius=high reversibility=full cost=low |
| DEEP_GATES | (none) |
| PATHS | 6 |

**REASON**: blast_radius=high — reversible: deny by default, evidence into the PR (no human wait)

<!-- gate-verdict: GATE=DENY_AND_LOG TRACK=standard blast_radius=high reversibility=full cost=low PATHS=6 STAGE=implement BASE=0a10f4af61a1 -->

> 룰 테이블만으로는 AUTO(`app-code-low-risk-baseline`)가 나온다 — 이 레포엔 `risk-rules.json`이 없어 소비 레포의 `harness` 룰이 적용되지 않기 때문이다. 검증기 본체 변경이므로 `blast_radius=high`로 **상향**했다(에이전트 입력은 올리는 방향만 반영된다).

## Decisions taken

- 해석기를 `lib/protect-globs.mjs`(가드의 SSOT lib, 이미 테스트 표면)에 뒀다. 중립 lib 신설이나 `gate-before-merge.mjs` 리팩터는 **하지 않았다** — 그 훅은 정상 동작 중이고 버그 티켓에서 동작하는 머지 게이트를 건드리는 건 순수 리스크다.
- 재루팅을 같은 저장소로 한정했다. 무관한 레포까지 넓히면 스코프 확장이고 현행 동작(비보호) 유지가 안전하다.
- 버전은 **patch(0.9.1)**. 의존 플러그인의 `loop-engine ^0.9.0` 범위가 0.9.1을 포함하므로 `ship-flow`/`loop-memory` 범프는 하지 않았다(CHANGELOG가 기록한 관례상 의존 범프는 minor일 때).
- 문서화된 non-goal 2건: ⑴ Bash에서 `payload.cwd`가 세션 루트인데 토큰이 형제 워크트리를 절대경로로 가리키는 경우는 여전히 통과(기존 대비 회귀 아님 — ADR-0036대로 Bash는 경계가 아니라 가드레일) ⑵ `NotebookEdit`의 `notebook_path`는 현행 훅도 안 본다(선재 미커버).

## 명시적 load-bearing 가정

케이스 10(플러그인 자기보호 복구)은 **`payload.cwd`가 `Edit`/`Write` 호출에도 온다**는 전제 위에 선다. 확정하지 못했다.

- 정황 근거: Claude Code 문서가 `cwd`를 "Common Input Fields"로 분류 · `hooks/record-run-event.mjs`의 `COMMON_FIELDS` · `gate-before-merge.mjs`의 "a field the hook receives on every call".
- 확정 못 한 이유: `record-run-event.mjs`가 PreToolUse에 등록돼 있지 않아 이 레포에 캡처 기록이 없고, 원장은 기록 전에 `cwd`를 제거한다. 헤드리스 `claude -p` 실측은 `Not logged in`으로 막혔다.
- **hermetic 테스트로는 원리적으로 검증 불가** — 테스트가 payload를 자기가 만들어 주입하므로 전제와 무관하게 항상 그린이다(AC 층위의 false-green).
- 완화: `process.cwd()` 폴백(케이스 17·18이 고정). 다만 훅 프로세스의 cwd가 세션 cwd와 같은지도 미확정이라 **완화이지 제거가 아니다**.
- 종단 확인 후속 → #63

## 리뷰 3종

`ship-flow:code-reviewer` BLOCK 2 · `ship-flow:test-hunter` BLOCK 3 · `ship-flow:verifier-integrity-hunter` NON-BLOCKER(리워드핵 0건). 전부 반영했다:

| 지적 | 처리 |
|---|---|
| 실효루트 catch만 로그가 없다 — 형제 catch 2개는 찍는다. 숨기는 실패모드가 **이 티켓의 병인 그 자체** | `console.error` 추가 + 테스트에 stderr 공백 어서션(fail-open 경로 미주행 control) |
| root 안 중첩 워크트리 미커버 (실측 ALLOW) | 파일시스템 판정으로 교체 + 케이스 13 |
| `prefix + suffix` 산출이 무증명 — `rel`이 `"undefineda.test.sh"`가 되는 변형도 12/12 그린이었다 | 루트앵커 glob 케이스 14·15 추가 |
| **Bash 채널에 DENY→ALLOW 회귀** (root=무장 워크트리 + cwd=비보호 형제) | "재루팅은 무장을 해제하지 못한다" 규칙 + 케이스 19 |
| `$OTHER` 픽스처 무검증 → 케이스 5가 조용히 vacuous해질 수 있다 | positive control 케이스 16 |
| `process.cwd()` 폴백 미테스트 | 케이스 17·18 |
| 릴리스 메타데이터 4종 누락 | 0.9.1 범프 3종(의존 범프는 불필요 — 위 Decisions) |
| Bash 중복 `resolveWorktreeRoot` 호출 · `loadPatterns` 무방비 · 부정확한 주석 3곳 | 전부 수정 |

## 범위 밖으로 분리 발행

- **#58** — `ac-verify.sh`의 무조건 `export LOOP_DIR`이 셀프테스트 2건을 깨뜨린다(AC 게이트가 자기 스위트를 그린으로 못 돌림). base 클론에서 재현 확정: `LOOP_DIR` 설정 시 `46/48`, `env -u LOOP_DIR` 복귀 시 `48/48`. 그래서 이 PR의 AC 하나가 `env -u LOOP_DIR` 접두를 쓴다 — 회피가 아니라 선재 결함 격리다.
- **#63** — 위 load-bearing 가정의 프로덕션 종단 확인.
- **BAC-787**(소비 레포) — `loop-doctor`의 GUARD 행이 메인 워크트리만 보고 "정상 ✓"이라 이 구멍에 오히려 안심을 준다. 이 계기판이 두 달간 매 세션 ✓를 찍고 있었다.

## 머지 시 주의

`#60`이 loop-engine 0.10.0을 들고 있다. 그게 먼저 착지하면 이 PR은 **0.10.1로 리베이스**해야 한다(`plugin.json` · `marketplace.json` · CHANGELOG 헤딩).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0121ZfwmNhWbRqogYzEDYx7H
