### PR TITLE
fix(loop-engine): "run as main" 가드가 공백 경로에서 조용히 무동작 (0.10.3)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "loop-engine",
       "source": "./tools/loop-engine",
       "description": "Core loop mechanics: verdict-run (machine-readable PASS/FAIL contract), loop-fix (closed verify->fix loop), lessons (verified-fix memory), classify-risk, require-tests, plugin-path (resolve sibling plugin install paths), check-docs-hygiene/check-pr-hygiene/check-module-size (repo hygiene gates). No framework opinions beyond \"the verifier is the ceiling, never the agent's self-report\".",
-      "version": "0.10.2",
+      "version": "0.10.3",
       "keywords": ["verifier", "tdd", "loop", "verdict", "lessons"]
     },
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,34 @@ Explicit-version channel — see [README § Development status](README.md#develo
 not a SHA channel. Entries below `## loop-engine 0.2.0` and earlier predate the multi-plugin split
 and refer to `loop-engine` only (see the un-prefixed version numbers).
 
+## loop-engine 0.10.3
+
+A "run as main" guard that silently stopped guarding.
+
+- **Two `bin/` gates did nothing at all when the checkout path contained a space.**
+  `check-module-size.mjs` and `check-pr-hygiene.mjs` detected direct execution with
+  ``import.meta.url === `file://${process.argv[1]}` ``. `import.meta.url` is percent-encoded
+  (spaces and non-ASCII become `%XX`); `process.argv[1]` is a raw OS path. On any checkout whose path
+  contains either, the two never match, the CLI block below never runs, and the script **exits 0
+  having printed nothing** — which `verdict` / `require-tests.sh` / CI read as the gate passing.
+  Measured: the same `check-module-size.mjs` file prints `PASS: module-size ratchet — 위반 없음` from
+  a normal path and produces **zero output, exit 0** from `a dir with spaces`. The module-size ratchet
+  simply ceases to exist there.
+
+  `plugin-path.mjs` had already fixed this (its comment says "BAC-699 review, ported") and
+  `lib/sanitize.mjs` carried the guard too — the port just never reached these two. All four now use
+  the single idiom.
+- **The idiom now also guards `process.argv[1]` being absent.** `pathToFileURL(undefined)` throws, so
+  under `node -e`, a worker, or an ESM loader hook, merely *importing* one of these modules killed the
+  caller. A resolver and a gate must be loadable from any context; `lib/sanitize.mjs` already did this,
+  the other three did not.
+- **`main-detection-guard.test.sh`** (suite 55 → 56) locks it from both sides. Text: every
+  `import.meta.url ===` site in the plugin must use `pathToFileURL` *and* the `process.argv[1] &&`
+  guard, and finding zero sites is a failure rather than a pass — otherwise the check goes vacuous the
+  moment files move. Behaviour: copy a bin into a directory whose name contains spaces, run it, and
+  require non-empty output, with a no-spaces control so "both silent" cannot masquerade as success;
+  plus an import-under-`node -e` probe for all four modules.
+
 ## loop-engine 0.10.2
 
 Release tagging is no longer a manual step.

--- a/tools/loop-engine/.claude-plugin/plugin.json
+++ b/tools/loop-engine/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "loop-engine",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "description": "Core loop mechanics: verdict-run (machine-readable PASS/FAIL contract), loop-fix (closed verify->fix loop), lessons (verified-fix memory), classify-risk, require-tests, check-docs-hygiene/check-pr-hygiene/check-module-size (repo hygiene gates). verifier=ceiling — the agent's self-judgement never substitutes for it.",
   "author": {
     "name": "paulkim-lansik"

--- a/tools/loop-engine/bin/check-module-size.mjs
+++ b/tools/loop-engine/bin/check-module-size.mjs
@@ -19,6 +19,7 @@
 import { execFileSync } from 'node:child_process';
 import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { join, relative, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
 
 const DEFAULT_BASELINE_REL = 'tools/module-size-baseline.json';
 const SKIP_DIRS = new Set([
@@ -246,6 +247,12 @@ function main() {
   process.exit(ok ? 0 : 1);
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+// `import.meta.url`은 percent-encoding된다(공백·비ASCII → %XX). `file://${process.argv[1]}`는 raw
+// OS 경로라, 체크아웃 경로에 공백이나 한글이 하나라도 있으면 두 문자열이 조용히 어긋나 아래 CLI
+// 블록이 통째로 실행되지 않는다 — 출력 0줄에 exit 0이라, 호출자는 "게이트 통과"로 읽는다(실측:
+// 같은 파일을 공백 있는 경로에 두면 출력이 사라진다). pathToFileURL()이 argv[1]을 같은 방식으로
+// 정규화한다. 앞의 `process.argv[1] &&`는 argv[1]이 없는 맥락(`node -e`, 워커)에서 pathToFileURL이
+// 던지지 않게 한다 — 리졸버/게이트는 어떤 맥락에서도 import만으로 죽으면 안 된다. (BAC-699 → BAC-792)
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   main();
 }

--- a/tools/loop-engine/bin/check-pr-hygiene.mjs
+++ b/tools/loop-engine/bin/check-pr-hygiene.mjs
@@ -33,6 +33,7 @@
 // Exit 0 = 참조 있음(+ 리뷰어 지정 시 전원 커버). Exit 1 = 하나라도 미달. --json으로 기계가독 결과.
 
 import { readFileSync } from 'node:fs';
+import { pathToFileURL } from 'node:url';
 
 // case-insensitive — 목적은 "참조가 존재하는가"이지 표기 규칙 검사가 아니다.
 const DEFAULT_REF_PATTERN = /\b[A-Z]{2,}-\d+\b/i;
@@ -158,6 +159,12 @@ function main() {
   process.exit(result.ok ? 0 : 1);
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+// `import.meta.url`은 percent-encoding된다(공백·비ASCII → %XX). `file://${process.argv[1]}`는 raw
+// OS 경로라, 체크아웃 경로에 공백이나 한글이 하나라도 있으면 두 문자열이 조용히 어긋나 아래 CLI
+// 블록이 통째로 실행되지 않는다 — 출력 0줄에 exit 0이라, 호출자는 "게이트 통과"로 읽는다(실측:
+// 같은 파일을 공백 있는 경로에 두면 출력이 사라진다). pathToFileURL()이 argv[1]을 같은 방식으로
+// 정규화한다. 앞의 `process.argv[1] &&`는 argv[1]이 없는 맥락(`node -e`, 워커)에서 pathToFileURL이
+// 던지지 않게 한다 — 리졸버/게이트는 어떤 맥락에서도 import만으로 죽으면 안 된다. (BAC-699 → BAC-792)
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   main();
 }

--- a/tools/loop-engine/bin/plugin-path.mjs
+++ b/tools/loop-engine/bin/plugin-path.mjs
@@ -97,8 +97,9 @@ function fail(plugin) {
 // Comparing them as strings silently mismatches on a checkout path containing either — the CLI
 // block below then never runs, and this script exits 0 having done nothing (a caller like
 // `pnpm verdict`/require-tests.sh would read that as success). pathToFileURL() normalizes argv[1]
-// the same way before comparing (BAC-699 review, ported).
-if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+// the same way before comparing (BAC-699 review, ported). 앞의 `process.argv[1] &&`는 argv[1]이
+// 없는 맥락(`node -e`, 워커)에서 pathToFileURL이 던지지 않게 한다 (BAC-792).
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   const [cmd, ...rest] = process.argv.slice(2);
   if (cmd === 'resolve') {
     const plugin = rest[0] || DEFAULT_PLUGIN;

--- a/tools/loop-engine/test/main-detection-guard.test.sh
+++ b/tools/loop-engine/test/main-detection-guard.test.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# BAC-792 — "이 파일이 직접 실행됐나?" 판정 관용구가 조용히 틀리는 걸 막는다.
+#
+# 관용구는 하나뿐이어야 한다:
+#     if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) { … }
+#
+# 왜 `file://${process.argv[1]}`가 아닌가 (실측, 이 회차):
+#   `import.meta.url`은 percent-encoding된다(공백·비ASCII → %XX). 템플릿 문자열은 raw OS 경로를 넣어
+#   두 값이 어긋난다. 그러면 CLI 블록이 통째로 실행되지 않고 **출력 0줄에 exit 0**이 된다 — 호출자
+#   (verdict / require-tests.sh / CI)는 그걸 "게이트 통과"로 읽는다. 같은 파일을 공백 있는 디렉터리에
+#   두면 `check-module-size.mjs`가 `PASS: …` 한 줄조차 없이 exit 0으로 끝났다. 래칫이 조용히 없어진다.
+#
+# 왜 앞의 `process.argv[1] &&`인가:
+#   argv[1]이 없는 맥락(`node -e`, 워커, ESM 로더)에서 pathToFileURL(undefined)는 던진다. 게이트와
+#   리졸버는 어떤 맥락에서도 **import만으로 죽으면 안 된다**.
+#
+# 이 테스트는 텍스트 검사와 행위 검사를 둘 다 한다. 텍스트만 보면 관용구를 지키면서 다르게 깨진
+# 구현을 놓치고, 행위만 보면 공백 없는 CI 경로에서 늘 통과해 애초에 이 버그를 못 잡는다.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ENGINE="$(cd "$HERE/.." && pwd)"
+
+fail() { echo "FAIL: $1"; exit 1; }
+
+# ── A. 텍스트: 관용구를 쓰는 모든 .mjs가 가드와 pathToFileURL을 함께 쓴다 ────────────────────
+found=0
+while IFS= read -r hit; do
+  [ -n "$hit" ] || continue
+  found=$((found + 1))
+  file="${hit%%:*}"
+  line="${hit#*:}"; line="${line#*:}"
+  case "$line" in
+    *'`file://${process.argv[1]}`'*)
+      fail "$file: main 감지에 템플릿 문자열을 쓴다 — 경로에 공백/비ASCII가 있으면 CLI 블록이 조용히 안 돌고 exit 0이 된다. pathToFileURL(process.argv[1]).href 로 바꿀 것" ;;
+  esac
+  case "$line" in
+    *'process.argv[1] &&'*) : ;;
+    *) fail "$file: main 감지에 argv[1] 가드가 없다 — argv[1]이 없는 맥락(node -e, 워커)에서 import만으로 던진다" ;;
+  esac
+  case "$line" in
+    *'pathToFileURL(process.argv[1]).href'*) : ;;
+    *) fail "$file: main 감지가 pathToFileURL로 정규화하지 않는다" ;;
+  esac
+done < <(grep -rn 'import\.meta\.url ===' "$ENGINE" --include='*.mjs' 2>/dev/null || true)
+
+# 하나도 못 찾았다면 grep이 실패한 것이지 "전부 통과"가 아니다. 이 구분이 없으면 이 테스트는
+# 파일 배치가 바뀌는 순간 조용히 아무것도 검사하지 않게 된다.
+[ "$found" -ge 1 ] || fail "main 감지 관용구를 하나도 찾지 못했다 — grep 대상($ENGINE)이 바뀌었는지 확인할 것. 검사가 vacuous해졌다"
+
+# ── B. 행위: 공백 있는 경로에서 실제로 CLI 블록이 도는가 ────────────────────────────────────
+SANDBOX="$(mktemp -d)" || fail "mktemp -d failed"
+trap 'rm -rf "$SANDBOX"' EXIT
+SPACED="$SANDBOX/a dir with spaces"
+mkdir -p "$SPACED" || fail "cannot create spaced dir"
+
+# 자기 완결적(상대 import 없음)이라 복사만으로 도는 bin만 고른다.
+BIN="$ENGINE/bin/check-module-size.mjs"
+[ -f "$BIN" ] || fail "check-module-size.mjs not found at $BIN"
+cp "$BIN" "$SPACED/" || fail "copy failed"
+
+OUT="$(cd "$SPACED" && node "./check-module-size.mjs" 2>&1)"
+if [ -z "$OUT" ]; then
+  fail "공백 있는 경로에서 실행했더니 출력이 0줄이다 — CLI 블록이 안 돌았고 exit 0만 남았다. 호출자는 이걸 '게이트 통과'로 읽는다"
+fi
+
+# 대조군: 공백 없는 경로에서도 같은 종류의 출력이 나와야 한다(둘 다 조용하면 위 검사가 무의미).
+PLAIN="$SANDBOX/plain"
+mkdir -p "$PLAIN" && cp "$BIN" "$PLAIN/"
+OUT2="$(cd "$PLAIN" && node "./check-module-size.mjs" 2>&1)"
+[ -n "$OUT2" ] || fail "공백 없는 경로에서도 출력이 없다 — 대조군이 성립하지 않아 B가 아무것도 증명하지 못한다"
+
+# ── C. import만으로 죽지 않는가 (argv[1]이 없는 맥락) ───────────────────────────────────────
+for m in bin/check-module-size.mjs bin/check-pr-hygiene.mjs bin/plugin-path.mjs lib/sanitize.mjs; do
+  [ -f "$ENGINE/$m" ] || continue
+  node -e "import('$ENGINE/$m').then(()=>process.exit(0)).catch((e)=>{console.error(e.message);process.exit(1)})" >/dev/null 2>&1 \
+    || fail "$m: argv[1]이 없는 맥락에서 import만으로 죽는다 — 게이트/리졸버는 어떤 맥락에서도 로드 가능해야 한다"
+done
+
+echo "PASS: main-detection guard — ${found}개 관용구 전부 pathToFileURL+argv[1] 가드, 공백 경로에서 CLI 실제 실행, argv[1] 없는 맥락에서 import 안전"


### PR DESCRIPTION
## 무엇이 문제였나

`check-module-size.mjs`와 `check-pr-hygiene.mjs`가 직접 실행 감지에 템플릿 문자열을 썼다:

```js
if (import.meta.url === `file://${process.argv[1]}`) {
```

`import.meta.url`은 percent-encoding된다(공백·비ASCII → `%XX`). `process.argv[1]`은 raw OS 경로다. **체크아웃 경로에 둘 중 하나라도 있으면 두 값이 영원히 어긋나고**, 아래 CLI 블록이 통째로 실행되지 않는다 — **출력 0줄에 exit 0.** `verdict` / `require-tests.sh` / CI는 그걸 게이트 통과로 읽는다.

실측 (같은 파일, 경로만 다름):

| 경로 | 출력 | exit |
|---|---|---|
| 일반 | `PASS: module-size ratchet — 위반 없음` | 0 |
| `a dir with spaces` | **(0줄)** | 0 |

그 체크아웃에서는 module-size 래칫이 **그냥 존재하지 않는다.** 아무 에러도 없이.

**이건 이미 한 번 고쳐진 버그다.** `plugin-path.mjs`에는 이 함정을 설명하는 긴 주석이 달려 있고(`BAC-699 review, ported`), `lib/sanitize.mjs`도 가드를 갖고 있었다. 이식이 이 둘에만 안 닿았을 뿐이다 — 그리고 닿지 않은 걸 아무것도 검사하지 않았다.

## 변경

넷 모두 단일 관용구로 통일:

```js
if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
```

앞의 `process.argv[1] &&`는 별개 문제를 막는다. `pathToFileURL(undefined)`는 던지므로, argv[1]이 없는 맥락(`node -e`, 워커, ESM 로더)에서는 **import만으로 호출자가 죽었다.** 리졸버와 게이트는 어떤 맥락에서도 로드 가능해야 한다. `lib/sanitize.mjs`만 이걸 갖고 있었다.

## 테스트 — `main-detection-guard.test.sh` (55 → 56)

양면으로 잠근다. 한쪽만으로는 부족해서다:

- **텍스트** — 모든 `import.meta.url ===` 지점이 `pathToFileURL` + `argv[1]` 가드를 함께 쓰는지. **관용구를 0건 발견하면 통과가 아니라 실패**로 본다. 안 그러면 파일 배치가 바뀌는 순간 검사가 조용히 vacuous해진다.
- **행위** — bin을 공백 있는 디렉터리에 복사해 실행하고 **출력이 비어 있지 않은지** 확인. 공백 없는 대조군을 함께 둬서 "둘 다 조용한 상태"가 성공으로 위장하지 못하게 한다.
- **로드 안전성** — 네 모듈 전부 `node -e` import에서 안 죽는지.

행위만 보면 공백 없는 CI 경로에서 늘 통과해 **애초에 이 버그를 못 잡고**, 텍스트만 보면 관용구를 지키면서 다르게 깨진 구현을 놓친다.

## 검증

- `loop-engine selftest 56/56` · `claude plugin validate --strict` 통과
- 위조 2종 전부 RED: 템플릿 문자열 복귀 / `argv[1]` 가드 제거
- 수정 후 공백 경로에서 두 bin 모두 실제로 동작(`check-pr-hygiene`은 정상적으로 FAIL을 냄)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VNR8Xbi414uHHzUFzmmMDp