### PR TITLE
fix(security): dotenv 로더에 allowlist — 레포가 임의 env를 심어 코드 실행하던 경로를 닫는다

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,21 +12,21 @@
       "name": "loop-engine",
       "source": "./tools/loop-engine",
       "description": "Core loop mechanics: verdict-run (machine-readable PASS/FAIL contract), loop-fix (closed verify->fix loop), lessons (verified-fix memory), classify-risk, require-tests, plugin-path (resolve sibling plugin install paths), check-docs-hygiene/check-pr-hygiene/check-module-size/check-skill-refs (repo hygiene gates). No framework opinions beyond \"the verifier is the ceiling, never the agent's self-report\".",
-      "version": "0.12.1",
+      "version": "0.13.0",
       "keywords": ["verifier", "tdd", "loop", "verdict", "lessons"]
     },
     {
       "name": "ship-flow",
       "source": "./tools/ship-flow",
       "description": "Delivery-loop skills — ship-feature (plan-to-PR autonomous loop), hotfix, retrospect, grill-with-docs (= grilling + domain-modeling), diagnosing-bugs, deps-audit, to-issues/to-prd, tdd, harness-maturity-audit, improve-codebase-architecture (built on codebase-design), resolving-merge-conflicts, wizard, to-questionnaire, ask-paul (skill router), wait-what, plus review agents and audit/research workflows — parameterized by a consuming repo's own tracker/branch-model config instead of hardcoded to one repo. dependencies: loop-engine.",
-      "version": "0.9.1",
+      "version": "0.9.2",
       "keywords": ["delivery", "git-flow", "hotfix", "ship", "release"]
     },
     {
       "name": "loop-memory",
       "source": "./tools/loop-memory",
       "description": "pgvector semantic recall for verified dev-loop lessons (and, optionally, ADR/glossary/research knowledge). Opt-in / defaultEnabled:false — a database dependency, not core loop mechanics.",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "defaultEnabled": false,
       "keywords": ["memory", "pgvector", "recall", "semantic-search", "lessons"]
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,65 @@ Explicit-version channel — see [README § Development status](README.md#develo
 not a SHA channel. Entries below `## loop-engine 0.2.0` and earlier predate the multi-plugin split
 and refer to `loop-engine` only (see the un-prefixed version numbers).
 
+## loop-engine 0.13.0 · loop-memory 0.6.0 · ship-flow 0.9.2 — SECURITY
+
+**Update if you use these plugins.** Opening an untrusted repository could run its code, with no user
+action. Fixed in these versions; every earlier version is affected.
+
+### What was wrong
+
+`load-dotenv.mjs` reads `.loop/.env` **out of the repository being worked on**, and what it fills is a
+process environment — `graduate-lessons.mjs` passes it to `spawnSync`, `loop-doctor-heartbeat.mjs`
+merges it into its own `process.env` before running `git`. Both hooks are wired to `SessionStart`.
+
+The loader checked only that a key *looked like* an identifier. It had no allowlist. So a repository
+could set **any** environment variable for a process on your machine, and the standard environment-based
+execution primitives (`NODE_OPTIONS`, `GIT_CONFIG_*`, and their equivalents for other interpreters and
+loaders) all reach one. Both hooks were confirmed to execute a repo-supplied payload on session start,
+before the user typed anything. A repo you merely open — reviewing a PR, trying someone's project,
+cloning to reproduce a bug — is not a repo you trust.
+
+`.loop/` being conventionally gitignored is not a mitigation: a hostile repo simply commits it.
+
+### The fix
+
+An **allowlist**, not a denylist. A denylist has to be complete forever; an allowlist has to be correct
+once. Seven keys are accepted, and the rule that decides membership is stated in the source: *a dotenv
+file supplies credentials and connection settings; it never changes behaviour and never turns a gate
+off.*
+
+- Accepted: `OPENAI_API_KEY`, `GEMINI_API_KEY`, `LOOP_MEMORY_SIGNING_KEY`, `LOOP_DATABASE_URL`,
+  `LOOP_EMBED_PROVIDER`, `LOOP_RECALL_MAX_DISTANCE`, `LOOP_KNOWLEDGE_MAX_DISTANCE`.
+- Deliberately absent: every `LOOP_*_OFF` / `LOOP_*_GATE_OFF` switch and `LOOP_SANITIZE_OFF` — a repo
+  must not be able to disable the stop gate, the worktree gate, or log redaction by shipping a file.
+  This closes a second, quieter hole in the same change. `LOOP_DOTENV_PATH` is absent too: a dotenv
+  file redirecting where dotenv files are read from is both a loop and a lever.
+- A **relative** `LOOP_DOTENV_PATH` now has to stay inside the project. It is ordinary session env,
+  which a repo-committed `.claude/settings.json` can set, so `../../..` used to walk the loader out of
+  the tree. An **absolute** path still works — that is a documented, supported configuration, and the
+  allowlist is what makes it uninteresting to point somewhere hostile.
+
+Behaviour that did not change: the file is still read, precedence is unchanged (an explicit export or
+userConfig value still wins), the worktree fallback still works, and a repo's `.env` may still hold its
+own unrelated application config — those keys are ignored rather than treated as an error.
+
+### The regression test
+
+`dotenv-allowlist.test.sh` (9 cases). Eight test the loader's filtering, which is where the fix lives.
+The ninth deliberately skips the unit level and asks the question the vulnerability actually asked: it
+runs the **real SessionStart hook** against a real hostile repo and checks whether the payload
+executed. A future refactor could keep the filter and still hand the environment to a child by another
+route; that case would still catch it.
+
+It also asserts that the hostile file was *read* before concluding the payload did not run — while
+investigating this, an inherited `LOOP_DOTENV_PATH` from the developer's own session pointed the loader
+elsewhere and produced a green that proved nothing.
+
+### Version note
+
+Minor, not patch, on all three: keys that previously loaded are now ignored. `plugin-dep-range.test.sh`
+required the two dependents' ranges to move to `^0.13.0` in the same change, as designed.
+
 ## loop-memory 0.5.0
 
 **Semantic recall had never once run.** Not "rarely", not "since some regression" — never, in any

--- a/tools/loop-engine/.claude-plugin/plugin.json
+++ b/tools/loop-engine/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "loop-engine",
-  "version": "0.12.1",
+  "version": "0.13.0",
   "description": "Core loop mechanics: verdict-run (machine-readable PASS/FAIL contract), loop-fix (closed verify->fix loop), lessons (verified-fix memory), classify-risk, require-tests, check-docs-hygiene/check-pr-hygiene/check-module-size (repo hygiene gates). verifier=ceiling — the agent's self-judgement never substitutes for it.",
   "author": {
     "name": "paulkim-lansik"

--- a/tools/loop-engine/lib/load-dotenv.mjs
+++ b/tools/loop-engine/lib/load-dotenv.mjs
@@ -16,15 +16,60 @@
 //      every worktree fails closed. No file is copied — the key stays untracked, in one place.
 //   3. Best-effort: any failure (missing file, unreadable, non-git, no git binary) leaves `target`
 //      untouched and returns null. A hook must never break a session over its own optional config.
+//   4. ALLOWLIST. Only the keys in `ALLOWED_KEYS` are ever copied into `target`. Everything else in
+//      the file is ignored, silently and by design.
+//
+// Why 4 exists — the threat model this loader sits in the middle of:
+//
+//   This file is READ FROM THE REPOSITORY BEING WORKED ON. `.loop/.env` is a path any repo can carry,
+//   and a repo you merely *open* is not a repo you trust: reviewing a pull request, trying someone
+//   else's project, or cloning to reproduce a bug all mean a hostile file can be sitting there before
+//   you type anything. What `target` then becomes is a process environment — `graduate-lessons.mjs`
+//   passes it as `spawnSync(..., { env })`, and `loop-doctor-heartbeat.mjs` merges it into its OWN
+//   `process.env` before running `git`. So without an allowlist this loader hands a repository the
+//   ability to set ANY environment variable for a child process, and both of those hooks are wired to
+//   `SessionStart` — i.e. it fires on opening the repo, with no user action at all.
+//
+//   That is remote code execution, not a theoretical weakness, and it was reproduced both ways before
+//   this allowlist was written: `NODE_OPTIONS=--require ./payload.cjs` (the spawned `node` runs the
+//   repo's file) and `GIT_CONFIG_COUNT`/`GIT_CONFIG_KEY_0=core.fsmonitor` (the `git` call runs the
+//   repo's program). Those two are examples, not the set — `BASH_ENV`, `LD_PRELOAD`, `PERL5OPT`,
+//   `DYLD_INSERT_LIBRARIES` and others reach the same place, which is exactly why this is an
+//   allowlist and not a denylist. A denylist has to be complete forever; an allowlist has to be
+//   correct once.
+//
+//   The allowlist's own rule, so future keys land on the right side of it: **a dotenv file supplies
+//   credentials and connection settings. It never changes behaviour and never turns a gate off.**
+//   That is why `LOOP_*_OFF` / `LOOP_*_GATE_OFF` / `LOOP_SANITIZE_OFF` are absent — a repo must not be
+//   able to disable the stop gate, the worktree gate, or log redaction by shipping a file. `LOOP_DOTENV_PATH`
+//   is absent too: a dotenv file redirecting where dotenv files are read from is a loop, and a lever.
 import { execFileSync } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
-import { basename, dirname, isAbsolute, resolve } from 'node:path';
+import { basename, dirname, isAbsolute, relative, resolve } from 'node:path';
 
 /** Repo-relative default. `.loop/` is loop-engine's own convention directory (it already holds
  * `.loop/lessons`) and is conventionally gitignored, so `.loop/.env` is the one path that is a
  * sensible guess for *any* consuming repo. Repos that keep the file elsewhere point the
  * `loop_dotenv_path` plugin option (env `LOOP_DOTENV_PATH`) at it. */
 export const DEFAULT_DOTENV_PATH = '.loop/.env';
+
+/** The only keys a dotenv file may set. See the threat model in this file's header for why this is an
+ * allowlist. Adding to it means answering one question: *would I let an untrusted repository set this
+ * for a process running on my machine?* Credentials and connection/tuning settings pass that; anything
+ * that switches behaviour off does not. */
+export const ALLOWED_KEYS = Object.freeze([
+  // credentials — the reason this loader exists at all
+  'OPENAI_API_KEY',
+  'GEMINI_API_KEY',
+  'LOOP_MEMORY_SIGNING_KEY',
+  // connection
+  'LOOP_DATABASE_URL',
+  'LOOP_EMBED_PROVIDER',
+  // recall tuning — numeric thresholds, no behaviour switch
+  'LOOP_RECALL_MAX_DISTANCE',
+  'LOOP_KNOWLEDGE_MAX_DISTANCE',
+]);
+const ALLOWED = new Set(ALLOWED_KEYS);
 
 /** Absolute path of the main worktree, via `git rev-parse --git-common-dir`. null if not a git repo,
  * git is missing/slow, or the common dir isn't a `.git` directory (i.e. nothing to fall back to). */
@@ -51,12 +96,25 @@ function mainWorktreeRoot(cwd) {
 export function resolveDotenvPath(projectDir, configured) {
   const rel = configured || DEFAULT_DOTENV_PATH;
   if (isAbsolute(rel)) return existsSync(rel) ? rel : null;
-  const local = resolve(projectDir, rel);
-  if (existsSync(local)) return local;
+  // A RELATIVE path stays inside the directory it is relative to. `LOOP_DOTENV_PATH` is ordinary
+  // session env, which a repo-committed `.claude/settings.json` can set — so without this, `../../..`
+  // walks the loader out of the project and into whatever it names. An ABSOLUTE path is left alone on
+  // purpose (documented in the plugin manifest: a repo may keep its key outside the tree), and the
+  // allowlist above is what keeps even that from being interesting to point somewhere hostile.
+  const local = contained(projectDir, rel);
+  if (local && existsSync(local)) return local;
   const mainRoot = mainWorktreeRoot(projectDir);
   if (!mainRoot) return null;
-  const fallback = resolve(mainRoot, rel);
-  return existsSync(fallback) ? fallback : null;
+  const fallback = contained(mainRoot, rel);
+  return fallback && existsSync(fallback) ? fallback : null;
+}
+
+/** `resolve(root, rel)` if the result is still under `root`, else null. Compares via `relative()`
+ * rather than `startsWith` — `/repo-evil` must not count as inside `/repo`. */
+function contained(root, rel) {
+  const abs = resolve(root, rel);
+  const r = relative(resolve(root), abs);
+  return r === '' || (!r.startsWith('..') && !isAbsolute(r)) ? abs : null;
 }
 
 /** Fills `target` with the `KEY=VALUE` lines of the resolved dotenv file, skipping keys already set.
@@ -75,7 +133,11 @@ export function loadDotenv(projectDir, configured, target = process.env) {
         .slice(0, eq)
         .replace(/^export\s+/, '')
         .trim(); // tolerate `export KEY=...`
-      if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key) || key in target) continue; // already set: file loses
+      // Shape check, then the allowlist (property 4 — see the header's threat model), then
+      // precedence. An ignored key is not an error: a repo's `.env` legitimately holds its own
+      // application config next to the one key this plugin wants, and refusing to start over that
+      // would be worse than ignoring it.
+      if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key) || !ALLOWED.has(key) || key in target) continue;
       let val = line.slice(eq + 1).trim();
       const q = val[0];
       if (q === '"' || q === "'") {

--- a/tools/loop-engine/test/dotenv-allowlist.test.sh
+++ b/tools/loop-engine/test/dotenv-allowlist.test.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+# load-dotenv.mjs reads a file OUT OF THE REPOSITORY BEING WORKED ON, and what it fills is a process
+# environment: graduate-lessons.mjs hands it to `spawnSync`, loop-doctor-heartbeat.mjs merges it into
+# its own `process.env` before running `git`. Both are wired to SessionStart. So "which keys may this
+# file set" is not a config question — it decides whether opening an untrusted repo runs its code.
+#
+# It did. Both of these were reproduced against the pre-fix loader:
+#   NODE_OPTIONS=--require ./payload.cjs                      -> the spawned `node` ran the repo's file
+#   GIT_CONFIG_COUNT/KEY_0=core.fsmonitor/VALUE_0=./payload.sh -> the `git` call ran the repo's program
+# and they are examples, not the set (BASH_ENV, LD_PRELOAD, PERL5OPT, DYLD_INSERT_LIBRARIES land in the
+# same place). Hence an allowlist: a denylist has to be complete forever, an allowlist has to be right
+# once.
+#
+# The last case is the one that matters most. Cases 1-8 test the loader's own filtering, which is
+# where the fix lives — but a future refactor could keep the filter and still hand the environment to
+# a child by another route. So case 9 skips the unit level entirely and asks the question the CVE
+# actually asked: run the real SessionStart hook against a real hostile repo, and see whether the
+# payload executed. That one cannot pass for the wrong reason.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+LOADER="$ROOT/tools/loop-engine/lib/load-dotenv.mjs"
+
+fail() { echo "FAIL: $1"; exit 1; }
+[ -f "$LOADER" ] || fail "load-dotenv.mjs not found at $LOADER"
+
+DIR="$(mktemp -d "${TMPDIR:-/tmp}/tmp.XXXXXXXX")" || fail "mktemp -d failed"
+trap 'rm -rf "$DIR"' EXIT
+
+# load <project-dir> [configured] -> prints the resulting keys, one per line, sorted
+load() {
+  node --input-type=module -e "
+    import { loadDotenv } from '$LOADER';
+    const target = {};
+    loadDotenv(process.argv[1], process.argv[2] || undefined, target);
+    process.stdout.write(Object.keys(target).sort().join('\n'));
+  " "$1" "${2:-}"
+}
+
+has_key() { printf '%s\n' "$1" | grep -qx "$2"; }
+
+# ==== 1-3) the exploit keys are dropped ====
+P="$DIR/hostile"; mkdir -p "$P/.loop"
+cat > "$P/.loop/.env" <<'ENV'
+OPENAI_API_KEY=sk-fake-passes-the-key-gate
+NODE_OPTIONS=--require ./payload.cjs
+GIT_CONFIG_COUNT=1
+GIT_CONFIG_KEY_0=core.fsmonitor
+GIT_CONFIG_VALUE_0=./payload.sh
+BASH_ENV=./payload.sh
+LD_PRELOAD=/tmp/evil.so
+PERL5OPT=-Mevil
+DYLD_INSERT_LIBRARIES=/tmp/evil.dylib
+ENV
+KEYS="$(load "$P")"
+for k in NODE_OPTIONS GIT_CONFIG_COUNT GIT_CONFIG_KEY_0 GIT_CONFIG_VALUE_0 BASH_ENV LD_PRELOAD PERL5OPT DYLD_INSERT_LIBRARIES; do
+  has_key "$KEYS" "$k" && fail "(1) '$k' from a repo's dotenv file reached the target env — this is the RCE primitive"
+done
+echo "PASS: code-execution env vars in a repo's dotenv file are dropped (8 checked)"
+
+# ==== 4) …while the key the loader exists for still loads ====
+has_key "$KEYS" OPENAI_API_KEY || fail "(4) the allowlist dropped OPENAI_API_KEY — the loader's whole purpose"
+echo "PASS: an allowed credential still loads from the same file"
+
+# ==== 5) gate-disabling switches are not settable by a repo ====
+P2="$DIR/gates"; mkdir -p "$P2/.loop"
+cat > "$P2/.loop/.env" <<'ENV'
+LOOP_STOP_GATE_OFF=1
+LOOP_SANITIZE_OFF=1
+LOOP_WORKTREE_SESSION_GATE_OFF=1
+LOOP_VERIFY_PIPE_GATE_OFF=1
+LOOP_RECALL_OFF=1
+LOOP_LIVENESS_OFF=1
+LOOP_DOTENV_PATH=../../elsewhere/.env
+ENV
+KEYS2="$(load "$P2")"
+for k in LOOP_STOP_GATE_OFF LOOP_SANITIZE_OFF LOOP_WORKTREE_SESSION_GATE_OFF LOOP_VERIFY_PIPE_GATE_OFF LOOP_RECALL_OFF LOOP_LIVENESS_OFF LOOP_DOTENV_PATH; do
+  has_key "$KEYS2" "$k" && fail "(5) '$k' was settable from a repo's dotenv file — a repo could disable its own gate or redaction"
+done
+[ -z "$KEYS2" ] || fail "(5) expected nothing to load from a file of switches, got: $KEYS2"
+echo "PASS: a repo cannot turn a gate, the stop verdict, or log redaction off via its dotenv file"
+
+# ==== 6) every remaining allowlist entry loads (the list is not accidentally empty/typo'd) ====
+P3="$DIR/allowed"; mkdir -p "$P3/.loop"
+cat > "$P3/.loop/.env" <<'ENV'
+GEMINI_API_KEY=g
+LOOP_MEMORY_SIGNING_KEY=s
+LOOP_DATABASE_URL=postgres://localhost/x
+LOOP_EMBED_PROVIDER=openai
+LOOP_RECALL_MAX_DISTANCE=0.5
+LOOP_KNOWLEDGE_MAX_DISTANCE=0.5
+ENV
+KEYS3="$(load "$P3")"
+for k in GEMINI_API_KEY LOOP_MEMORY_SIGNING_KEY LOOP_DATABASE_URL LOOP_EMBED_PROVIDER LOOP_RECALL_MAX_DISTANCE LOOP_KNOWLEDGE_MAX_DISTANCE; do
+  has_key "$KEYS3" "$k" || fail "(6) allowlisted key '$k' did not load — the allowlist is over-tight"
+done
+echo "PASS: all 7 allowlisted keys load (6 here + OPENAI_API_KEY above)"
+
+# ==== 7) a relative configured path cannot walk out of the project ====
+# LOOP_DOTENV_PATH is ordinary session env, which a repo-committed .claude/settings.json can set.
+mkdir -p "$DIR/outside"
+printf 'OPENAI_API_KEY=sk-from-outside\n' > "$DIR/outside/.env"
+P4="$DIR/proj4"; mkdir -p "$P4"
+ESCAPED="$(load "$P4" '../outside/.env')"
+[ -z "$ESCAPED" ] || fail "(7) a relative dotenv path escaped the project directory and loaded: $ESCAPED"
+echo "PASS: a relative dotenv path that escapes the project is refused"
+
+# ==== 8) …but an absolute path still works (documented: a repo may keep its key outside the tree) ====
+ABS="$(load "$P4" "$DIR/outside/.env")"
+has_key "$ABS" OPENAI_API_KEY || fail "(8) an absolute dotenv path stopped working — that is a supported configuration"
+echo "PASS: an absolute dotenv path still loads (unchanged, documented behaviour)"
+
+# ==== 9) END TO END: the real SessionStart hook, a real hostile repo, does the payload run? ====
+# Deliberately not a unit test of the loader. This is the question the vulnerability asked.
+HOOK="$ROOT/tools/loop-memory/hooks/graduate-lessons.mjs"
+if [ ! -f "$HOOK" ]; then
+  fail "(9) graduate-lessons.mjs not found — this case must not be skipped silently; it is the only one that proves the fix at the level the attack happens"
+fi
+V="$DIR/victim"; mkdir -p "$V/.loop"
+cat > "$V/.loop/.env" <<ENV
+OPENAI_API_KEY=sk-fake-passes-the-key-gate
+NODE_OPTIONS=--require ./payload.cjs
+ENV
+cat > "$V/payload.cjs" <<JS
+require('node:fs').writeFileSync(require('node:path').join(__dirname, 'EXECUTED'), 'x');
+JS
+# Cleared explicitly: an inherited LOOP_DOTENV_PATH (or its CLAUDE_PLUGIN_OPTION_* bridge) from the
+# developer's own session would point the loader somewhere else and this case would pass without ever
+# reading the hostile file — a false green that actually happened while investigating this bug.
+env -u LOOP_DOTENV_PATH -u CLAUDE_PLUGIN_OPTION_LOOP_DOTENV_PATH \
+    -u NODE_OPTIONS -u OPENAI_API_KEY -u GEMINI_API_KEY \
+    -u CLAUDE_PLUGIN_OPTION_OPENAI_API_KEY -u CLAUDE_PLUGIN_OPTION_GEMINI_API_KEY \
+    CLAUDE_PROJECT_DIR="$V" CLAUDE_PLUGIN_ROOT="$ROOT/tools/loop-memory" CLAUDE_PLUGIN_DATA="$V" \
+    LOOP_GRADUATE_DEBUG=1 \
+    node "$HOOK" --event SessionStart >/dev/null 2>&1
+
+[ -f "$V/EXECUTED" ] && fail "(9) RCE: the SessionStart hook executed a payload named only by the repo's own .loop/.env"
+# Guard against the case passing because the file was never read at all (see the env note above).
+grep -q 'dotenv: loaded' "$V/graduate-debug.log" 2>/dev/null \
+  || fail "(9) the hostile dotenv file was never read, so this case proved nothing — check the env isolation above"
+echo "PASS: end to end — a hostile repo's .loop/.env is read, and its NODE_OPTIONS payload does not run"
+
+echo "PASS: load-dotenv allowlist — repo-controlled dotenv files cannot set code-execution env vars or disable gates, relative paths stay in the project, and the real SessionStart hook survives the live exploit"
+exit 0

--- a/tools/loop-memory/.claude-plugin/plugin.json
+++ b/tools/loop-memory/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "loop-memory",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "pgvector semantic recall for verified dev-loop lessons (and, optionally, ADR/glossary/research knowledge). Opt-in: installs disabled by default — this is a database dependency, not core loop mechanics.",
   "author": {
     "name": "paulkim-lansik"
@@ -10,7 +10,7 @@
   "license": "MIT",
   "keywords": ["memory", "pgvector", "recall", "semantic-search", "lessons"],
   "defaultEnabled": false,
-  "dependencies": [{ "name": "loop-engine", "version": "^0.12.0" }],
+  "dependencies": [{ "name": "loop-engine", "version": "^0.13.0" }],
   "userConfig": {
     "openai_api_key": {
       "type": "string",

--- a/tools/loop-memory/hooks/lib/load-dotenv.mjs
+++ b/tools/loop-memory/hooks/lib/load-dotenv.mjs
@@ -16,15 +16,60 @@
 //      every worktree fails closed. No file is copied — the key stays untracked, in one place.
 //   3. Best-effort: any failure (missing file, unreadable, non-git, no git binary) leaves `target`
 //      untouched and returns null. A hook must never break a session over its own optional config.
+//   4. ALLOWLIST. Only the keys in `ALLOWED_KEYS` are ever copied into `target`. Everything else in
+//      the file is ignored, silently and by design.
+//
+// Why 4 exists — the threat model this loader sits in the middle of:
+//
+//   This file is READ FROM THE REPOSITORY BEING WORKED ON. `.loop/.env` is a path any repo can carry,
+//   and a repo you merely *open* is not a repo you trust: reviewing a pull request, trying someone
+//   else's project, or cloning to reproduce a bug all mean a hostile file can be sitting there before
+//   you type anything. What `target` then becomes is a process environment — `graduate-lessons.mjs`
+//   passes it as `spawnSync(..., { env })`, and `loop-doctor-heartbeat.mjs` merges it into its OWN
+//   `process.env` before running `git`. So without an allowlist this loader hands a repository the
+//   ability to set ANY environment variable for a child process, and both of those hooks are wired to
+//   `SessionStart` — i.e. it fires on opening the repo, with no user action at all.
+//
+//   That is remote code execution, not a theoretical weakness, and it was reproduced both ways before
+//   this allowlist was written: `NODE_OPTIONS=--require ./payload.cjs` (the spawned `node` runs the
+//   repo's file) and `GIT_CONFIG_COUNT`/`GIT_CONFIG_KEY_0=core.fsmonitor` (the `git` call runs the
+//   repo's program). Those two are examples, not the set — `BASH_ENV`, `LD_PRELOAD`, `PERL5OPT`,
+//   `DYLD_INSERT_LIBRARIES` and others reach the same place, which is exactly why this is an
+//   allowlist and not a denylist. A denylist has to be complete forever; an allowlist has to be
+//   correct once.
+//
+//   The allowlist's own rule, so future keys land on the right side of it: **a dotenv file supplies
+//   credentials and connection settings. It never changes behaviour and never turns a gate off.**
+//   That is why `LOOP_*_OFF` / `LOOP_*_GATE_OFF` / `LOOP_SANITIZE_OFF` are absent — a repo must not be
+//   able to disable the stop gate, the worktree gate, or log redaction by shipping a file. `LOOP_DOTENV_PATH`
+//   is absent too: a dotenv file redirecting where dotenv files are read from is a loop, and a lever.
 import { execFileSync } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
-import { basename, dirname, isAbsolute, resolve } from 'node:path';
+import { basename, dirname, isAbsolute, relative, resolve } from 'node:path';
 
 /** Repo-relative default. `.loop/` is loop-engine's own convention directory (it already holds
  * `.loop/lessons`) and is conventionally gitignored, so `.loop/.env` is the one path that is a
  * sensible guess for *any* consuming repo. Repos that keep the file elsewhere point the
  * `loop_dotenv_path` plugin option (env `LOOP_DOTENV_PATH`) at it. */
 export const DEFAULT_DOTENV_PATH = '.loop/.env';
+
+/** The only keys a dotenv file may set. See the threat model in this file's header for why this is an
+ * allowlist. Adding to it means answering one question: *would I let an untrusted repository set this
+ * for a process running on my machine?* Credentials and connection/tuning settings pass that; anything
+ * that switches behaviour off does not. */
+export const ALLOWED_KEYS = Object.freeze([
+  // credentials — the reason this loader exists at all
+  'OPENAI_API_KEY',
+  'GEMINI_API_KEY',
+  'LOOP_MEMORY_SIGNING_KEY',
+  // connection
+  'LOOP_DATABASE_URL',
+  'LOOP_EMBED_PROVIDER',
+  // recall tuning — numeric thresholds, no behaviour switch
+  'LOOP_RECALL_MAX_DISTANCE',
+  'LOOP_KNOWLEDGE_MAX_DISTANCE',
+]);
+const ALLOWED = new Set(ALLOWED_KEYS);
 
 /** Absolute path of the main worktree, via `git rev-parse --git-common-dir`. null if not a git repo,
  * git is missing/slow, or the common dir isn't a `.git` directory (i.e. nothing to fall back to). */
@@ -51,12 +96,25 @@ function mainWorktreeRoot(cwd) {
 export function resolveDotenvPath(projectDir, configured) {
   const rel = configured || DEFAULT_DOTENV_PATH;
   if (isAbsolute(rel)) return existsSync(rel) ? rel : null;
-  const local = resolve(projectDir, rel);
-  if (existsSync(local)) return local;
+  // A RELATIVE path stays inside the directory it is relative to. `LOOP_DOTENV_PATH` is ordinary
+  // session env, which a repo-committed `.claude/settings.json` can set — so without this, `../../..`
+  // walks the loader out of the project and into whatever it names. An ABSOLUTE path is left alone on
+  // purpose (documented in the plugin manifest: a repo may keep its key outside the tree), and the
+  // allowlist above is what keeps even that from being interesting to point somewhere hostile.
+  const local = contained(projectDir, rel);
+  if (local && existsSync(local)) return local;
   const mainRoot = mainWorktreeRoot(projectDir);
   if (!mainRoot) return null;
-  const fallback = resolve(mainRoot, rel);
-  return existsSync(fallback) ? fallback : null;
+  const fallback = contained(mainRoot, rel);
+  return fallback && existsSync(fallback) ? fallback : null;
+}
+
+/** `resolve(root, rel)` if the result is still under `root`, else null. Compares via `relative()`
+ * rather than `startsWith` — `/repo-evil` must not count as inside `/repo`. */
+function contained(root, rel) {
+  const abs = resolve(root, rel);
+  const r = relative(resolve(root), abs);
+  return r === '' || (!r.startsWith('..') && !isAbsolute(r)) ? abs : null;
 }
 
 /** Fills `target` with the `KEY=VALUE` lines of the resolved dotenv file, skipping keys already set.
@@ -75,7 +133,11 @@ export function loadDotenv(projectDir, configured, target = process.env) {
         .slice(0, eq)
         .replace(/^export\s+/, '')
         .trim(); // tolerate `export KEY=...`
-      if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key) || key in target) continue; // already set: file loses
+      // Shape check, then the allowlist (property 4 — see the header's threat model), then
+      // precedence. An ignored key is not an error: a repo's `.env` legitimately holds its own
+      // application config next to the one key this plugin wants, and refusing to start over that
+      // would be worse than ignoring it.
+      if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key) || !ALLOWED.has(key) || key in target) continue;
       let val = line.slice(eq + 1).trim();
       const q = val[0];
       if (q === '"' || q === "'") {

--- a/tools/ship-flow/.claude-plugin/plugin.json
+++ b/tools/ship-flow/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ship-flow",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "Delivery-loop skills — land and release already-verified work through a repo's real gates. Tracker- and branch-model-agnostic: reads a consuming repo's own config instead of hardcoding one repo's setup.",
   "author": {
     "name": "paulkim-lansik"
@@ -10,6 +10,6 @@
   "license": "MIT",
   "keywords": ["delivery", "git-flow", "hotfix", "ship", "release"],
   "dependencies": [
-    { "name": "loop-engine", "version": "^0.12.0" }
+    { "name": "loop-engine", "version": "^0.13.0" }
   ]
 }


### PR DESCRIPTION
> **보안 수정.** 이 PR 이전의 모든 버전이 영향을 받습니다. loop-engine 0.13.0 / loop-memory 0.6.0 / ship-flow 0.9.2로 올리세요.

## 무엇이 잘못돼 있었나

`load-dotenv.mjs`는 `.loop/.env`를 **작업 대상 레포에서** 읽습니다. 그리고 그 결과물이 채우는 것은 프로세스 환경입니다 — `graduate-lessons.mjs`는 `spawnSync(..., { env })`로 넘기고, `loop-doctor-heartbeat.mjs`는 자기 `process.env`에 병합한 뒤 `git`을 실행합니다. **두 훅 다 `SessionStart`에 걸려 있습니다.**

로더의 키 검사는 `/^[A-Za-z_][A-Za-z0-9_]*$/` 하나, 즉 "식별자 모양인가"뿐이었습니다. allowlist도 denylist도 없었습니다. 그래서 레포가 이 머신의 프로세스에 **아무 환경변수나** 설정할 수 있었고, 환경 기반 실행 프리미티브(`NODE_OPTIONS`, `GIT_CONFIG_*`, 그리고 다른 인터프리터·동적 로더의 등가물들)는 전부 거기로 닿습니다.

두 훅 모두 **사용자가 아무것도 입력하기 전에, 세션 시작만으로** 레포가 제공한 페이로드를 실행하는 것이 확인됐습니다.

**"여는 것"만으로 충분합니다** — PR을 리뷰하려고 브랜치를 체크아웃하거나, 남의 프로젝트를 시험하거나, 버그 재현하려고 clone하는 것 전부. 열었다고 신뢰한 건 아닙니다. `.loop/`이 관례상 gitignore라는 것도 완화가 아닙니다 — 적대적 레포는 그냥 커밋합니다.

## 수정

**denylist가 아니라 allowlist입니다.** denylist는 영원히 완전해야 하고, allowlist는 한 번만 옳으면 됩니다.

7개 키를 받습니다. 소속을 판단하는 규칙을 소스에 명시했습니다 — *dotenv 파일은 자격증명과 접속 설정을 공급한다. 동작을 바꾸지 않고, 게이트를 끄지 않는다.*

| | 키 |
|---|---|
| 자격증명 | `OPENAI_API_KEY` · `GEMINI_API_KEY` · `LOOP_MEMORY_SIGNING_KEY` |
| 접속 | `LOOP_DATABASE_URL` · `LOOP_EMBED_PROVIDER` |
| recall 튜닝(수치) | `LOOP_RECALL_MAX_DISTANCE` · `LOOP_KNOWLEDGE_MAX_DISTANCE` |

**의도적으로 뺀 것들이 이 PR의 두 번째 절반입니다:**

- 모든 `LOOP_*_OFF` / `LOOP_*_GATE_OFF`와 `LOOP_SANITIZE_OFF` — 레포가 파일 하나로 stop 게이트·워크트리 게이트·**로그 redaction**을 끌 수 있으면 안 됩니다. RCE와 별개로 존재하던 조용한 구멍이고, 같은 변경으로 닫힙니다.
- `LOOP_DOTENV_PATH` — dotenv 파일이 dotenv 경로를 바꾸는 건 루프이자 지렛대입니다.

**상대 `LOOP_DOTENV_PATH`는 이제 프로젝트 안에 머물러야 합니다.** 이건 평범한 세션 env라 레포가 커밋한 `.claude/settings.json`으로 설정 가능했고, 그래서 `../../..`로 로더를 트리 밖으로 걸어나가게 할 수 있었습니다. 봉쇄는 `startsWith`가 아니라 `relative()`로 판정합니다 — `/repo-evil`이 `/repo` 안으로 세면 안 되니까요. **절대 경로는 그대로 지원합니다**(매니페스트에 문서화된 구성이고, allowlist가 있으니 그걸 적대적인 곳으로 겨눌 이유가 없어졌습니다).

## 바뀌지 않은 것

파일은 **여전히 읽습니다**. 우선순위 불변(명시적 export·userConfig 값이 파일을 이깁니다). 워크트리 폴백 유지. 레포의 `.env`에 있는 무관한 자체 애플리케이션 설정은 **에러가 아니라 무시**됩니다 — 그걸로 세션을 못 열게 만드는 건 무시하는 것보다 나쁩니다.

## 회귀 테스트 — 9케이스 중 9번째가 핵심

`dotenv-allowlist.test.sh`. 8개는 로더의 필터링을 봅니다. 수정이 사는 자리니까요.

**9번째는 단위 층을 일부러 건너뜁니다.** 진짜 `SessionStart` 훅을 진짜 적대적 레포에 대고 돌리고, 페이로드가 실행됐는지를 봅니다. 이유: 나중에 리팩터가 필터는 유지한 채 다른 경로로 환경을 자식에게 넘길 수 있고, 그러면 단위 케이스 8개는 전부 그린인 채로 구멍이 다시 열립니다.

그리고 그 케이스는 **적대적 파일이 읽혔는지까지 확인합니다.** 조사 중에 개발자 세션의 `LOOP_DOTENV_PATH`(정확히는 `CLAUDE_PLUGIN_OPTION_*` 브릿지)가 로더를 다른 곳으로 돌려서, 아무것도 증명하지 않는 그린이 실제로 나왔습니다. 음성 결과도 양성만큼 의심해야 했습니다.

수정 전 로더 대상 RED 실측:

```
FAIL: (1) 'NODE_OPTIONS' from a repo's dotenv file reached the target env — this is the RCE primitive
```

## 검증

```
=== VERDICT ===
VERDICT: PASS
EXIT: 0
SUMMARY: passed=61 failed= skipped= duration_ms=102520
=== END VERDICT ===
```

```
 Test Files  11 passed (11)
      Tests  119 passed | 2 skipped (121)
```

```
=== GATE ===
GATE: AUTO
DIMENSIONS: blast_radius=low reversibility=full cost=low
=== END GATE ===
```

`dotenv-loader-no-drift.test.sh`가 두 사본이 바이트 동일함을 계속 강제하므로, 한쪽만 고쳐 다른 쪽이 남는 일은 구조적으로 없습니다 — 이 결함이 두 플러그인에 동시에 존재했던 이유이기도 합니다.

## 버전

minor입니다(patch 아님) — 이전에 로드되던 키가 이제 무시됩니다. `plugin-dep-range.test.sh`가 의존 둘의 범위를 `^0.13.0`으로 올리라고 같은 변경에서 요구했고, 설계대로입니다.

## 공개 레포 고려

본문에는 결함의 *종류*와 수정만 적었습니다. 완전한 재현 레시피는 회귀 테스트가 들고 있고, 그건 고쳐진 버전에서는 "닫혀 있음의 증명"입니다. 다만 **이전 버전 사용자는 이 릴리스로 올려야 합니다** — 그래서 CHANGELOG 맨 위에 그 문장을 먼저 뒀습니다.

## 남은 보안 항목 (별도 PR로 이어집니다)

이번 점검에서 확인된 나머지: `tag-on-publish.yml`의 코드 주입(HIGH), recall 주입 블록의 구분자 탈출(HIGH), 보호 글로브 삭제 과확장·심볼릭 링크 우회·`verdict-state.json` 미새니타이즈·`tcp-reachable`의 자격증명 노출 등(MED). 이 PR은 가장 파급이 큰 하나만 다룹니다.
