### PR TITLE
refactor(ship-flow): ask-matt -> ask-paul — 본문은 이미 우리 것, 이름만 남아 있었다

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -18,8 +18,8 @@
     {
       "name": "ship-flow",
       "source": "./tools/ship-flow",
-      "description": "Delivery-loop skills — ship-feature (plan-to-PR autonomous loop), hotfix, retrospect, grill-with-docs (= grilling + domain-modeling), diagnosing-bugs, deps-audit, to-issues/to-prd, tdd, harness-maturity-audit, improve-codebase-architecture (built on codebase-design), resolving-merge-conflicts, wizard, to-questionnaire, ask-matt (skill router), wait-what, plus review agents and audit/research workflows — parameterized by a consuming repo's own tracker/branch-model config instead of hardcoded to one repo. dependencies: loop-engine.",
-      "version": "0.8.0",
+      "description": "Delivery-loop skills — ship-feature (plan-to-PR autonomous loop), hotfix, retrospect, grill-with-docs (= grilling + domain-modeling), diagnosing-bugs, deps-audit, to-issues/to-prd, tdd, harness-maturity-audit, improve-codebase-architecture (built on codebase-design), resolving-merge-conflicts, wizard, to-questionnaire, ask-paul (skill router), wait-what, plus review agents and audit/research workflows — parameterized by a consuming repo's own tracker/branch-model config instead of hardcoded to one repo. dependencies: loop-engine.",
+      "version": "0.9.0",
       "keywords": ["delivery", "git-flow", "hotfix", "ship", "release"]
     },
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ Explicit-version channel — see [README § Development status](README.md#develo
 not a SHA channel. Entries below `## loop-engine 0.2.0` and earlier predate the multi-plugin split
 and refer to `loop-engine` only (see the un-prefixed version numbers).
 
+## ship-flow 0.9.0
+
+`ask-matt` is renamed **`ask-paul`**. The name was the last thing upstream about it.
+
+Its body was already rewritten rather than ported in 0.6.0 — it routes over *this* plugin's skills
+(the `ship-feature` single entrypoint, the risk gate's REQUIRE stops, the verdict contract, the
+`verifier-integrity-hunter` pass, `retrospect`'s verified-only rule) and names none of upstream's.
+So the name described a provenance the file no longer had, and pointed a reader at the wrong author's
+opinions.
+
+- **The lock entry stays**, keyed `ask-paul` with `skillPath` still pointing at upstream's
+  `skills/engineering/ask-matt/SKILL.md`. That pairing is what keeps `vendor-sync` watching upstream's
+  version — as a source of *ideas* now, not of text. The `fork` reason records the rename and why.
+- **NOTICE follows the lock.** `attribution-completeness.test.sh` derives its list from the lock keys,
+  so the rename would have gone RED had NOTICE not been updated with it — which is the gate doing
+  exactly what it was added for in 0.8.0, one release later.
+- **Breaking for anyone typing the old name.** `/ship-flow:ask-matt` no longer resolves; use
+  `/ship-flow:ask-paul`. No skill body referenced it, so nothing internal broke.
+
+Earlier entries below keep the old name where they describe what shipped at the time — renaming a
+changelog rewrites history rather than recording it.
+
 ## ship-flow 0.8.0
 
 The last seven skills that lived in a consuming repo move into the plugin. Nothing here is new work —

--- a/NOTICE
+++ b/NOTICE
@@ -15,7 +15,7 @@ verbatim; others have been substantially rewritten or deliberately diverge — e
 field in `skills-lock.json` mark the deliberate divergences. In all cases the original is the origin of
 the work.
 
-- `ask-matt`
+- `ask-paul` (renamed from upstream's `ask-matt`; body rewritten, see the `fork` entry in `skills-lock.json`)
 - `code-review`
 - `codebase-design`
 - `diagnosing-bugs`

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,14 +1,14 @@
 {
   "version": 1,
   "skills": {
-    "ask-matt": {
+    "ask-paul": {
       "source": "mattpocock/skills",
       "sourceType": "github",
       "skillPath": "skills/engineering/ask-matt/SKILL.md",
-      "localPath": "tools/ship-flow/skills/ask-matt/SKILL.md",
-      "computedHash": "e9b1ceab2cc30a4916f492a821d5c8c4dc84965797778e66f7a7e1f398d5367c",
+      "localPath": "tools/ship-flow/skills/ask-paul/SKILL.md",
+      "computedHash": "aed70b7d9c7259898e4e8d36a9cb76dcddda8d14fb937e76226e9d54da7fd000",
       "fork": {
-        "reason": "Rewritten, not ported: upstream routes over ~15 skills this plugin does not ship. Receiving upstream's body would fill it with handoffs to nothing.",
+        "reason": "Rewritten, not ported: upstream routes over ~15 skills this plugin does not ship. Receiving upstream's body would fill it with handoffs to nothing. Renamed ask-matt -> ask-paul in ship-flow 0.9.0 because the body shares no text with upstream and the old name misdescribed what it routes over; the entry stays here to keep tracking upstream's version as a source of ideas, not of text.",
         "since": "2026-08-26"
       }
     },

--- a/tools/ship-flow/.claude-plugin/plugin.json
+++ b/tools/ship-flow/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ship-flow",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Delivery-loop skills — land and release already-verified work through a repo's real gates. Tracker- and branch-model-agnostic: reads a consuming repo's own config instead of hardcoding one repo's setup.",
   "author": {
     "name": "paulkim-lansik"

--- a/tools/ship-flow/skills/ask-paul/SKILL.md
+++ b/tools/ship-flow/skills/ask-paul/SKILL.md
@@ -1,10 +1,10 @@
 ---
-name: ask-matt
+name: ask-paul
 description: Ask which skill or flow fits your situation. A router over the skills this plugin ships.
 disable-model-invocation: true
 ---
 
-# Ask Matt
+# Ask Paul
 
 > **Output language.** Read `outputLanguage` (a BCP-47 tag, e.g. `ko`) from
 > `.claude/ship-flow.config.json` and write **every human-facing prose artifact** — reports, summaries,


### PR DESCRIPTION
## 무엇

`ship-flow:ask-matt` → **`ship-flow:ask-paul`**. 이름 하나만 바뀐다.

## 왜

0.6.0에서 이 스킬은 **상류 본문을 포팅한 게 아니라 새로 썼다**. `skills-lock.json`의 fork 사유가 당시 그걸 명시했다:

> "Rewritten, not ported: upstream routes over ~15 skills this plugin does not ship. Receiving upstream's body would fill it with handoffs to nothing."

본문의 라우팅 대상은 전부 이 플러그인 것이다 — `ship-feature` 단일 진입점, 위험 게이트의 REQUIRE 정지점, verdict 계약("검증기가 천장, 에이전트 자기보고 아님"), `verifier-integrity-hunter`, `retrospect`의 verified-only 기록, `to-prd → to-issues` 분해, `hotfix`의 2단 브랜치 모델. 상류 스킬은 한 개도 안 가리킨다.

즉 이름이 파일에 더는 없는 출처를 가리키고 있었고, 사용자를 **다른 저자의 의견** 쪽으로 오도했다.

## 어떻게

| 파일 | 변경 |
|---|---|
| `tools/ship-flow/skills/{ask-matt → ask-paul}/SKILL.md` | 디렉터리 rename + frontmatter `name` + `# Ask Paul` 제목. **본문 무수정** |
| `skills-lock.json` | 키 `ask-paul`, `localPath` 갱신, `computedHash` 재계산, fork 사유에 개명 근거 추가. **`skillPath`는 상류 `skills/engineering/ask-matt/SKILL.md` 유지** |
| `NOTICE` | 목록 항목을 `ask-paul`로 (개명 사실 괄호 표기) |
| `.claude-plugin/marketplace.json` | ship-flow description + version |
| `tools/ship-flow/.claude-plugin/plugin.json` | 0.8.0 → 0.9.0 |
| `CHANGELOG.md` | 0.9.0 항목 신설 |

**`skillPath`를 상류 경로로 남긴 게 핵심이다.** lock은 `skillPath`(상류)와 `localPath`(우리)를 따로 들고 있어서, 키를 바꿔도 `vendor-sync`의 상류 추적이 끊기지 않는다 — 다만 이제 그 추적은 *텍스트* 출처가 아니라 *아이디어* 출처를 본다. fork 사유에 그 구분을 적어 뒀다.

**CHANGELOG의 과거 항목(0.6.0/0.7.0/0.8.0)은 옛 이름 그대로 둔다.** 당시 무엇이 나갔는지를 적은 기록이라 개명하면 기록이 아니라 역사 수정이 된다. 0.9.0 항목 끝에 그 정책을 한 줄로 명시했다.

## 게이트가 실제로 작동했다

`attribution-completeness.test.sh`(0.8.0에서 추가)는 NOTICE 목록을 **lock 키에서 도출**한다. NOTICE만 옛 이름으로 되돌려 RED를 실측했다:

```
### RED 증명: NOTICE만 옛 이름으로 되돌린 상태 ###
PASS: NOTICE credits mattpocock/skills
  VIOLATION: 'ask-paul' is a derived skill in the lock but NOTICE does not list it
FAIL: 1 attribution gap(s) — derived work would ship without the notice its license requires
### 복구 후 ###
PASS: NOTICE credits mattpocock/skills
PASS: every upstream in the lock is credited in NOTICE, with its copyright reproduced
```

한 릴리스 만에 제 몫을 했다 — 손으로 관리하는 목록이었다면 조용히 어긋났을 자리다.

`vendor-lock-consistency.test.sh`의 두 방향(ghost entry / unregistered)도 이 rename이 정확히 건드리는 지점인데, 디렉터리명·lock 키·`localPath` 셋이 일치해 그린이다.

## 검증

```
=== VERDICT ===
VERDICT: PASS
EXIT: 0
SUMMARY: passed=60 failed= skipped= duration_ms=107483
LOG: /Users/paul/dev/paul-loop-askpaul/.loop/last-run.log
=== END VERDICT ===
```

```
loop-engine selftest: 60/60 passed
```

위험 판정:

```
=== RISK ===
STAGE: pr
PATHS: 7
RULE: blast_radius=low reversibility=full cost=low
FINAL: blast_radius=low reversibility=full cost=low
MATCHED: app-code-low-risk-baseline — no path rule matched + ≤10 files (BAC-584)
TRACK: standard
DEEP_GATES: (none)
=== END RISK ===
=== GATE ===
GATE: AUTO
=== END GATE ===
```

## Breaking

`/ship-flow:ask-matt`는 더 이상 안 잡힌다 → `/ship-flow:ask-paul`. 레포 전체 grep 결과 이 이름을 참조하던 **스킬 본문은 0건**이라 내부 핸드오프 파손은 없다. 남은 언급은 CHANGELOG의 과거 기록(의도적 유지)과 lock의 `skillPath`(상류 경로)뿐이다.

## Decisions taken

- **CHANGELOG 과거 항목 미수정** — 대안은 전면 개명. 기록의 정확성이 이름 일관성보다 우선한다고 판단.
- **lock 엔트리 유지(삭제 아님)** — 본문이 상류와 한 줄도 안 겹치므로 "파생 아님"으로 lock에서 빼는 선택지가 있었으나, 그러면 상류 `ask-matt`의 변경을 `vendor-sync`가 더 이상 안 본다. 아이디어 추적을 잃는 쪽이 손해라고 판단해 유지하고, 성격 차이는 fork 사유에 문서화.
- **minor bump(0.9.0)** — 사용자가 치는 이름이 바뀌므로 patch가 아니라 minor.
