### PR TITLE
fix(license): 파생 스킬 24건의 MIT 표기가 없었다 — NOTICE 추가 + 표기 정합 게이트

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,68 @@
+# NOTICE
+
+This project includes work derived from other open-source projects. Each derived file's origin is
+recorded per-file in [`skills-lock.json`](skills-lock.json) (`source` and `skillPath`), which is the
+authoritative provenance record and is kept in sync by `vendor-lock-consistency.test.sh`.
+
+---
+
+## mattpocock/skills
+
+<https://github.com/mattpocock/skills>
+
+24 skills under `tools/ship-flow/skills/` are derived from this project. Some are close to
+verbatim; others have been substantially rewritten or deliberately diverge — entries carrying a `fork`
+field in `skills-lock.json` mark the deliberate divergences. In all cases the original is the origin of
+the work.
+
+- `ask-matt`
+- `code-review`
+- `codebase-design`
+- `diagnosing-bugs`
+- `domain-modeling`
+- `grill-me`
+- `grill-with-docs`
+- `grilling`
+- `handoff`
+- `improve-codebase-architecture`
+- `prototype`
+- `research`
+- `resolving-merge-conflicts`
+- `setup`
+- `tdd`
+- `teach`
+- `to-issues`
+- `to-prd`
+- `to-questionnaire`
+- `triage`
+- `wait-what`
+- `wayfinder`
+- `wizard`
+- `write-a-skill`
+
+The original project is distributed under the MIT License, reproduced in full below as required by
+that license. It applies to the portions of this project derived from it.
+
+```
+MIT License
+
+Copyright (c) 2026 Matt Pocock
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```

--- a/README.ko.md
+++ b/README.ko.md
@@ -228,3 +228,7 @@ tools/loop-engine/
 ## 라이선스
 
 MIT — [LICENSE](LICENSE) 참고.
+
+`ship-flow`의 일부는 [mattpocock/skills](https://github.com/mattpocock/skills)에서 파생됐다(그쪽도 MIT).
+저작권·허가 고지는 [NOTICE](NOTICE)에 그대로 실려 있고, 파일별 출처는 [`skills-lock.json`](skills-lock.json)에
+산다. 둘이 어긋나면 `attribution-completeness.test.sh`가 RED를 낸다.

--- a/README.md
+++ b/README.md
@@ -374,3 +374,8 @@ path stayed.
 ## License
 
 MIT — see [LICENSE](LICENSE).
+
+Parts of `ship-flow` are derived from [mattpocock/skills](https://github.com/mattpocock/skills), also
+MIT. Its copyright and permission notice are reproduced in [NOTICE](NOTICE); per-file provenance lives
+in [`skills-lock.json`](skills-lock.json), and `attribution-completeness.test.sh` keeps the two from
+drifting apart.

--- a/tools/loop-engine/test/attribution-completeness.test.sh
+++ b/tools/loop-engine/test/attribution-completeness.test.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# This repo is public and redistributes skills derived from other projects. Those projects' licenses
+# (MIT, in every current case) require their copyright and permission notice to travel with any
+# substantial portion of the work. NOTICE carries them.
+#
+# The failure this prevents is drift, not malice: a skill gets vendored, `skills-lock.json` records
+# where it came from, NOTICE is not touched, and the repo quietly redistributes one more file without
+# attribution. Nothing errors — the lock and NOTICE just stop agreeing. That is how the gap this test
+# was written for opened in the first place: 24 lock entries, zero mentions of the upstream author
+# anywhere outside prose.
+#
+# Checked against the lock rather than a hand-kept list, so a new vendored skill is covered the moment
+# it is registered.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+LOCK="$ROOT/skills-lock.json"
+NOTICE="$ROOT/NOTICE"
+
+fail() { echo "FAIL: $1"; exit 1; }
+
+[ -f "$NOTICE" ] || fail "NOTICE not found at $NOTICE — this repo redistributes derived work and must carry its upstreams' notices"
+[ -f "$LOCK" ] || fail "skills-lock.json not found — cannot tell what is derived, so attribution cannot be checked"
+
+VIOLATIONS=0
+
+# 1. Every distinct upstream named in the lock has a section in NOTICE.
+SOURCES="$(node -e '
+  const l = JSON.parse(require("fs").readFileSync(process.argv[1], "utf8"));
+  const s = new Set(Object.values(l.skills || {}).map((e) => e.source).filter(Boolean));
+  process.stdout.write([...s].sort().join("\n") + (s.size ? "\n" : ""));
+' "$LOCK")" || fail "skills-lock.json is not readable JSON"
+
+[ -n "$SOURCES" ] || fail "no upstream source recorded in the lock — this check verified nothing"
+
+while IFS= read -r src; do
+  [ -n "$src" ] || continue
+  if grep -qF "$src" "$NOTICE"; then
+    echo "PASS: NOTICE credits $src"
+  else
+    echo "  VIOLATION: the lock records skills derived from '$src' but NOTICE never names it"
+    VIOLATIONS=$((VIOLATIONS + 1))
+  fi
+done <<< "$SOURCES"
+
+# 2. Every derived skill is listed by name, so a reader can tell which files the notice covers.
+while IFS= read -r name; do
+  [ -n "$name" ] || continue
+  grep -qF "\`$name\`" "$NOTICE" && continue
+  echo "  VIOLATION: '$name' is a derived skill in the lock but NOTICE does not list it"
+  VIOLATIONS=$((VIOLATIONS + 1))
+done < <(node -e '
+  const l = JSON.parse(require("fs").readFileSync(process.argv[1], "utf8"));
+  process.stdout.write(Object.keys(l.skills || {}).sort().join("\n") + "\n");
+' "$LOCK")
+
+# 3. The upstream copyright line itself must be present — naming the project is not the same as
+#    carrying its notice, and the notice is what the license actually requires.
+grep -qE '^Copyright \(c\) .+' "$NOTICE" || {
+  echo "  VIOLATION: NOTICE names upstreams but reproduces no upstream copyright line"
+  VIOLATIONS=$((VIOLATIONS + 1))
+}
+
+[ "$VIOLATIONS" -eq 0 ] || fail "$VIOLATIONS attribution gap(s) — derived work would ship without the notice its license requires"
+echo "PASS: every upstream in the lock is credited in NOTICE, with its copyright reproduced"


### PR DESCRIPTION
이 레포는 **public**이고, `mattpocock/skills`(MIT, © 2026 Matt Pocock) 파생 스킬을 **24건** 재배포한다. 그런데 출처도 저작권 표기도 어디에도 없었다.

## 실측

```
$ git grep -ln "mattpocock" origin/main -- ':!skills-lock.json'
CHANGELOG.md
docs/audits/2026-08-20-harness-maturity-audit.md
tools/loop-engine/bin/check-skill-refs.mjs
tools/loop-engine/bin/mattpocock-skills-sync-check.mjs
tools/loop-engine/test/mattpocock-skills-sync-check.test.sh
tools/ship-flow/skills/vendor-sync/SKILL.md
```

전부 **산문·감사문서·도구 내부**다. `README.md`·`README.ko.md`·`LICENSE`·`marketplace.json`에는 한 번도 나오지 않고, 파생 스킬 자신도 출처를 밝히지 않는다:

```
$ git show origin/main:tools/ship-flow/skills/teach/SKILL.md | grep -i "mattpocock\|derived\|adapted"
(없음)
```

MIT는 이렇게 요구한다:

> The above copyright notice and this permission notice shall be included in all copies or **substantial portions** of the Software.

스킬 문서 전문을 싣는 것은 substantial portion이다.

## 소비 레포의 ADR-0078이 이걸 예견했다

ADR-0078 **결정 3**: *"vendored mattpocock 스킬은 재배포하지 않는다 — 재배포 시 **라이선스·프로버넌스**·이중 drift가 그대로 재발한다."*

세 가지 중 **이중 drift는 0.7.0에서 닫았다**(`skills-lock.json` + `vendor-sync` + `vendor-lock-consistency.test.sh`). 나머지 둘은 닫지 않은 채 재배포 범위만 늘렸다 — 0.5.0(#65)에서 시작해 0.6.0(#70) → 0.7.0(#73) → 0.8.0(#75)까지, 2건에서 24건으로.

**재배포 자체는 되돌리지 않는다.** 사용자가 2026-08-26에 정한 방향이 "모든 개발작업은 paul-loop 안에서만 돌아간다"이고, 그에 따라 상류 플러그인(`mattpocock-skills@claude-plugins-official`)을 비활성화했다. ADR-0078 결정 3의 전제였던 *"upstream이 이미 설치형 플러그인이니 재배포할 이유가 없다"*가 그 결정으로 사라졌다. 바뀐 것은 결론이 아니라 전제이고, **그 전제 변경이 요구하는 의무를 이 PR이 이행한다.**

## 무엇을 했나

- **`NOTICE`** — 상류 MIT **전문과 저작권 줄을 그대로** 싣고, 파생 스킬 24건을 이름으로 열거한다. 파일별 출처는 `skills-lock.json`(`source`/`skillPath`)이 정본이라고 가리킨다.
- **`README.md` · `README.ko.md`의 License 절**에 NOTICE 포인터.
- **`attribution-completeness.test.sh`** (스위트 59 → 60).

### 게이트가 검사하는 것

1. lock에 기록된 **모든 상류**가 NOTICE에 credit돼 있다.
2. **모든 파생 스킬이 이름으로** 열거돼 있다 — 고지가 어느 파일을 덮는지 읽는 사람이 알 수 있어야 한다.
3. **상류 저작권 줄이 실제로 실려 있다** — 프로젝트 이름을 적는 것과 고지를 싣는 것은 다르고, 라이선스가 요구하는 것은 후자다.

목록을 손으로 유지하지 않고 **lock에서 파생**한다 — 새 벤더 스킬은 등재되는 순간 커버된다. 하드코딩한 목록은 "새 스킬을 목록에 안 넣어서 안 잡힌다"는 같은 결함을 하나 더 만드는 것이다.

RED를 실제로 확인했다 — lock에 항목 하나를 넣고 NOTICE를 그대로 두면:

```
  VIOLATION: the lock records skills derived from 'someone/else' but NOTICE never names it
  VIOLATION: '__redproof__' is a derived skill in the lock but NOTICE does not list it
FAIL: 2 attribution gap(s) — derived work would ship without the notice its license requires
```

**이 갭이 생긴 방식이 정확히 그거다** — 스킬을 벤더링하고, lock에 적고, NOTICE는 안 만진다. 아무것도 에러를 내지 않는다.

## 검증

```
=== VERDICT ===
VERDICT: PASS
EXIT: 0
SUMMARY: passed=60 failed= skipped= duration_ms=100870
LOG: /Users/paul/dev/paul-loop-attr/.loop/last-run.log
=== END VERDICT ===
```

```
loop-engine selftest: 60/60 passed
```

> 첫 실행은 `No space left on device`로 14건이 깨졌다(머신 여유 587Mi). 코드와 무관하며, docker 빌드 캐시 15.64GB를 회수해(다른 세션의 컨테이너·볼륨은 미접촉) 재실행한 결과가 위다.

## 게이트 판정

```
GATE: AUTO
TRACK: standard
FINAL: blast_radius=low reversibility=full cost=low
MATCHED: app-code-low-risk-baseline — no path rule matched + ≤10 files (BAC-584)
```

## Decisions taken

- **개별 스킬 파일마다 출처 주석을 넣지 않았다.** 24개 파일에 헤더를 다는 대신 `NOTICE`(고지) + `skills-lock.json`(파일별 출처) 두 층으로 나눴다 — 후자는 이미 존재하고 게이트가 지키고 있다. 파일마다 다는 방식은 손으로 유지되는 24곳을 만들고, 그게 이 결함의 원형이다.
- **`LICENSE`는 건드리지 않았다.** 이 레포 자체 저작물의 라이선스는 그대로이고, 파생분에 대한 고지는 `NOTICE`가 관례적인 자리다.
- **ADR-0078 결정 3의 정정 기록은 이 PR에 없다** — 그 ADR은 소비 레포에 산다. **BAC-823**에서 addendum으로 남긴다.
