### PR TITLE
ci: tag `<plugin>--v<semver>` on publish, deriving the list from the manifest (0.10.2)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "loop-engine",
       "source": "./tools/loop-engine",
       "description": "Core loop mechanics: verdict-run (machine-readable PASS/FAIL contract), loop-fix (closed verify->fix loop), lessons (verified-fix memory), classify-risk, require-tests, plugin-path (resolve sibling plugin install paths), check-docs-hygiene/check-pr-hygiene/check-module-size (repo hygiene gates). No framework opinions beyond \"the verifier is the ceiling, never the agent's self-report\".",
-      "version": "0.10.1",
+      "version": "0.10.2",
       "keywords": ["verifier", "tdd", "loop", "verdict", "lessons"]
     },
     {

--- a/.github/workflows/tag-on-publish.yml
+++ b/.github/workflows/tag-on-publish.yml
@@ -1,0 +1,91 @@
+name: tag on publish
+
+# Publishes `<plugin>--v<semver>` for every plugin whose current version has no tag yet.
+#
+# Why this exists: tagging was a manual step, and manual steps stop happening silently. By the time
+# it was noticed, all three plugins were several releases past their newest tag (loop-engine
+# 0.10.1 vs loop-engine--v0.8.0, ship-flow 0.5.0 vs ship-flow--v0.2.9, loop-memory 0.4.1 vs
+# loop-memory--v0.2.6). Nothing was broken-looking: `plugin.json` said the new version, the
+# marketplace served it, and CI was green — the tag was simply the one artifact nobody's gate looked
+# at. A consuming repo that pins by tag (this marketplace's documented channel — ADR-0078 addendum
+# #2, "explicit semver, not a SHA channel") then cannot express the version it needs, and falls back
+# to pinning a commit, which is exactly the SHA channel that addendum rules out.
+#
+# This does NOT make consumers auto-follow anything. It only makes an already-published version
+# addressable by its own number. Choosing which version to pin stays a deliberate human edit in the
+# consuming repo.
+#
+# The plugin list is DERIVED from `.claude-plugin/marketplace.json`, never hardcoded here — a
+# hardcoded list is the same failure one level down: add a fourth plugin, forget this file, and its
+# releases go untagged just as silently. `tag-on-publish-derives-plugins.test.sh` locks that.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch: # backfill: re-run against main to tag whatever is currently missing
+
+# Least privilege: this job writes tags and nothing else.
+permissions:
+  contents: write
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # tags are needed to know which ones already exist
+
+      - name: create missing version tags
+        env:
+          SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          # name+version straight from each plugin's own manifest. marketplace.json supplies the
+          # LIST (its `source` paths); plugin.json supplies the VERSION, because that is the one
+          # `calculatePluginVersion` honours at install time — tagging the marketplace entry's copy
+          # would tag a number that may not be what actually installs. `claude plugin validate
+          # --strict` already fails the PR when the two disagree, so this reads the authoritative one.
+          # A plain `while read` rather than `mapfile`: this body is also exercised by
+          # `tag-on-publish-derives-plugins.test.sh`, which runs on developer machines where
+          # /bin/bash is still 3.2 and has no `mapfile`.
+          sources=$(python3 -c '
+          import json
+          for p in json.load(open(".claude-plugin/marketplace.json"))["plugins"]:
+              print(p["source"])
+          ')
+
+          [ -n "$sources" ] || { echo "::error::no plugins found in marketplace.json"; exit 1; }
+
+          created=0
+          while IFS= read -r src; do
+            [ -n "$src" ] || continue
+            manifest="${src#./}/.claude-plugin/plugin.json"
+            if [ ! -f "$manifest" ]; then
+              echo "::error::marketplace.json lists $src but $manifest does not exist"
+              exit 1
+            fi
+            name=$(python3 -c "import json;print(json.load(open('$manifest'))['name'])")
+            version=$(python3 -c "import json;print(json.load(open('$manifest'))['version'])")
+            tag="${name}--v${version}"
+
+            if git rev-parse -q --verify "refs/tags/${tag}" >/dev/null; then
+              echo "· ${tag} already exists"
+              continue
+            fi
+            echo "+ ${tag} -> ${SHA}"
+            git tag "$tag" "$SHA"
+            created=$((created + 1))
+          # Herestring, not a pipe: a pipe would run the loop in a subshell, where `created` and any
+          # `exit 1` above would be discarded — the loop would look like it ran and found nothing.
+          done <<< "$sources"
+
+          if [ "$created" -eq 0 ]; then
+            echo "nothing to tag — every plugin's current version is already published"
+            exit 0
+          fi
+          # One push for all new tags. Never --force: an existing tag is left exactly as it was
+          # (the `rev-parse` skip above), so a released version can't be silently repointed.
+          git push origin --tags
+          echo "created ${created} tag(s)"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,40 @@ Explicit-version channel — see [README § Development status](README.md#develo
 not a SHA channel. Entries below `## loop-engine 0.2.0` and earlier predate the multi-plugin split
 and refer to `loop-engine` only (see the un-prefixed version numbers).
 
+## loop-engine 0.10.2
+
+Release tagging is no longer a manual step.
+
+- **New `.github/workflows/tag-on-publish.yml` publishes `<plugin>--v<semver>` on every push to
+  `main`** for any plugin whose current version has no tag yet. Tagging had been manual, and manual
+  steps stop happening silently: by the time anyone looked, all three plugins were several releases
+  past their newest tag — `loop-engine 0.10.1` vs `loop-engine--v0.8.0`, `ship-flow 0.5.0` vs
+  `ship-flow--v0.2.9`, `loop-memory 0.4.1` vs `loop-memory--v0.2.6`. Nothing looked broken:
+  `plugin.json` carried the new number, the marketplace served it, CI was green. The tag was simply
+  the one artifact no gate examined.
+
+  The cost landed on consumers. This marketplace's documented channel is explicit semver, not SHAs
+  (ADR-0078 addendum #2), but a repo that pins by tag cannot name a version that was never tagged —
+  so glucofit-partners' CI ended up pinning a raw commit for all three plugins, which is precisely
+  the SHA channel that addendum rules out. Tagging on publish restores the option.
+
+  This does not make consumers auto-follow anything; it only makes an already-published version
+  addressable. `workflow_dispatch` is wired so the backlog can be filled by re-running against
+  `main`, and an existing tag is skipped rather than moved — a released version can never be
+  silently repointed.
+- **`tag-on-publish-derives-plugins.test.sh`** (suite 54 → 55) runs the workflow's actual shell body
+  against a sandbox repo of four fake plugins, none named like the real ones. The property under test
+  is not "the workflow mentions three names" but "the workflow finds whatever the manifest lists" — a
+  hardcoded list inside the workflow would be the same failure one level down, where adding a fourth
+  plugin leaves it untagged with everything still green. Also covers: a published tag is skipped and
+  not rewritten, a second run on the same commit is a clean no-op rather than a push error (`main`
+  gets many pushes between releases, and a workflow that errors on "nothing to do" gets switched
+  off), and a manifest entry pointing at a missing directory fails loudly instead of being skipped.
+
+  The version bump is for the test file alone — no runtime behaviour changed. It exists because
+  `tools/loop-engine/` ships as the plugin's source, so its content must not change under a version
+  number that has already been handed out.
+
 ## loop-engine 0.10.1
 
 The reward-hack guard was structurally never armed in the workflow its consuming repo mandates.

--- a/tools/loop-engine/.claude-plugin/plugin.json
+++ b/tools/loop-engine/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "loop-engine",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "Core loop mechanics: verdict-run (machine-readable PASS/FAIL contract), loop-fix (closed verify->fix loop), lessons (verified-fix memory), classify-risk, require-tests, check-docs-hygiene/check-pr-hygiene/check-module-size (repo hygiene gates). verifier=ceiling — the agent's self-judgement never substitutes for it.",
   "author": {
     "name": "paulkim-lansik"

--- a/tools/loop-engine/test/tag-on-publish-derives-plugins.test.sh
+++ b/tools/loop-engine/test/tag-on-publish-derives-plugins.test.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# Locks `.github/workflows/tag-on-publish.yml`: it must tag EVERY plugin the marketplace lists, by
+# deriving the list at run time rather than carrying its own copy of it.
+#
+# Why: the workflow exists because a manual step stopped happening silently. A hardcoded plugin list
+# inside it reintroduces the same failure one level down — add a fourth plugin, forget to edit this
+# workflow, and that plugin's releases go untagged with everything still green. So the property under
+# test is not "the workflow mentions three names", it is "the workflow finds whatever is in the
+# manifest".
+#
+# This runs the workflow's actual shell body against a sandbox repo rather than grepping it. Grep
+# would pass on a workflow that reads the manifest and then ignores it.
+set -uo pipefail
+# `$0`, not `$BASH_SOURCE`: run.sh executes each test as `bash -c "$content" "$t"`.
+ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+WF="$ROOT/.github/workflows/tag-on-publish.yml"
+
+fail() { echo "FAIL: $1"; exit 1; }
+
+[ -f "$WF" ] || fail "tag-on-publish.yml is missing — published versions go untagged again"
+
+grep -q 'permissions:' "$WF" || fail "workflow declares no permissions block — it would inherit the default token scope while pushing tags"
+grep -q 'contents: write' "$WF" || fail "workflow cannot push tags without contents: write"
+
+# Extract the tagging step's shell body: everything indented under its `run: |`, dedented.
+SCRIPT="$(awk '
+  /^      - name: create missing version tags$/ { step = 1 }
+  step && /^        run: \|$/ { body = 1; next }
+  body {
+    if ($0 !~ /^          / && $0 !~ /^[[:space:]]*$/) exit
+    sub(/^          /, "")
+    print
+  }
+' "$WF")"
+
+# A silently-empty extraction would make every assertion below vacuous — the exact failure mode this
+# suite exists to prevent. Require it to have found real content.
+case "$SCRIPT" in
+  *'git tag'*) : ;;
+  *) fail "could not extract the tagging step's shell body from $WF (the step name or its indentation changed) — the assertions below would have passed vacuously" ;;
+esac
+
+# Comment-stripped, so a comment *explaining* why force is avoided doesn't read as force being used.
+if printf '%s\n' "$SCRIPT" | sed 's/[[:space:]]*#.*$//' | grep -qE 'push[^|]*--force|git tag[[:space:]]+-[a-zA-Z]*f'; then
+  fail "the tagging step force-updates tags — a published version could be silently repointed at a different commit"
+fi
+
+SANDBOX="$(mktemp -d)" || fail "mktemp -d failed — cannot build the hermetic sandbox"
+trap 'rm -rf "$SANDBOX"' EXIT
+
+# A fake marketplace with FOUR plugins, deliberately none of them named like the real ones. A
+# workflow carrying a hardcoded list of the real names tags nothing here and fails the count below.
+mkdir -p "$SANDBOX/repo" && cd "$SANDBOX/repo"
+mkdir -p .claude-plugin
+cat > .claude-plugin/marketplace.json <<'JSON'
+{ "name": "sandbox", "owner": { "name": "t" }, "plugins": [
+  { "name": "alpha", "source": "./tools/alpha", "description": "d", "version": "1.0.0" },
+  { "name": "beta",  "source": "./tools/beta",  "description": "d", "version": "2.3.4" },
+  { "name": "gamma", "source": "./tools/gamma", "description": "d", "version": "0.1.0" },
+  { "name": "delta", "source": "./tools/delta", "description": "d", "version": "9.9.9" }
+] }
+JSON
+for p in alpha:1.0.0 beta:2.3.4 gamma:0.1.0 delta:9.9.9; do
+  n="${p%%:*}"; v="${p##*:}"
+  mkdir -p "tools/$n/.claude-plugin"
+  printf '{ "name": "%s", "version": "%s" }\n' "$n" "$v" > "tools/$n/.claude-plugin/plugin.json"
+done
+
+git init -q . && git add -A
+git -c user.email=t@t -c user.name=t commit -q -m init
+# A bare remote so the workflow's `git push origin --tags` has somewhere real to go.
+git init -q --bare "$SANDBOX/remote.git"
+git remote add origin "$SANDBOX/remote.git"
+git push -q origin HEAD:refs/heads/main
+
+# One version is already published — the workflow must leave it alone, not re-tag or fail.
+git tag 'beta--v2.3.4'
+git push -q origin 'beta--v2.3.4'
+
+SHA="$(git rev-parse HEAD)"
+OUT="$(SHA="$SHA" bash -c "$SCRIPT" 2>&1)" || fail "the workflow's tagging step exited non-zero in the sandbox:
+$OUT"
+
+for expect in 'alpha--v1.0.0' 'gamma--v0.1.0' 'delta--v9.9.9'; do
+  git -C "$SANDBOX/remote.git" rev-parse -q --verify "refs/tags/$expect" >/dev/null \
+    || fail "workflow did not publish $expect — it is not deriving the plugin list from marketplace.json (a hardcoded list would miss exactly these). Output:
+$OUT"
+done
+
+# The pre-existing tag must still point where it did: skipped, never rewritten.
+[ "$(git -C "$SANDBOX/remote.git" rev-parse 'beta--v2.3.4')" = "$SHA" ] \
+  || fail "workflow moved an already-published tag"
+
+# Idempotence: a second run on the same commit must be a clean no-op, not a push failure. `main`
+# gets many pushes between releases, and a workflow that errors on "nothing to do" is a workflow
+# people switch off.
+OUT2="$(SHA="$SHA" bash -c "$SCRIPT" 2>&1)" || fail "re-running on an already-tagged commit failed:
+$OUT2"
+case "$OUT2" in
+  *'nothing to tag'*) : ;;
+  *) fail "second run did not report a no-op — got: $OUT2" ;;
+esac
+
+# A manifest listing a plugin whose directory is gone must be a loud error, not a silent skip.
+python3 - <<'PY'
+import json
+p = '.claude-plugin/marketplace.json'
+d = json.load(open(p))
+d['plugins'].append({"name": "ghost", "source": "./tools/ghost", "description": "d", "version": "1.0.0"})
+json.dump(d, open(p, 'w'))
+PY
+if SHA="$SHA" bash -c "$SCRIPT" >/dev/null 2>&1; then
+  fail "a marketplace entry pointing at a missing plugin directory was skipped silently — that is how a plugin stops being tagged without anyone noticing"
+fi
+
+echo "PASS: tag-on-publish derives its plugin list from the manifest, skips published versions without rewriting them, no-ops cleanly, and fails loudly on a missing plugin dir"


### PR DESCRIPTION
## 문제

태그 발행이 **수동**이었고, 수동 단계는 조용히 멈춘다. 확인해보니 셋 다 최신 태그에서 여러 릴리스 밀려 있었어:

| 플러그인 | `plugin.json` | 최신 태그 |
|---|---|---|
| loop-engine | 0.10.1 | `loop-engine--v0.8.0` |
| ship-flow | 0.5.0 | `ship-flow--v0.2.9` |
| loop-memory | 0.4.1 | `loop-memory--v0.2.6` |

**아무것도 고장 나 보이지 않았다는 게 핵심이다.** `plugin.json`은 새 번호를 들고 있고, 마켓플레이스는 그걸 서빙하고, CI는 그린이었다. 태그는 단지 **어떤 게이트도 보지 않는 유일한 산출물**이었을 뿐이다.

비용은 소비 레포가 치렀다. 이 마켓플레이스의 문서화된 채널은 SHA가 아니라 명시 semver인데(ADR-0078 addendum #2), **발행된 적 없는 태그는 핀할 수가 없다** — 그래서 glucofit-partners CI가 세 플러그인 전부를 raw 커밋으로 핀하게 됐다. 그 addendum이 배제하기로 한 바로 그 SHA 채널이다.

## 변경

**`.github/workflows/tag-on-publish.yml`** — `main` push마다(+ `workflow_dispatch`) 태그 없는 현재 버전에 `<plugin>--v<semver>`를 발행.

- 플러그인 목록은 `marketplace.json`에서 **파생**한다(하드코딩 아님)
- 버전은 각 `plugin.json`에서 읽는다 — 설치 시 `calculatePluginVersion`이 존중하는 게 그쪽이라, 마켓플레이스 엔트리를 읽으면 실제 설치되지 않는 번호를 태깅할 수 있다
- 이미 있는 태그는 **건너뛴다**(이동 아님). force-push 없음 — 발행된 버전이 조용히 다른 커밋을 가리키는 일이 불가능
- 소비자 자동추종을 만드는 게 아니다. 이미 발행된 버전을 **번호로 부를 수 있게** 할 뿐

**`tag-on-publish-derives-plugins.test.sh`** (스위트 54 → 55) — 워크플로의 **실제 셸 본문을 추출해** 가짜 플러그인 4개짜리 샌드박스 레포에 실행한다. 이름은 일부러 실제 셋과 전혀 다르게 뒀다.

검사하는 속성은 "워크플로가 세 이름을 언급하는가"가 아니라 **"매니페스트에 있는 걸 찾아내는가"**다 — 워크플로 안의 하드코딩 목록은 같은 실패를 한 단계 아래로 옮긴 것뿐이라(네 번째 플러그인을 추가하고 이 파일을 잊으면 그 플러그인만 조용히 태깅 누락) grep 기반 테스트로는 못 잡는다.

추가로: 이미 발행된 태그 미변경 · 같은 커밋 재실행 시 깨끗한 no-op(`main`은 릴리스 사이에 push가 많고, "할 일 없음"에 에러 내는 워크플로는 결국 꺼진다) · 매니페스트가 없는 디렉터리를 가리키면 조용한 skip이 아니라 **loud error**.

## 검증

- `loop-engine selftest 55/55` · `claude plugin validate --strict` 통과
- **위조 2건 확인** — 목록 하드코딩 → RED, force-push 도입 → RED. 복구 후 PASS
- 개발 중 실제로 걸러진 것: `mapfile`은 bash 4+ 전용이라 macOS(3.2)에서 죽는다. 테스트가 로컬에서 잡아줘서 herestring + `while read`로 교체 (파이프면 서브셸이라 `created`/`exit 1`이 버려진다는 점도 주석으로 못박음)

## 버전

0.10.1 → **0.10.2**. 런타임 동작 변화는 없고 **테스트 파일 때문**이다 — `tools/loop-engine/`가 플러그인 소스로 배포되니, 이미 배포된 버전 번호 아래에서 내용이 바뀌면 안 된다.

## 머지 후

이 워크플로가 첫 실행에서 현재 세 버전(`loop-engine--v0.10.2` · `ship-flow--v0.5.0` · `loop-memory--v0.4.1`)을 자동 발행한다. 그다음 glucofit-partners의 `.github/actions/setup-loop-engine/action.yml`을 커밋 핀 → 태그 핀으로 되돌릴 수 있다(BAC-792 후속 과제).

과거 버전 태그(loop-engine 0.9.0 등)는 **소급 발행하지 않는다** — 어느 커밋이 어느 버전을 도입했는지 사후에 맞히는 건 틀릴 여지가 있고, 지금 아무도 그 버전을 핀하고 있지 않다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VNR8Xbi414uHHzUFzmmMDp