### PR TITLE
fix(loop-memory): 시맨틱 recall이 한 번도 동작한 적이 없었다 — 프롬프트 필드명 (#35)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -26,7 +26,7 @@
       "name": "loop-memory",
       "source": "./tools/loop-memory",
       "description": "pgvector semantic recall for verified dev-loop lessons (and, optionally, ADR/glossary/research knowledge). Opt-in / defaultEnabled:false — a database dependency, not core loop mechanics.",
-      "version": "0.4.3",
+      "version": "0.5.0",
       "defaultEnabled": false,
       "keywords": ["memory", "pgvector", "recall", "semantic-search", "lessons"]
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,72 @@ Explicit-version channel — see [README § Development status](README.md#develo
 not a SHA channel. Entries below `## loop-engine 0.2.0` and earlier predate the multi-plugin split
 and refer to `loop-engine` only (see the un-prefixed version numbers).
 
+## loop-memory 0.5.0
+
+**Semantic recall had never once run.** Not "rarely", not "since some regression" — never, in any
+session, since the hook existed.
+
+`recall-lessons.mjs` read the prompt from `input.user_input`. Claude Code's UserPromptSubmit payload
+does not have that field. Measured 2026-08-27 with a capture hook on a live session — the payload's
+keys are:
+
+```
+session_id, transcript_path, cwd, prompt_id, permission_mode, hook_event_name, prompt
+```
+
+So every firing read `undefined` → `''` → length 0 → `prompt too short` → exit 0. Fail-open turned a
+wrong field name into perfect silence.
+
+**The liveness ledger (added for issue #35) is what made this visible**, and it is worth stating what
+it took: 205 `memory.*` events in the consuming repo's `.loop/runs/`, of which
+
+```
+memory.recall     skipped    prompt_too_short       x176
+memory.graduate   synced     ok                     x29
+```
+
+176 firings, one reason, every one with `prompt_chars: 0` and `key: true`. A hook that fires and
+does nothing looks exactly like a hook that is working and finding nothing — until the ledger records
+*why* it did nothing, at which point 176 identical self-gates stop looking like user behaviour.
+Issue #35 asked "do these hooks ever fire?"; the answer is yes for both, and the instrumentation
+added to answer it immediately surfaced a worse question the issue had not asked.
+
+**Why no test caught it**: every recall test in this repo fed `user_input` itself. They agreed with
+the code's premise instead of checking it — the same false-green shape as loop-engine 0.12.1's
+`payload.cwd` (tests that build the payload can never prove the payload's shape). New cases now drive
+the hook with the real `prompt` field.
+
+### The fix
+
+- Read `input.prompt ?? input.user_input`. Both are kept because there really are two callers with
+  two shapes: Claude Code sends `prompt`; loop-engine's own `bin/context-budget.mjs` (O1b) spawns
+  this hook with `user_input`. They are separate plugins that version independently, so a skew is a
+  real state, not a hypothetical.
+- **New liveness reason `prompt_field_missing`**, distinct from `prompt_too_short`. This is the part
+  that matters more than the field name: "the field wasn't there" and "the user typed something
+  short" are different facts, and collapsing them is what let this hide for 176 firings. A rename
+  upstream now reads as `prompt_field_missing` in the ledger instead of as hundreds of two-character
+  prompts in a row.
+
+### A/B on one identical real payload
+
+```
+before (origin/main):  outcome=skipped  reason=prompt_too_short  prompt_chars=0
+after:                 outcome=error    reason=cli_failed        prompt_chars=38  cli_status=1
+```
+
+The `cli_failed` after the fix is a probe key against a stopped pgvector — i.e. the **next** gate.
+Before the fix, the key and the database were irrelevant, because execution never reached them.
+
+### Still owed
+
+An end-to-end recall — a real prompt matching a real graduated lesson and injecting it — needs an
+embedding key and a running pgvector, neither of which is currently configured in the consuming repo
+(`.env` has no `OPENAI_API_KEY`/`GEMINI_API_KEY`; `loop-memory-pg` has been `Exited` for four days).
+That observation was **unreachable** before this fix, so it stays owed rather than closed. Issue #35's
+"do the hooks fire" half is answered by the 205 ledger events; the "does it help a real session
+recall a real lesson" half needs that configuration to exist first.
+
 ## loop-engine 0.12.1
 
 Comments only — but they close issue #63, which was open on a load-bearing *assumption*.

--- a/tools/loop-memory/.claude-plugin/plugin.json
+++ b/tools/loop-memory/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "loop-memory",
-  "version": "0.4.3",
+  "version": "0.5.0",
   "description": "pgvector semantic recall for verified dev-loop lessons (and, optionally, ADR/glossary/research knowledge). Opt-in: installs disabled by default — this is a database dependency, not core loop mechanics.",
   "author": {
     "name": "paulkim-lansik"

--- a/tools/loop-memory/hooks/recall-lessons.mjs
+++ b/tools/loop-memory/hooks/recall-lessons.mjs
@@ -150,8 +150,27 @@ try {
   const input = readHookInput();
   sessionId = typeof input?.session_id === 'string' ? input.session_id : '';
   if (input === null) out('', 'stdin parse fail', 'skipped', 'stdin_parse_fail');
-  const prompt = String(input.user_input || '').trim();
+  // Two accepted field names, for two real callers — not an alias and its legacy form:
+  //   `prompt`     — Claude Code's UserPromptSubmit payload. MEASURED 2026-08-27 (issue #35): the
+  //                  payload's keys are session_id, transcript_path, cwd, prompt_id,
+  //                  permission_mode, hook_event_name, prompt. There is no `user_input` on it.
+  //   `user_input` — loop-engine's own bin/context-budget.mjs (O1b) spawns this hook with that shape.
+  //
+  // This hook read ONLY `user_input` until now, so every live firing saw '' and self-gated as "prompt
+  // too short" — 176 firings in the consuming repo's ledger, 176 × prompt_too_short, all with
+  // prompt_chars: 0 and key: true. Semantic recall had never once run. Fail-open turned a wrong field
+  // name into silence, and the tests agreed with it because they all fed `user_input` themselves.
+  //
+  // Hence the two reasons below rather than one. "The field wasn't there" and "the user typed
+  // something short" are different facts about different problems, and collapsing them is what let
+  // this hide: a rename upstream now reads as `prompt_field_missing` in the ledger instead of looking
+  // like a user who types two characters, hundreds of times in a row.
+  const hasPromptField =
+    typeof input.prompt === 'string' || typeof input.user_input === 'string';
+  const prompt = String(input.prompt ?? input.user_input ?? '').trim();
   live.prompt_chars = prompt.length; // length only — the prompt itself is never recorded
+  if (!hasPromptField)
+    out('', 'no recognised prompt field on the payload', 'skipped', 'prompt_field_missing');
   if (prompt.length < 8)
     out('', `prompt too short (${prompt.length})`, 'skipped', 'prompt_too_short');
 

--- a/tools/loop-memory/test/hooks-liveness.test.ts
+++ b/tools/loop-memory/test/hooks-liveness.test.ts
@@ -209,6 +209,51 @@ describe('recall liveness — the four states fail-open otherwise flattens into 
     expect(e.payload.prompt_chars).toBe(2);
   });
 
+  // ── issue #35: the prompt field. Claude Code's UserPromptSubmit payload carries the prompt as
+  // `prompt`; this hook read `user_input`, which the payload does not have. Every firing therefore
+  // saw an empty string, self-gated as "prompt too short", and exited 0 — indistinguishable from a
+  // user who typed something short. Measured in the consuming repo's run ledger: 176 firings,
+  // 176 × `prompt_too_short`, every one with `prompt_chars: 0` and `key: true`.
+  //
+  // These tests could not have caught it: every one of them fed `user_input`, i.e. they agreed with
+  // the code's wrong premise instead of checking it. `user_input` is kept as a second accepted field
+  // because loop-engine's own context-budget.mjs (O1b) spawns this hook with that shape — two real
+  // callers, two shapes, not a legacy alias.
+  it('reads the real UserPromptSubmit field (`prompt`), not just `user_input`', () => {
+    runRecall(
+      { GEMINI_API_KEY: 'k' },
+      { session_id: SESSION, hook_event_name: 'UserPromptSubmit', prompt: 'a prompt long enough to pass the length gate' },
+    );
+    const e = only('memory.recall');
+    expect(e.payload.prompt_chars).toBe('a prompt long enough to pass the length gate'.length);
+    expect(e.payload.reason).not.toBe('prompt_too_short');
+    expect(e.payload.reason).not.toBe('prompt_field_missing');
+  });
+
+  it('still reads `user_input` — context-budget.mjs spawns the hook with that shape', () => {
+    runRecall(
+      { GEMINI_API_KEY: 'k' },
+      { session_id: SESSION, user_input: 'a prompt long enough to pass the length gate' },
+    );
+    const e = only('memory.recall');
+    expect(e.payload.prompt_chars).toBe('a prompt long enough to pass the length gate'.length);
+    expect(e.payload.reason).not.toBe('prompt_too_short');
+  });
+
+  it('a payload carrying NO recognised prompt field is its own reason, not "too short"', () => {
+    // The whole point of the fix: if the field is ever renamed again, the ledger says so instead of
+    // looking like 176 short prompts in a row.
+    runRecall({ GEMINI_API_KEY: 'k' }, { session_id: SESSION, hook_event_name: 'UserPromptSubmit' });
+    const e = only('memory.recall');
+    expect(e.payload.reason).toBe('prompt_field_missing');
+    expect(e.payload.prompt_chars).toBe(0);
+  });
+
+  it('an empty-string prompt field is "too short", not "missing" — the field was there', () => {
+    runRecall({ GEMINI_API_KEY: 'k' }, { session_id: SESSION, prompt: '' });
+    expect(only('memory.recall').payload.reason).toBe('prompt_too_short');
+  });
+
   it('SELF-GATED (unparseable stdin) is recorded rather than lost', () => {
     runRecall({ GEMINI_API_KEY: 'k' }, 'not json at all');
     expect(only('memory.recall').payload.reason).toBe('stdin_parse_fail');


### PR DESCRIPTION
Refs #35 — 이슈의 "훅이 발동하는가" 절반은 답했고, "실제 recall이 실제 세션을 돕는가" 절반은 **여전히 열려 있다**(아래 "아직 못 닫은 것"). 그래서 `Closes`가 아니다.

## 발견

**시맨틱 recall은 한 번도 동작한 적이 없다.** "드물게"도 "어느 회귀 이후"도 아니고, 훅이 존재한 이래 **단 한 번도**.

`recall-lessons.mjs:153`이 프롬프트를 `input.user_input`에서 읽는다. Claude Code의 UserPromptSubmit payload에는 그 필드가 없다. 캡처 훅으로 실측한 payload 키:

```
keys            = ['session_id', 'transcript_path', 'cwd', 'prompt_id', 'permission_mode', 'hook_event_name', 'prompt']
has "user_input" = False
has "prompt"     = True
```

그래서 모든 발동이 `undefined` → `''` → 길이 0 → `prompt too short` → exit 0. **fail-open 계약이 틀린 필드명을 완벽한 침묵으로 바꿨다.**

## 이걸 드러낸 건 #35용으로 넣은 계측이다

소비 레포 `.loop/runs/`의 `memory.*` 이벤트 205건(2026-08-25 ~ 08-26):

```
=== type / outcome / reason ===
  memory.recall     skipped    prompt_too_short       x176
  memory.graduate   synced     ok                     x29
```

recall 176건 전부:

```
{"outcome": "skipped", "reason": "prompt_too_short", "key": true, "dotenv": true,
 "prompt_chars": 0, "lessons": {...}, "injected_chars": 0, "ms": 1}
```

`key: true`, `dotenv: true` — 설정은 멀쩡했다. `prompt_chars: 0`이 176번.

**발동하는데 아무것도 안 하는 훅은, *왜* 아무것도 안 했는지가 기록되기 전까지 "정상 동작 중이고 매치가 없을 뿐"과 겉모습이 같다.** #35는 "이 훅들이 발동은 하나?"를 물었고 답은 둘 다 예다 — 그리고 그 답을 내려고 넣은 계측이, 이슈가 묻지 않은 더 나쁜 문제를 즉시 드러냈다. 이게 liveness가 존재하는 이유의 실증이다.

## 어떤 테스트도 못 잡은 이유

이 레포의 recall 테스트가 **전부 `user_input`을 직접 먹였다**:

```
tools/loop-memory/test/hooks-dotenv.test.ts:77     user_input: 'a prompt long enough…'
tools/loop-memory/test/hooks-liveness.test.ts:94   user_input: 'a prompt long enough…'
tools/loop-memory/test/hooks-liveness.test.ts:206  { session_id: SESSION, user_input: 'hi' }
…
```

코드의 전제를 *검사*한 게 아니라 그 전제에 *동의*했다. loop-engine 0.12.1(#63)의 `payload.cwd`와 정확히 같은 false-green 모양이다 — **payload를 자기가 만드는 테스트는 payload의 모양을 증명할 수 없다.** 다만 #63은 전제가 맞았고 이번엔 틀렸다.

## 수정

- **`input.prompt ?? input.user_input`** — 둘 다 수용. 별칭과 그 레거시 형태가 아니라 **실제 호출자가 둘**이다: Claude Code는 `prompt`, loop-engine의 `bin/context-budget.mjs:229`(O1b 실주입 측정)는 `user_input`. 독립 버전 관리되는 별개 플러그인이라 버전 스큐는 가정이 아니라 실재하는 상태다.
- **새 liveness 이유 `prompt_field_missing`** — `prompt_too_short`와 분리. 필드명 수정보다 이쪽이 오래 간다: *"필드가 없었다"* 와 *"사용자가 짧게 썼다"* 는 서로 다른 문제에 대한 서로 다른 사실이고, **둘을 한 슬롯에 합친 게 176발동 동안 이게 숨은 이유다.** 앞으로 상류가 필드를 또 바꾸면 원장에 `prompt_field_missing`으로 찍힌다 — 두 글자짜리 프롬프트를 수백 번 친 사용자처럼 보이는 대신.

빈 문자열(`prompt: ''`)은 여전히 `prompt_too_short`다 — 필드는 있었으니까. 회귀 4건이 네 경우를 각각 잠근다.

## A/B — 동일한 실제 payload 하나

```
before (origin/main):  outcome=skipped  reason=prompt_too_short  prompt_chars=0
after:                 outcome=error    reason=cli_failed        prompt_chars=38  cli_status=1
```

수정 후의 `cli_failed`는 프로브 키 + 중지된 pgvector, 즉 **다음** 관문이다. 수정 전에는 키도 DB도 무의미했다 — 실행이 거기까지 간 적이 없다.

## 검증

```
 Test Files  11 passed (11)
      Tests  119 passed | 2 skipped (121)
```

```
=== VERDICT ===
VERDICT: PASS
EXIT: 0
SUMMARY: passed=60 failed= skipped= duration_ms=107420
LOG: /Users/paul/dev/paul-loop-35/.loop/last-run.log
=== END VERDICT ===
```

```
=== GATE ===
GATE: AUTO
DIMENSIONS: blast_radius=low reversibility=full cost=low
=== END GATE ===
```

RED 실측(수정 전 신규 테스트 2건 실패):

```
AssertionError: expected 'prompt_too_short' to be 'prompt_field_missing'
```

## 아직 못 닫은 것 (#35를 열어 두는 이유)

end-to-end recall — 실제 프롬프트가 실제 졸업 교훈과 매치돼 주입되는 것 — 은 임베딩 키와 기동 중인 pgvector가 필요하고, 지금 소비 레포엔 **둘 다 없다**:

- `.env`에 `OPENAI_API_KEY`/`GEMINI_API_KEY` 없음
- `loop-memory-pg` 컨테이너 `Exited (255) 4 days ago`

(원장의 176건은 `key: true`였으므로 8/25~26 시점엔 키가 있었다. 지금은 없다.)

**그 관측은 이 수정 전에는 도달 불가능했다** — 그래서 닫지 않고 남긴다. #35의 "훅이 발동하는가"는 205건의 원장 이벤트로 답이 됐고, "실제 세션의 recall을 돕는가"는 그 설정이 먼저 존재해야 측정할 수 있다.

## Decisions taken

- **`user_input` 수용을 유지** — 지우면 더 단순하지만 `context-budget.mjs`가 조용히 깨진다(정확히는 이제 `prompt_field_missing`으로 시끄럽게 깨진다). 크로스-플러그인 버전 스큐가 실재하므로 두 형태를 다 받는 게 맞다.
- **`prompt_field_missing`을 새로 만든다** — 기존 `prompt_too_short`에 흡수시킬 수도 있었지만, 그 흡수가 애초에 이 결함을 숨긴 메커니즘이다.
- **minor 범프(0.5.0)** — 새 reason 값은 원장 소비자가 매칭할 수 있는 표면이고, 동작 자체가 바뀐다. loop-memory에 의존하는 플러그인이 없어 캐스케이드 없음.
- **`Closes #35`를 쓰지 않는다** — 이슈가 요구한 L4("실제 recall 발동 관측")는 아직 증거가 없다. 절반만 답하고 닫으면 원장이 남긴 교훈을 그대로 되풀이하는 셈이다.
