### PR TITLE
fix(plugins): 의존 범위가 loop-engine 0.11.0을 배제하고 있었다 — 넓히고 게이트로 잠근다

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -19,14 +19,14 @@
       "name": "ship-flow",
       "source": "./tools/ship-flow",
       "description": "Delivery-loop skills — ship-feature (plan-to-PR autonomous loop), hotfix, retrospect, grill-with-docs (= grilling + domain-modeling), diagnosing-bugs, deps-audit, to-issues/to-prd, tdd, harness-maturity-audit, improve-codebase-architecture (built on codebase-design), resolving-merge-conflicts, wizard, to-questionnaire, ask-matt (skill router), wait-what, plus review agents and audit/research workflows — parameterized by a consuming repo's own tracker/branch-model config instead of hardcoded to one repo. dependencies: loop-engine.",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "keywords": ["delivery", "git-flow", "hotfix", "ship", "release"]
     },
     {
       "name": "loop-memory",
       "source": "./tools/loop-memory",
       "description": "pgvector semantic recall for verified dev-loop lessons (and, optionally, ADR/glossary/research knowledge). Opt-in / defaultEnabled:false — a database dependency, not core loop mechanics.",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "defaultEnabled": false,
       "keywords": ["memory", "pgvector", "recall", "semantic-search", "lessons"]
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,35 @@ Explicit-version channel — see [README § Development status](README.md#develo
 not a SHA channel. Entries below `## loop-engine 0.2.0` and earlier predate the multi-plugin split
 and refer to `loop-engine` only (see the un-prefixed version numbers).
 
+## ship-flow 0.6.1 · loop-memory 0.4.2
+
+Both dependents declared `loop-engine: ^0.10.0`. On a `0.x` line the caret pins the minor, so that
+range admits `0.10.z` and **excludes `0.11.0`** — the version published one entry below, carrying the
+`check-skill-refs` gate.
+
+Nothing failed. `claude plugin update` reported success and kept the old version:
+
+```
+$ claude plugin update loop-engine@paul-loop
+✔ loop-engine is already at the latest version satisfying ^0.10.0, ^0.10.0
+  (0.10.3, required by ship-flow, loop-memory).
+```
+
+The consuming repo kept resolving `0.10.3-e1cae157b97a` while `0.11.0` sat downloaded in the plugin
+cache, unreachable. This is the defect class this repo keeps meeting — **the thing that was supposed
+to start running quietly does not** — arriving this time through the version graph rather than a
+gate's wiring. Left alone it applies to every future loop-engine release, not just this one.
+
+- **Ranges widened to `^0.11.0`** in both dependents' `plugin.json`, versions bumped, and
+  `marketplace.json` synced.
+- **`plugin-dep-range.test.sh`** (suite 57 → 58) makes it mechanical: every sibling plugin's declared
+  loop-engine range must admit the loop-engine version this repo actually ships. Dependents are
+  **discovered** from `tools/*/.claude-plugin/plugin.json`, so a plugin added later is covered without
+  editing the test. Two fail-closed paths: finding **no** dependent at all is an error (discovery
+  broke — it verified nothing), and a range in a form the checker doesn't understand is an error
+  rather than a pass, since an unrecognised range is exactly how this check would stop checking.
+  Range parsing is inline `node` — a gate must not add a semver dependency to this repo.
+
 ## ship-flow 0.6.0
 
 Adopts upstream's **decomposition** — three skills that were inlined are now standalone and called by

--- a/tools/loop-engine/test/plugin-dep-range.test.sh
+++ b/tools/loop-engine/test/plugin-dep-range.test.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# A sibling plugin's declared dependency range must admit the loop-engine version this repo
+# actually ships. Bumping loop-engine's minor while dependents still pin `^0.10.0` does not fail
+# anywhere — `claude plugin update` reports success and quietly keeps the old version, because the
+# caret range on a 0.x line excludes the next minor. The new loop-engine is then published,
+# downloaded into the plugin cache, and unreachable to every consumer, with nothing reporting it.
+#
+# Observed 2026-08-26: loop-engine 0.11.0 (the check-skill-refs gate) shipped in PR #70 while
+# ship-flow 0.6.0 and loop-memory 0.4.1 both declared `^0.10.0`. `claude plugin update` printed
+# "already at the latest version satisfying ^0.10.0, ^0.10.0 (0.10.3, required by ship-flow,
+# loop-memory)" and the consuming repo kept resolving 0.10.3.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+
+fail() { echo "FAIL: $1"; exit 1; }
+
+ENGINE_MANIFEST="$ROOT/tools/loop-engine/.claude-plugin/plugin.json"
+[ -f "$ENGINE_MANIFEST" ] || fail "loop-engine manifest not found at $ENGINE_MANIFEST"
+
+# Ranges are checked in node: this repo has no semver dependency and must not grow one for a gate.
+# Only the forms this repo actually uses are understood; anything else is a hard error rather than a
+# silent pass, since an unrecognised range is exactly how this check would stop checking.
+check() { # $1=range $2=version -> prints "yes"/"no", or exits non-zero on an unknown form
+  node --input-type=module -e '
+    const [range, version] = process.argv.slice(1);
+    const parse = (v) => {
+      const m = /^(\d+)\.(\d+)\.(\d+)/.exec(v);
+      if (!m) { console.error(`unparseable version: ${v}`); process.exit(2); }
+      return m.slice(1, 4).map(Number);
+    };
+    const cmp = (a, b) => a[0] - b[0] || a[1] - b[1] || a[2] - b[2];
+    const ver = parse(version);
+    let lo, hi; // hi is exclusive; null means unbounded
+    if (range.startsWith("^")) {
+      lo = parse(range.slice(1));
+      // caret on a 0.x line pins the minor — ^0.10.0 admits 0.10.z but never 0.11.0
+      hi = lo[0] === 0 ? [0, lo[1] + 1, 0] : [lo[0] + 1, 0, 0];
+    } else if (range.startsWith(">=")) {
+      lo = parse(range.slice(2)); hi = null;
+    } else if (/^\d/.test(range)) {
+      lo = parse(range); hi = [lo[0], lo[1], lo[2] + 1];
+    } else {
+      console.error(`unrecognised range form: ${range}`); process.exit(2);
+    }
+    const ok = cmp(ver, lo) >= 0 && (hi === null || cmp(ver, hi) < 0);
+    console.log(ok ? "yes" : "no");
+  ' "$1" "$2"
+}
+
+ENGINE_VERSION="$(node -e 'console.log(JSON.parse(require("fs").readFileSync(process.argv[1],"utf8")).version)' "$ENGINE_MANIFEST")" \
+  || fail "could not read loop-engine version"
+[ -n "$ENGINE_VERSION" ] || fail "loop-engine version is empty"
+
+# Discover dependents rather than listing them — a plugin added later must be covered automatically.
+DEPENDENTS=0
+VIOLATIONS=0
+for manifest in "$ROOT"/tools/*/.claude-plugin/plugin.json; do
+  [ -f "$manifest" ] || continue
+  [ "$manifest" = "$ENGINE_MANIFEST" ] && continue
+  name="$(node -e 'console.log(JSON.parse(require("fs").readFileSync(process.argv[1],"utf8")).name||"")' "$manifest")"
+  range="$(node -e '
+    const d = JSON.parse(require("fs").readFileSync(process.argv[1],"utf8"));
+    const dep = (d.dependencies||[]).find((x) => x && x.name === "loop-engine");
+    console.log(dep ? dep.version : "");
+  ' "$manifest")"
+  [ -n "$range" ] || continue
+  DEPENDENTS=$((DEPENDENTS + 1))
+  verdict="$(check "$range" "$ENGINE_VERSION")" || fail "$name declares a dependency range this check cannot interpret ($range) — teach the check the form rather than leaving it unchecked"
+  if [ "$verdict" = "yes" ]; then
+    echo "PASS: $name's range $range admits loop-engine $ENGINE_VERSION"
+  else
+    echo "  VIOLATION: $name declares loop-engine $range, which excludes the shipped $ENGINE_VERSION"
+    VIOLATIONS=$((VIOLATIONS + 1))
+  fi
+done
+
+# Fail closed: finding no dependents at all means the discovery broke, not that everything is fine.
+[ "$DEPENDENTS" -gt 0 ] || fail "no sibling plugin declares a loop-engine dependency — discovery is broken, so this check verified nothing"
+
+[ "$VIOLATIONS" -eq 0 ] || fail "$VIOLATIONS dependent(s) pin a range that excludes loop-engine $ENGINE_VERSION — a consumer would silently keep the old version"
+echo "PASS: every dependent's range admits the shipped loop-engine $ENGINE_VERSION ($DEPENDENTS checked)"

--- a/tools/loop-memory/.claude-plugin/plugin.json
+++ b/tools/loop-memory/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "loop-memory",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "pgvector semantic recall for verified dev-loop lessons (and, optionally, ADR/glossary/research knowledge). Opt-in: installs disabled by default — this is a database dependency, not core loop mechanics.",
   "author": {
     "name": "paulkim-lansik"
@@ -10,7 +10,7 @@
   "license": "MIT",
   "keywords": ["memory", "pgvector", "recall", "semantic-search", "lessons"],
   "defaultEnabled": false,
-  "dependencies": [{ "name": "loop-engine", "version": "^0.10.0" }],
+  "dependencies": [{ "name": "loop-engine", "version": "^0.11.0" }],
   "userConfig": {
     "openai_api_key": {
       "type": "string",

--- a/tools/ship-flow/.claude-plugin/plugin.json
+++ b/tools/ship-flow/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ship-flow",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Delivery-loop skills — land and release already-verified work through a repo's real gates. Tracker- and branch-model-agnostic: reads a consuming repo's own config instead of hardcoding one repo's setup.",
   "author": {
     "name": "paulkim-lansik"
@@ -10,6 +10,6 @@
   "license": "MIT",
   "keywords": ["delivery", "git-flow", "hotfix", "ship", "release"],
   "dependencies": [
-    { "name": "loop-engine", "version": "^0.10.0" }
+    { "name": "loop-engine", "version": "^0.11.0" }
   ]
 }


### PR DESCRIPTION
PR #70이 loop-engine을 0.11.0으로 올렸다. **그 버전은 어떤 소비자에게도 도달할 수 없는 상태였다.**

## 발견

#70 머지 직후 플러그인을 최신화하다 나왔다:

```
$ claude plugin marketplace update paul-loop
✔ Successfully updated marketplace: paul-loop

$ claude plugin update loop-engine@paul-loop
✔ loop-engine is already at the latest version satisfying ^0.10.0, ^0.10.0
  (0.10.3, required by ship-flow, loop-memory).

$ claude plugin update ship-flow@paul-loop
✔ Plugin "ship-flow" updated from 0.5.0 to 0.6.0 for scope user.
```

ship-flow는 올라갔는데 loop-engine은 안 올라갔다. **성공으로 보고하면서.**

원인은 한 줄이다 — 두 dependent가 똑같이 이렇게 선언하고 있었다:

```json
"dependencies": [{ "name": "loop-engine", "version": "^0.10.0" }]
```

`0.x` 라인에서 caret은 **마이너를 고정**한다. `^0.10.0`은 `>=0.10.0 <0.11.0`이라 `0.11.0`을 배제한다. 그래서 0.11.0은 마켓플레이스 갱신으로 캐시에 내려왔지만 리졸버가 절대 고르지 않는다:

```
$ ls ~/.claude/plugins/cache/paul-loop/loop-engine/ | sort -V | tail -3
0.10.3
0.10.3-e1cae157b97a
0.11.0

$ node tools/plugin-path.mjs resolve          # 소비 레포에서
/Users/paul/.claude/plugins/cache/paul-loop/loop-engine/0.10.3-e1cae157b97a
```

## 왜 이게 이 레포의 문제인가

이 레포가 반복해서 만나는 결함군이다 — **돌기 시작했어야 할 것이 조용히 안 돈다.** 이번엔 게이트 배선이 아니라 **버전 그래프**를 통해 왔다. 실패 신호가 없는 정도가 아니라, 명령이 체크마크와 함께 성공을 보고한다.

그리고 이건 이번 릴리스 한 번의 문제가 아니다. 범위를 그대로 두면 **앞으로의 모든 loop-engine 마이너 릴리스**가 같은 방식으로 도달하지 못한다.

## 수정

- 두 dependent의 범위를 `^0.11.0`으로. 버전은 패치 범프(`ship-flow 0.6.1` · `loop-memory 0.4.2`), `marketplace.json` 동기화.
- **`plugin-dep-range.test.sh`** (스위트 57 → 58) — 모든 형제 플러그인의 선언 범위가 이 레포가 **실제로 배포하는** loop-engine 버전을 받아들여야 한다.

수정 전 이 테스트가 실제로 RED다:

```
  VIOLATION: loop-memory declares loop-engine ^0.10.0, which excludes the shipped 0.11.0
  VIOLATION: ship-flow declares loop-engine ^0.10.0, which excludes the shipped 0.11.0
FAIL: 2 dependent(s) pin a range that excludes loop-engine 0.11.0 — a consumer would silently keep the old version
```

수정 후:

```
PASS: loop-memory's range ^0.11.0 admits loop-engine 0.11.0
PASS: ship-flow's range ^0.11.0 admits loop-engine 0.11.0
PASS: every dependent's range admits the shipped loop-engine 0.11.0 (2 checked)
```

### 게이트 설계에서 신경 쓴 것

- **dependent를 열거하지 않고 발견한다** (`tools/*/.claude-plugin/plugin.json`) — 나중에 추가되는 플러그인이 자동으로 커버된다. 목록을 하드코딩하면 "새 플러그인을 목록에 안 넣어서 안 잡힌다"는 같은 종류의 결함을 하나 더 만드는 것이다.
- **fail-closed 2종.** dependent를 하나도 못 찾으면 통과가 아니라 **에러**다(발견이 깨진 것이고, 그건 아무것도 검증하지 않은 것이다). 해석할 수 없는 범위 형태도 통과가 아니라 에러다 — 모르는 형태를 넘겨주는 게 바로 이 검사가 조용히 멈추는 방식이다.
- **semver 의존성을 추가하지 않았다.** 범위 판정은 inline `node`다. 게이트 하나 때문에 이 레포에 런타임 의존성이 생기면 안 된다.

## 검증

```
=== VERDICT ===
VERDICT: PASS
EXIT: 0
SUMMARY: passed=58 failed= skipped= duration_ms=97257
LOG: /Users/paul/dev/paul-loop-dep/.loop/last-run.log
=== END VERDICT ===
```

```
$ claude plugin validate --strict .                  → ✔ Validation passed
$ claude plugin validate --strict tools/ship-flow    → ✔ Validation passed
$ claude plugin validate --strict tools/loop-memory  → ✔ Validation passed
$ claude plugin validate --strict tools/loop-engine  → ✔ Validation passed
```

## 게이트 판정

```
GATE: AUTO
TRACK: standard
FINAL: blast_radius=low reversibility=full cost=low
MATCHED: app-code-low-risk-baseline — no path rule matched + ≤10 files (BAC-584)
```

## Decisions taken

- **`^0.11.0`으로 올렸고 `>=0.10.0`으로 풀지 않았다.** 범위를 풀면 이 게이트가 영원히 초록이 되어 아무것도 검사하지 않는다. 마이너마다 dependent를 함께 올리는 부담은 남지만, 그게 게이트가 잡아야 할 바로 그 순간이다.
- **loop-engine 자신은 범프하지 않았다.** 0.11.0의 내용은 그대로고 바뀐 것은 dependent 쪽 선언이다.
