### PR TITLE
fix: AC 게이트가 구현과 무관한 이유로 내던 거짓 판정 세 경로 (#74, #58, #71)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,21 +12,21 @@
       "name": "loop-engine",
       "source": "./tools/loop-engine",
       "description": "Core loop mechanics: verdict-run (machine-readable PASS/FAIL contract), loop-fix (closed verify->fix loop), lessons (verified-fix memory), classify-risk, require-tests, plugin-path (resolve sibling plugin install paths), check-docs-hygiene/check-pr-hygiene/check-module-size/check-skill-refs (repo hygiene gates). No framework opinions beyond \"the verifier is the ceiling, never the agent's self-report\".",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "keywords": ["verifier", "tdd", "loop", "verdict", "lessons"]
     },
     {
       "name": "ship-flow",
       "source": "./tools/ship-flow",
       "description": "Delivery-loop skills — ship-feature (plan-to-PR autonomous loop), hotfix, retrospect, grill-with-docs (= grilling + domain-modeling), diagnosing-bugs, deps-audit, to-issues/to-prd, tdd, harness-maturity-audit, improve-codebase-architecture (built on codebase-design), resolving-merge-conflicts, wizard, to-questionnaire, ask-paul (skill router), wait-what, plus review agents and audit/research workflows — parameterized by a consuming repo's own tracker/branch-model config instead of hardcoded to one repo. dependencies: loop-engine.",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "keywords": ["delivery", "git-flow", "hotfix", "ship", "release"]
     },
     {
       "name": "loop-memory",
       "source": "./tools/loop-memory",
       "description": "pgvector semantic recall for verified dev-loop lessons (and, optionally, ADR/glossary/research knowledge). Opt-in / defaultEnabled:false — a database dependency, not core loop mechanics.",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "defaultEnabled": false,
       "keywords": ["memory", "pgvector", "recall", "semantic-search", "lessons"]
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,60 @@ Explicit-version channel — see [README § Development status](README.md#develo
 not a SHA channel. Entries below `## loop-engine 0.2.0` and earlier predate the multi-plugin split
 and refer to `loop-engine` only (see the un-prefixed version numbers).
 
+## loop-engine 0.12.0
+
+Two ways the AC gate returned a verdict that had nothing to do with the code under test, and one
+timing case that turned load into a false accusation. All three are the same defect: **the gate
+reports something other than what it measured.**
+
+- **`expect:` had exactly one corpus (issue #74).** It grepped the `verify:` command's log — so an
+  `artifacts:` + `expect:` contract with no `verify:` grepped an *empty* log and reported
+  `expect substring not found`. That is the most natural way to write a documentation contract, and
+  it was structurally unpassable while reporting itself as an implementation defect. Measured on a
+  real contract from PR #73: the file contained the substring six times.
+
+  `expect:` now picks its corpus from what the AC declares — `verify:` present → its log
+  (**unchanged**, and deliberately not widened to also cover artifacts when both are given: a
+  contract that passes today must keep meaning exactly what it meant); no `verify:` but
+  `artifacts:` → the contents of those files, a match in any one of them satisfying it; **neither →
+  exit 2**, a contract error rather than an AC failure. That last distinction is the point of the
+  change: reported as a *violation*, the cheapest fix is to delete the `expect:` — and then the
+  contract quietly checks nothing, which is the failure this repo's gates exist to prevent.
+
+- **The suite could not run under a non-default `LOOP_DIR` (issue #58).** `verdict-run.sh` writes
+  its state to `${LOOP_DIR:-.loop}/verdict-state.json`, but two tests asserted a hardcoded `.loop`,
+  so `60/60` became `58/60` the moment `LOOP_DIR` moved. `ac-verify.sh` exports exactly that when
+  given `--log-dir` — so any plan whose AC ran this suite failed permanently, and the reason was
+  four levels down in a log. The two tests now resolve the path the way the contract defines it.
+
+  Fixing that surfaced a third: `verdict-mutation-guard`'s gitignored-write case only ever worked
+  because `verdict-run.sh` happened to create `.loop/` first. Under another `LOOP_DIR` the write
+  failed with *No such file or directory* and the case went red while appearing to say "the guard
+  tripped" — it was really saying "the command failed". The case now creates the directory it
+  writes into, and proves only what it claims.
+
+- **`loop-fix-protect` case16 had ~0.5s of margin (issue #71).** It races a 1s watchdog against a
+  2s-delayed mutation, and at the default 1.5s grace the recheck window closed barely after the
+  mutation was due. On a loaded machine it flipped — and PR #70 misattributed exactly that to an
+  unrelated new test. `LOOP_PROTECT_GRACE_SEC=5` is now pinned in the case: every ordering it proves
+  is unchanged (1 < 2 < 1+5), the margin goes from ~0.5s to ~5s, and the case costs ~4.6s more.
+  Nothing about the behaviour under test was weakened — which is the outcome the misattribution
+  pressure was pushing against.
+
+Version note: this is a minor, not a patch — `expect:` gained a corpus it did not have and a new
+exit-2 path exists. `plugin-dep-range.test.sh` (added in 0.11.0) went red on the bump, naming both
+dependents still pinned to `^0.11.0`, which is what it was written to do.
+
+## ship-flow 0.9.1
+
+`ship-feature`'s `AC-CONTRACTS.md` follows loop-engine 0.12.0: which corpus `expect:` searches, why
+`verify:` + `artifacts:` still searches output only, and the one rejected combination. Adds the
+documentation-contract example — `artifacts:` + `expect:`, no `verify:` — that could not work before.
+
+## loop-memory 0.4.3
+
+Dependency range only: `loop-engine ^0.11.0` → `^0.12.0`.
+
 ## ship-flow 0.9.0
 
 `ask-matt` is renamed **`ask-paul`**. The name was the last thing upstream about it.

--- a/tools/loop-engine/.claude-plugin/plugin.json
+++ b/tools/loop-engine/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "loop-engine",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "Core loop mechanics: verdict-run (machine-readable PASS/FAIL contract), loop-fix (closed verify->fix loop), lessons (verified-fix memory), classify-risk, require-tests, check-docs-hygiene/check-pr-hygiene/check-module-size (repo hygiene gates). verifier=ceiling — the agent's self-judgement never substitutes for it.",
   "author": {
     "name": "paulkim-lansik"

--- a/tools/loop-engine/bin/ac-verify.sh
+++ b/tools/loop-engine/bin/ac-verify.sh
@@ -26,8 +26,9 @@
 #   AC: <description> | verify: <command> | artifacts: <paths> | expect: <substring>
 #   - AC: <description> | verify: <command>
 #
-# Only `AC: <description>` is required. `verify:`, `artifacts:`, and `expect:` are each optional,
-# may appear in any combination, and in any order after the description — each field is
+# Only `AC: <description>` is required. `verify:`, `artifacts:`, and `expect:` are each optional
+# and may appear in any order after the description. One combination is rejected: `expect:` alone,
+# with neither `verify:` nor `artifacts:`, has nothing to search (see expect: below). Each field is
 # separated from its neighbours by ` | ` (space-pipe-space). An AC line with none of the three
 # optional fields is a legitimate, human-readable-only acceptance criterion: it counts as
 # `skipped` in the aggregate, not as a failure in itself.
@@ -47,9 +48,19 @@
 #                ac-verify.sh itself runs from (NOT the plan file's directory — verify commands
 #                and artifacts are expected relative to the repo/worktree root, same as verify
 #                commands already are).
-#   - expect:    the per-AC log (verdict-run.sh's untruncated LOG output for that AC; empty if
-#                the AC has no verify: field) must contain this LITERAL substring (`grep -F`, not
-#                a regex).
+#   - expect:    a LITERAL substring (`grep -F`, not a regex) that must be found in the AC's
+#                corpus. Which corpus depends on what else the AC declares (issue #74):
+#                  verify: present         -> the per-AC log (verdict-run.sh's untruncated LOG
+#                                             output for that AC). Unchanged, and NOT widened to
+#                                             also cover artifacts when both are declared — an
+#                                             existing contract must keep meaning what it meant.
+#                  no verify:, artifacts:  -> the contents of those artifact files (`grep -rF`, so
+#                                             a directory artifact is searched recursively). A
+#                                             match in ANY listed artifact satisfies it.
+#                  neither                 -> a contract error: exit 2, not an AC failure. There is
+#                                             no corpus, so the check could never hold; reporting
+#                                             that as a violation invites weakening the AC instead
+#                                             of fixing the contract.
 # An AC is fully PASSED only if every field it declares independently passes. A field that isn't
 # present on that AC line is simply not checked (neither pass nor fail).
 #
@@ -332,6 +343,18 @@ while IFS= read -r line || [ -n "$line" ]; do
     fi
     contracted=$((contracted + 1))
 
+    # ---- issue #74: `expect:` needs a corpus to search. With `verify:` it is that command's log;
+    # without it, the `artifacts:` files themselves (below). With NEITHER, there is nothing to grep
+    # — pre-fix this greped an empty log and reported "expect substring not found", i.e. a contract
+    # that cannot hold reported as though the implementation were at fault. That is a contract
+    # error, not an AC violation, so it gets exit 2 like every other usage error here rather than
+    # exit 1 — the distinction matters because a "violation" invites weakening the AC until it
+    # passes, which is how a contract ends up checking nothing.
+    if [ -n "$expect_field" ] && [ -z "$verify_cmd" ] && [ -z "$artifacts_field" ]; then
+      echo "ac-verify.sh: AC #$idx (\"$desc\") declares expect: with neither verify: nor artifacts: — there is nothing for expect: to search. Give the AC a verify: command (expect: greps its output) or an artifacts: list (expect: greps those files)." >&2
+      exit 2
+    fi
+
     ac_log="$LOGSUBDIR/ac-$idx.log"
     reasons=()
 
@@ -387,9 +410,29 @@ while IFS= read -r line || [ -n "$line" ]; do
     fi
 
     if [ -n "$expect_field" ]; then
-      if ! grep -qF -- "$expect_field" "$ac_log" 2>/dev/null; then
-        reasons+=("expect substring not found: \"$expect_field\"")
+      expect_found=0
+      if [ -n "$verify_cmd" ]; then
+        # verify: present — its log is the corpus, unchanged. Deliberately NOT widened to also
+        # search the artifacts when both are declared: that would quietly make an existing
+        # contract easier to satisfy, and every contract that passes today must keep meaning
+        # exactly what it meant. Widening only happens where the corpus was previously empty.
+        grep -qF -- "$expect_field" "$ac_log" 2>/dev/null && expect_found=1
+      else
+        # No verify: — the declared artifacts are the corpus (issue #74). A match in ANY of them
+        # satisfies expect:. Paths that don't exist are skipped here rather than erroring: the
+        # artifacts check above already produced a "missing artifact(s)" reason for them, and an
+        # AC carrying both reasons reports both.
+        IFS=',' read -ra epaths <<< "$artifacts_field"
+        if [ "${#epaths[@]}" -gt 0 ]; then
+          for ep in "${epaths[@]}"; do
+            ept="$(trim "$ep")"
+            [ -z "$ept" ] && continue
+            [ -e "$ept" ] || continue
+            if grep -rqF -- "$expect_field" "$ept" 2>/dev/null; then expect_found=1; break; fi
+          done
+        fi
       fi
+      [ "$expect_found" -eq 0 ] && reasons+=("expect substring not found: \"$expect_field\"")
     fi
 
     ac_ok=1

--- a/tools/loop-engine/test/ac-verify.test.sh
+++ b/tools/loop-engine/test/ac-verify.test.sh
@@ -270,6 +270,60 @@ STATE_CONTENT_R3="$(cat "$STATE_FILE_R")"
 printf '%s' "$STATE_CONTENT_R3" | grep -q '"verdict":"PASS"' && fail "(r3): the seeded PASS must NOT survive an extra-positional-argument usage error (the EXIT trap must already be armed during argument parsing), got: $STATE_CONTENT_R3"
 printf '%s' "$STATE_CONTENT_R3" | grep -q '"verdict":"FAIL"' || fail "(r3): expected verdict-state.json to be corrected to FAIL by the trap, got: $STATE_CONTENT_R3"
 
+# ==== (t) issue #74: `expect:` had exactly one corpus — the verify: log — so an `artifacts:` +
+# `expect:` contract with no verify: was STRUCTURALLY unpassable: it grepped an empty log and
+# reported "expect substring not found", which reads as an implementation defect rather than a
+# contract that cannot hold. The pressure that creates is the dangerous direction: drop the
+# `expect:` to make the AC pass, and the contract quietly checks nothing.
+#
+# Fixed semantics, in precedence order:
+#   verify: present            -> expect greps the verify log (UNCHANGED — nothing that passed before changes)
+#   no verify:, artifacts:     -> expect greps the artifact files' contents (the natural reading)
+#   neither                    -> usage error, exit 2 (there is no corpus to search; not a violation)
+SUB="$DIR/t"; mkdir -p "$SUB"; cd "$SUB" || fail "cd t"
+
+# ---- (t1) artifacts: + expect:, no verify: — substring present in the artifact -> PASS ----
+printf 'alpha\nfork appears here\nomega\n' > doc.md
+printf -- '- AC: the doc states the fork rule | artifacts: doc.md | expect: fork\n' > plan-t1.md
+OUT_T1="$(run_ac_verify plan-t1.md .loop-t1 2>&1)"; CODE_T1=$?
+[ "$CODE_T1" -eq 0 ] || fail "(t1): artifacts+expect with no verify: must search the ARTIFACT, not an empty log — expected exit 0, got $CODE_T1: $OUT_T1"
+printf '%s' "$OUT_T1" | grep -qE '^SUMMARY: passed=1 failed=0 skipped=0 ' || fail "(t1): expected passed=1: $OUT_T1"
+
+# ---- (t2) same shape, substring genuinely absent from the artifact -> FAIL (still fails closed) ----
+printf -- '- AC: the doc states the fork rule | artifacts: doc.md | expect: nowhere-in-this-file\n' > plan-t2.md
+OUT_T2="$(run_ac_verify plan-t2.md .loop-t2 2>&1)"; CODE_T2=$?
+[ "$CODE_T2" -eq 1 ] || fail "(t2): a substring genuinely absent from the artifact must still FAIL, got $CODE_T2: $OUT_T2"
+printf '%s' "$OUT_T2" | grep -q '^FAIL: AC "the doc states the fork rule":.*expect substring not found' || fail "(t2): expected the expect reason to name the missing substring: $OUT_T2"
+
+# ---- (t3) expect: with NEITHER verify: nor artifacts: -> usage error (exit 2), not a violation ----
+printf -- '- AC: nothing to search | expect: something\n' > plan-t3.md
+OUT_T3="$(run_ac_verify plan-t3.md .loop-t3 2>&1)"; CODE_T3=$?
+[ "$CODE_T3" -eq 2 ] || fail "(t3): expect: with no verify: and no artifacts: has no corpus to search — that is a contract error (exit 2), not an AC violation (exit 1); got $CODE_T3: $OUT_T3"
+printf '%s' "$OUT_T3" | grep -q 'expect:' || fail "(t3): the error must name the offending field: $OUT_T3"
+printf '%s' "$OUT_T3" | grep -q '^FAIL: ' && fail "(t3): a usage error must NOT be reported as an AC violation line: $OUT_T3"
+
+# ---- (t4) verify: present -> the verify log stays the corpus. A substring that appears in the
+# artifact but NOT in the verify output must still FAIL: this fix widens where expect can look
+# only when there was no corpus at all, it never quietly makes an existing contract easier. ----
+printf -- '- AC: verify log is still the corpus | verify: echo unrelated-output | artifacts: doc.md | expect: fork\n' > plan-t4.md
+OUT_T4="$(run_ac_verify plan-t4.md .loop-t4 2>&1)"; CODE_T4=$?
+[ "$CODE_T4" -eq 1 ] || fail "(t4): with verify: present, expect must still grep the verify log only (the artifact contains 'fork', the log does not) — expected exit 1, got $CODE_T4: $OUT_T4"
+printf '%s' "$OUT_T4" | grep -q 'expect substring not found' || fail "(t4): expected the expect reason: $OUT_T4"
+
+# ---- (t5) several artifacts: a match in any one of them satisfies expect ----
+printf 'nothing here\n' > first.md
+printf 'the needle is in the second file\n' > second.md
+printf -- '- AC: any artifact may carry it | artifacts: first.md, second.md | expect: needle\n' > plan-t5.md
+OUT_T5="$(run_ac_verify plan-t5.md .loop-t5 2>&1)"; CODE_T5=$?
+[ "$CODE_T5" -eq 0 ] || fail "(t5): a match in any listed artifact must satisfy expect, got $CODE_T5: $OUT_T5"
+
+# ---- (t6) a missing artifact still fails on its own terms, and expect is reported honestly
+# alongside it rather than being silently skipped ----
+printf -- '- AC: artifact gone | artifacts: absent.md | expect: anything\n' > plan-t6.md
+OUT_T6="$(run_ac_verify plan-t6.md .loop-t6 2>&1)"; CODE_T6=$?
+[ "$CODE_T6" -eq 1 ] || fail "(t6): expected exit 1, got $CODE_T6: $OUT_T6"
+printf '%s' "$OUT_T6" | grep -q 'missing artifact(s): absent.md' || fail "(t6): expected the missing-artifact reason: $OUT_T6"
+
 cd "$ORIG_PWD" || true
 
 # ==== (s) FIX round-5 regression: --log-dir's LOG_DIR/LOOP_DIR coupling must be applied INLINE the

--- a/tools/loop-engine/test/loop-fix-protect.test.sh
+++ b/tools/loop-engine/test/loop-fix-protect.test.sh
@@ -548,7 +548,15 @@ if [ ! -f armed.marker ]; then
 fi
 EOF
 
-"$LOOPFIX" --verify 'sh fake-verify-fail.sh' --fix 'sh fake-fix-delay.sh' --protect 'guard-file.txt' --idle-timeout-sec 1 --max-iter 5 >/dev/null 2>&1
+# LOOP_PROTECT_GRACE_SEC is pinned here rather than left at its 1.5s default (issue #71). The
+# behaviour under test is the ORDERING — watchdog timeout (1s) shorter than the grace period, and a
+# mutation delayed (2s) past the watchdog — not the specific numbers. At the default the recheck
+# window closed ~0.5s after the mutation was due to land, so on a loaded machine the case flipped
+# red for reasons unrelated to the guard. That misattribution already happened once (PR #70 blamed
+# an unrelated new test), and the pressure it creates points at weakening this case — which is the
+# exact behaviour this file exists to prevent. Pinning grace to 5s keeps every ordering the case
+# proves (1 < 2 < 1+5) and buys ~5s of margin instead of ~0.5s.
+LOOP_PROTECT_GRACE_SEC=5 "$LOOPFIX" --verify 'sh fake-verify-fail.sh' --fix 'sh fake-fix-delay.sh' --protect 'guard-file.txt' --idle-timeout-sec 1 --max-iter 5 >/dev/null 2>&1
 code=$?
 [ "$code" -eq 3 ] || fail "case16: expected exit 3 (PROTECTED-VIOLATION) — a watchdog timeout shorter than the grace period must not let the mutation escape detection, got $code"
 grep -q "PROTECTED FILE MODIFIED" .loop/history.log || fail "case16: expected the PROTECTED FILE MODIFIED marker"

--- a/tools/loop-engine/test/verdict-mutation-guard.test.sh
+++ b/tools/loop-engine/test/verdict-mutation-guard.test.sh
@@ -10,6 +10,15 @@ VR="$HERE/../bin/verdict-run.sh"
 fail() { echo "FAIL: $1"; exit 1; }
 [ -x "$VR" ] || fail "verdict-run.sh not executable at $VR"
 
+# verdict-run.sh writes its state to ${LOOP_DIR:-.loop}/verdict-state.json (bin/verdict-run.sh:92).
+# These cases cd into the repo under test, so the state path is resolved the same way rather than
+# written as a bare `.loop/...` (issue #58 — a hardcoded `.loop` made the whole suite unrunnable
+# under a non-default LOOP_DIR, which is what ac-verify.sh exports when given --log-dir).
+# NOTE the deliberate exception below: case 3's `.gitignore` entry and its `.loop/scratch.log`
+# write stay literal — that case is about gitignore semantics, not about where state lands.
+LOOPD="${LOOP_DIR:-.loop}"
+STATE_JSON="$LOOPD/verdict-state.json"
+
 WORK="$(mktemp -d "${TMPDIR:-/tmp}/tmp.XXXXXXXX")" || fail "mktemp -d failed"
 trap 'rm -rf "$WORK"' EXIT
 
@@ -33,7 +42,7 @@ code=$?
 [ "$code" -eq 1 ] || fail "case1: expected exit 1 on mutation, got $code"
 printf '%s\n' "$out" | grep -q "VERDICT: FAIL" || fail "case1: expected VERDICT: FAIL"
 printf '%s\n' "$out" | grep -q "workspace mutated" || fail "case1: expected the mutation FAIL line"
-grep -q '"verdict":"FAIL"' .loop/verdict-state.json || fail "case1: verdict state must record FAIL (Stop-gate consistency)"
+grep -q '"verdict":"FAIL"' "$STATE_JSON" || fail "case1: verdict state must record FAIL (Stop-gate consistency)"
 
 # ── case 1b: 같은 repo에서 무변조 재실행 → 자체 산출물(.loop)로 오탐하지 않는다 ─────────────
 out="$("$VR" --guard-mutation -- sh -c 'true' 2>/dev/null)"
@@ -53,7 +62,14 @@ R="$WORK/r3"; mkrepo "$R"; cd "$R" || fail "cd r3"
 printf '.loop/\n' > .gitignore
 git add .gitignore
 git commit -qm ignore
-out="$("$VR" --guard-mutation -- sh -c 'echo log >> .loop/scratch.log' 2>/dev/null)"
+# `mkdir -p` is part of the command under test, not setup: this write only ever succeeded because
+# verdict-run.sh happened to create `.loop/` first (for its own default LOG target). Under a
+# non-default LOOP_DIR it doesn't, the append fails with "No such file or directory", and the case
+# goes red while appearing to say "the guard tripped on a gitignored write" — it was really saying
+# "the command failed". Creating the directory the case writes into removes that hidden dependency
+# and leaves the case proving only what it claims. (Both paths stay literal `.loop`: this case is
+# about gitignore semantics, and `.loop/` is what its .gitignore lists.)
+out="$("$VR" --guard-mutation -- sh -c 'mkdir -p .loop && echo log >> .loop/scratch.log' 2>/dev/null)"
 code=$?
 [ "$code" -eq 0 ] || fail "case3: gitignored writes must not trip the guard, got $code"
 printf '%s\n' "$out" | grep -q "VERDICT: PASS" || fail "case3: expected VERDICT: PASS"
@@ -109,7 +125,7 @@ n_blk="$(printf '%s\n' "$out" | grep -c '^=== VERDICT ===$')"
 printf '%s\n' "$out" | grep -q "VERDICT: FAIL" || fail "case8: expected VERDICT: FAIL"
 printf '%s\n' "$out" | grep -q "VERDICT: PASS" && fail "case8: the inner forged PASS block must not be re-emitted"
 printf '%s\n' "$out" | grep -q "workspace mutated" || fail "case8: expected the mutation FAIL line"
-grep -q '"verdict":"FAIL"' .loop/verdict-state.json || fail "case8: verdict state must record FAIL"
+grep -q '"verdict":"FAIL"' "$STATE_JSON" || fail "case8: verdict state must record FAIL"
 
 # ── case 9: loop-fix 배선 — --guard-mutation passthrough가 실제로 가드를 켠다(무음 가드-off
 #            회귀 방지: 플래그가 조용히 떨어지면 verify는 정상 동작하며 가드만 사라진다) ────────

--- a/tools/loop-engine/test/verdict-state-producer.test.sh
+++ b/tools/loop-engine/test/verdict-state-producer.test.sh
@@ -18,6 +18,20 @@ fail() { echo "FAIL: $1"; exit 1; }
 [ -x "$VERDICT_RUN" ] || fail "verdict-run.sh not found/executable at $VERDICT_RUN"
 [ -x "$LOOP_FIX" ] || fail "loop-fix.sh not found/executable at $LOOP_FIX"
 
+# verdict-run.sh writes its state to ${LOOP_DIR:-.loop}/verdict-state.json (bin/verdict-run.sh:92),
+# so these assertions resolve the same way instead of hardcoding `.loop` (issue #58). Hardcoding
+# made this suite unrunnable under a non-default LOOP_DIR — which is exactly what ac-verify.sh
+# exports when given --log-dir, so any plan whose AC ran this suite failed permanently for a reason
+# that had nothing to do with the code under test. A relative LOOP_DIR stays relative to the repo
+# under test; an absolute one is used as-is.
+LOOPD="${LOOP_DIR:-.loop}"
+state_file() {  # $1 = repo root
+  case "$LOOPD" in
+    /*) printf '%s/verdict-state.json' "$LOOPD" ;;
+    *)  printf '%s/%s/verdict-state.json' "$1" "$LOOPD" ;;
+  esac
+}
+
 WORK="$(mktemp -d "${TMPDIR:-/tmp}/tmp.XXXXXXXX")" || fail "mktemp -d failed"
 cleanup() { chmod -R u+w "$WORK" 2>/dev/null || true; rm -rf "$WORK"; }
 trap cleanup EXIT
@@ -34,11 +48,11 @@ state_field() { # $1=field → prints value (validates JSON while at it)
   node -e '
     const st = JSON.parse(require("fs").readFileSync(process.argv[1], "utf8"));
     process.stdout.write(String(st[process.argv[2]]));
-  ' "$REPO2/.loop/verdict-state.json" "$1"
+  ' "$(state_file "$REPO2")" "$1"
 }
 (cd "$REPO2" && "$VERDICT_RUN" -- true >/dev/null 2>&1)
 [ "$?" = "0" ] || fail "verdict-run -- true must exit 0"
-[ -f "$REPO2/.loop/verdict-state.json" ] || fail "verdict-run must write .loop/verdict-state.json"
+[ -f "$(state_file "$REPO2")" ] || fail "verdict-run must write \${LOOP_DIR:-.loop}/verdict-state.json (looked at $(state_file "$REPO2"))"
 [ "$(state_field verdict)" = "PASS" ] || fail "state verdict must be PASS after a passing run"
 [ "$(state_field sha)" = "$HEAD2" ] || fail "state sha must be the verified HEAD ($HEAD2), got $(state_field sha)"
 [ "$(state_field dirty)" = "false" ] || fail "state dirty must be false on a clean tree"
@@ -62,7 +76,7 @@ mkdir -p "$NOGIT"
 node -e '
   const st = JSON.parse(require("fs").readFileSync(process.argv[1], "utf8"));
   if (st.sha !== "unknown" || st.dirty !== true) { console.error(st); process.exit(1); }
-' "$NOGIT/.loop/verdict-state.json" || fail "non-git verdict state must record sha=unknown dirty=true (fail-closed input)"
+' "$(state_file "$NOGIT")" || fail "non-git verdict state must record sha=unknown dirty=true (fail-closed input)"
 # control chars in cmd must not corrupt the state JSON (review M5).
 rm -f "$REPO2/untracked.txt"
 (cd "$REPO2" && "$VERDICT_RUN" -- sh -c "$(printf 'true #\rCR')" >/dev/null 2>&1)

--- a/tools/loop-memory/.claude-plugin/plugin.json
+++ b/tools/loop-memory/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "loop-memory",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "pgvector semantic recall for verified dev-loop lessons (and, optionally, ADR/glossary/research knowledge). Opt-in: installs disabled by default — this is a database dependency, not core loop mechanics.",
   "author": {
     "name": "paulkim-lansik"
@@ -10,7 +10,7 @@
   "license": "MIT",
   "keywords": ["memory", "pgvector", "recall", "semantic-search", "lessons"],
   "defaultEnabled": false,
-  "dependencies": [{ "name": "loop-engine", "version": "^0.11.0" }],
+  "dependencies": [{ "name": "loop-engine", "version": "^0.12.0" }],
   "userConfig": {
     "openai_api_key": {
       "type": "string",

--- a/tools/ship-flow/.claude-plugin/plugin.json
+++ b/tools/ship-flow/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ship-flow",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Delivery-loop skills — land and release already-verified work through a repo's real gates. Tracker- and branch-model-agnostic: reads a consuming repo's own config instead of hardcoding one repo's setup.",
   "author": {
     "name": "paulkim-lansik"
@@ -10,6 +10,6 @@
   "license": "MIT",
   "keywords": ["delivery", "git-flow", "hotfix", "ship", "release"],
   "dependencies": [
-    { "name": "loop-engine", "version": "^0.11.0" }
+    { "name": "loop-engine", "version": "^0.12.0" }
   ]
 }

--- a/tools/ship-flow/skills/ship-feature/AC-CONTRACTS.md
+++ b/tools/ship-flow/skills/ship-feature/AC-CONTRACTS.md
@@ -14,8 +14,9 @@ AC: <description> | verify: <command> | artifacts: <path1>,<path2> | expect: <su
 ```
 
 - Only `AC: <description>` is required.
-- `verify:`, `artifacts:`, and `expect:` are each **optional**, may appear in **any combination**,
-  and in **any order**.
+- `verify:`, `artifacts:`, and `expect:` are each **optional** and may appear in **any order**.
+- One combination is rejected: **`expect:` alone**, with neither `verify:` nor `artifacts:`. It has
+  nothing to search, so `ac-verify.sh` reports it as a contract error (exit 2), not as a failing AC.
 - Fields are separated by ` | ` (space-pipe-space).
 - `artifacts:` paths are **comma-separated**, not space-separated — a path may itself contain
   spaces, so spaces cannot be the separator.
@@ -26,10 +27,28 @@ AC: <description> | verify: <command> | artifacts: <path1>,<path2> | expect: <su
 |---|---|
 | `verify:` | Runs the command as a subprocess; a zero exit code passes |
 | `artifacts:` | Checks each listed path exists after the run |
-| `expect:` | Checks the `verify:` command's output contains this substring |
+| `expect:` | Checks that this literal substring appears in the AC's corpus — see below |
 
 Each is a deterministic subprocess judgment, which is the point: the gate's result doesn't depend on
 the agent's own account of whether the feature works.
+
+**Which corpus `expect:` searches** depends on what else the AC declares:
+
+| The AC declares | `expect:` searches |
+|---|---|
+| `verify:` (with or without `artifacts:`) | the `verify:` command's output |
+| `artifacts:`, no `verify:` | the contents of those files (a directory is searched recursively; a match in **any** listed artifact satisfies it) |
+| neither | nothing — contract error, exit 2 |
+
+When both `verify:` and `artifacts:` are present, `expect:` searches the **output only**. That is
+deliberate: a contract you wrote against a command's output keeps meaning exactly that, and never
+starts passing because the substring happened to appear in a file.
+
+A documentation contract therefore reads naturally — no `verify:` needed:
+
+```
+AC: the skill states that forked entries are excluded from bulk backports | artifacts: skills/vendor-sync/SKILL.md | expect: fork
+```
 
 ## Examples
 


### PR DESCRIPTION
Closes #74, closes #58, closes #71.

## 무엇

세 이슈는 같은 결함군이다 — **게이트가 측정한 것과 다른 것을 보고한다.** 셋 다 그 거짓 판정이 "구현을 고쳐라"로 읽히고, 가장 싼 수리가 **검사를 약화시키는 방향**을 가리킨다는 점에서 같다.

| 이슈 | 게이트가 한 말 | 실제로 일어난 일 |
|---|---|---|
| **#74** | `expect substring not found` | 파일이 아니라 **빈 로그**를 grep했다 |
| **#58** | `58/60 passed` | 두 테스트가 `.loop`를 하드코딩해 계약과 다른 곳을 봤다 |
| **#71** | `case16: expected exit 3 … got 1` | 부하 때문에 재검사 창이 뮤테이션을 놓쳤다 |

## #74 — `expect:` 의 코퍼스를 계약에 맞춘다

`expect:`는 코퍼스가 하나뿐이었다: `verify:` 명령의 로그(`ac-verify.sh:50`). `verify:` 없이 `artifacts:` + `expect:`로 쓴 계약은 **빈 문자열**을 grep했고, 어떤 부분문자열도 찾을 수 없었다. PR #73에서 실제로 걸린 계약:

```
AC: `fork` 표시된 항목은 일괄 백포트 후보에서 제외된다고 스킬이 규정한다 | artifacts: tools/ship-flow/skills/vendor-sync/SKILL.md | expect: fork
```

그 파일에 `fork`는 **6번** 나온다.

**위험한 건 반대 방향이다.** "위반"으로 보고되면 가장 싼 수리는 `expect:`를 지우는 것이고, 그러면 계약이 조용히 아무것도 검사하지 않는다 — 이 레포의 게이트들이 존재하는 이유 그 자체다.

코퍼스를 AC가 선언한 것에서 고른다:

| AC가 선언한 것 | `expect:`가 검사하는 대상 |
|---|---|
| `verify:` (with/without `artifacts:`) | 그 명령의 출력 — **불변** |
| `artifacts:`, `verify:` 없음 | 그 파일들의 내용 (`grep -rF`, 디렉터리는 재귀, 하나만 맞아도 만족) |
| 둘 다 없음 | 없음 → **exit 2** (계약 오류, AC 실패 아님) |

**`verify:`가 있을 때 아티팩트로 확장하지 않는 건 의도다.** 지금 통과하는 계약은 지금과 똑같은 뜻을 유지해야 한다 — 확장은 코퍼스가 애초에 비어 있던 자리에서만 일어난다. 회귀 `t4`가 이걸 잠근다: 아티팩트엔 있고 로그엔 없는 문자열은 **여전히 FAIL**.

`exit 2` 선택은 이슈가 남긴 두 방향 중 하나를 고른 게 아니라 **둘 다** 취한 것이다 — 코퍼스가 있으면 검사하고, 아예 없으면 계약 오류. "조용한 실패"가 남는 경로가 없다.

회귀 6건 추가(`t1`~`t6`). RED 실측:

```
FAIL: (t1): artifacts+expect with no verify: must search the ARTIFACT, not an empty log — expected exit 0, got 1
```

## #58 — 셀프테스트가 `${LOOP_DIR:-.loop}`를 존중한다

`verdict-run.sh:92`가 `STATE_FILE="${LOOP_DIR:-.loop}/verdict-state.json"`인데, 두 테스트가 `.loop`를 하드코딩했다:

```
$ bash tools/loop-engine/test/run.sh                          → loop-engine selftest: 60/60 passed
$ LOOP_DIR=$(mktemp -d) bash tools/loop-engine/test/run.sh     → loop-engine selftest: 58/60 passed
```

`ac-verify.sh:175`가 `--log-dir`를 받으면 **정확히 그 `LOOP_DIR`을 export** 한다. 따라서

```
AC: ... | verify: bash tools/loop-engine/test/run.sh | expect: 60/60 passed
```

라고 쓴 계획은 구현이 완벽해도 영구 FAIL이었고, 실패 원인이 "테스트가 LOOP_DIR을 존중하지 않음"이라는 사실은 로그 네 겹 아래에 있었다.

이슈의 제안대로 **테스트 쪽을 고쳤다** — `ac-verify.sh`의 export는 의도된 결합이고, 하드코딩한 쪽이 계약보다 좁게 주장하고 있었다.

**고치는 김에 세 번째가 드러났다.** `verdict-mutation-guard` case3의 gitignored 쓰기는 `verdict-run.sh`가 자기 기본 LOG 때문에 `.loop/`를 **먼저 만들어 준 덕에만** 성공하고 있었다:

```
$ sh -c 'echo log >> .loop/scratch.log'
sh: .loop/scratch.log: No such file or directory
```

LOOP_DIR이 다른 곳이면 append가 죽고, 케이스는 *"gitignored 쓰기가 가드를 건드렸다"*는 얼굴로 빨강이 된다 — 실제로는 *"명령이 실패했다"* 였다. 케이스가 자기가 쓰는 디렉터리를 스스로 만들게 해서 그 숨은 의존을 없앴다. 증명하는 내용은 그대로다.

## #71 — case16의 여유를 ~0.5s → ~5s

case16은 1초 워치독과 2초 지연 뮤테이션을 경주시킨다. 기본 grace가 1.5s라 재검사 창은 뮤테이션 예정 시각 **직후**에 닫혔다.

**이번 라운드에서 실제로 다시 뒤집혔다** — 하필 #58 수정의 가치를 증명하는 바로 그 경로(계획 AC로 스위트를 돌리기)에서:

```
FAIL: case16: expected exit 3 (PROTECTED-VIOLATION) — a watchdog timeout shorter than the grace period must not let the mutation escape detection, got 1
```

그래서 별건이 아니라 **블로킹 의존**으로 보고 같이 잡았다: 그 경로가 불안정하면 #58을 고친 의미가 없다.

`LOOP_PROTECT_GRACE_SEC=5`를 케이스에 못박는다. 증명하는 순서관계는 전부 그대로다(**1 < 2 < 1+5**) — 워치독이 grace보다 짧다는 조건도 유지된다. 여유만 ~0.5s → ~5s. 비용 +4.6s(17.7s → 22.3s). 3회 연속 그린 실측: `22.32s` / `22.22s` / `22.95s`.

PR #70에서 같은 빨강을 "방금 추가한 테스트 탓"으로 오귀속했었다. 그 압력이 향하는 곳은 결국 이 케이스를 약화시키는 쪽이고, 그건 이 파일이 막으려는 행위 그 자체다 — **약화 없이 여유만** 늘린 이유다.

## 버전

**loop-engine 0.11.0 → 0.12.0 (minor)** — `expect:`가 없던 코퍼스를 얻었고 새 exit-2 경로가 생겼다. patch가 아니다.

#72에서 넣은 `plugin-dep-range.test.sh`가 범프 직후 정확히 제 일을 했다:

```
  VIOLATION: loop-memory declares loop-engine ^0.11.0, which excludes the shipped 0.12.0
  VIOLATION: ship-flow declares loop-engine ^0.11.0, which excludes the shipped 0.12.0
FAIL: 2 dependent(s) pin a range that excludes loop-engine 0.12.0 — a consumer would silently keep the old version
```

범위 갱신 후:

```
PASS: loop-memory's range ^0.12.0 admits loop-engine 0.12.0
PASS: ship-flow's range ^0.12.0 admits loop-engine 0.12.0
PASS: every dependent's range admits the shipped loop-engine 0.12.0 (2 checked)
```

ship-flow 0.9.1(AC-CONTRACTS.md 반영) · loop-memory 0.4.3(범위만).

## 검증

전체 스위트:

```
=== VERDICT ===
VERDICT: PASS
EXIT: 0
SUMMARY: passed=60 failed= skipped= duration_ms=106997
LOG: /Users/paul/dev/paul-loop-acv/.loop/last-run.log
=== END VERDICT ===
```

AC 계약 6건 — #58의 핵심 주장(비기본 LOOP_DIR)과 #74의 두 경로, #71의 protect 스위트를 각각 계약으로 걸었다:

```
=== VERDICT ===
VERDICT: PASS
EXIT: 0
SUMMARY: passed=6 failed=0 skipped=0 duration_ms=282268
LOG: /Users/paul/dev/paul-loop-acv/.loop/ac-verify.log
=== END VERDICT ===
```

이 6/6은 **load 16.60**에서 나왔다 — case16이 뒤집혔던 실행보다 높은 부하다.

## Decisions taken

- **#74를 두 방향 다 취했다** — 이슈는 "exit 2로 보고" 또는 "artifacts를 검사"를 선택지로 남겼다. 하나만 고르면 나머지 절반이 조용한 실패로 남는다: 코퍼스가 있는데 exit 2를 내면 여전히 못 쓰고, 코퍼스가 없는데 검사하려 들면 검사할 게 없다. 둘 다 취해야 "조용히 실패"가 사라진다.
- **`verify:` + `artifacts:` 동시 선언 시 로그만 검사** — 확장하는 쪽이 "더 관대해서" 나아 보이지만, 지금 통과하는 계약의 의미를 바꾼다. 회귀 t4로 잠갔다.
- **#71을 같은 PR에 포함** — 별건이지만 #58 수정의 검증 경로를 직접 막고 있었다. 이번 실행에서 재현된 그 실패가 근거다.
- **minor 범프 + 의존 캐스케이드** — patch로 눌러 캐스케이드를 피할 수 있었지만 새 코퍼스는 capability다. 캐스케이드 비용(버전 문자열 2 + 범위 2)이 낮고, #72 게이트가 그걸 보이게 만드는 게 원래 목적이다.
- **CHANGELOG 과거 항목 미수정** — 이전 PR과 같은 정책.

## 범위 밖 (별건으로 남김)

개발 머신 디스크가 `1.0Gi` 남았다(`docker builder prune`/`image prune` 회수량 `0B` — 더 나올 게 없다). 587Mi였을 때 스위트가 실제로 죽은 적이 있다. 이 PR의 코드와 무관하고 사용자 머신 정리라 손대지 않았다.


## Gate verdict

### Gate verdict — classify-risk (ADR-0061 · 3-tier)

| Field | Value |
|---|---|
| GATE | **REQUIRE** |
| TRACK | risky |
| FINAL | blast_radius=high reversibility=? cost=? |
| DEEP_GATES | (none) |
| PATHS | 11 |

**MATCHED**
- many-files (11 > 10) — broad change

**REASON**: reversibility is missing or unrecognised ("") → fail closed to human approval; cost is missing or unrecognised ("") → fail closed to human approval; blast_radius=high

<!-- gate-verdict: GATE=REQUIRE TRACK=risky blast_radius=high reversibility=? cost=? PATHS=11 STAGE=pr BASE=472d44e923f2 -->

민감 경로 룰이 매치된 게 아니라 **11파일(>10)** 이 fail-closed로 REQUIRE를 만들었다. 사람 승인을 받고 이 PR을 열었다.
