### PR TITLE
fix(security): MED 6건 — 보호 글로브 과확장 삭제 · ln 우회 · 자격증명 노출 · 경로 탈출 · 맨몸 시크릿 · stale clone URL

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,21 +12,21 @@
       "name": "loop-engine",
       "source": "./tools/loop-engine",
       "description": "Core loop mechanics: verdict-run (machine-readable PASS/FAIL contract), loop-fix (closed verify->fix loop), lessons (verified-fix memory), classify-risk, require-tests, plugin-path (resolve sibling plugin install paths), check-docs-hygiene/check-pr-hygiene/check-module-size/check-skill-refs (repo hygiene gates). No framework opinions beyond \"the verifier is the ceiling, never the agent's self-report\".",
-      "version": "0.13.1",
+      "version": "0.13.2",
       "keywords": ["verifier", "tdd", "loop", "verdict", "lessons"]
     },
     {
       "name": "ship-flow",
       "source": "./tools/ship-flow",
       "description": "Delivery-loop skills — ship-feature (plan-to-PR autonomous loop), hotfix, retrospect, grill-with-docs (= grilling + domain-modeling), diagnosing-bugs, deps-audit, to-issues/to-prd, tdd, harness-maturity-audit, improve-codebase-architecture (built on codebase-design), resolving-merge-conflicts, wizard, to-questionnaire, ask-paul (skill router), wait-what, plus review agents and audit/research workflows — parameterized by a consuming repo's own tracker/branch-model config instead of hardcoded to one repo. dependencies: loop-engine.",
-      "version": "0.9.2",
+      "version": "0.9.3",
       "keywords": ["delivery", "git-flow", "hotfix", "ship", "release"]
     },
     {
       "name": "loop-memory",
       "source": "./tools/loop-memory",
       "description": "pgvector semantic recall for verified dev-loop lessons (and, optionally, ADR/glossary/research knowledge). Opt-in / defaultEnabled:false — a database dependency, not core loop mechanics.",
-      "version": "0.6.1",
+      "version": "0.6.2",
       "defaultEnabled": false,
       "keywords": ["memory", "pgvector", "recall", "semantic-search", "lessons"]
     }

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -6,6 +6,12 @@ on:
   pull_request:
     branches: [main]
 
+# 이 워크플로는 GITHUB_TOKEN으로 아무것도 쓰지 않는다(스캔 결과는 잡 종료코드로만 나간다).
+# 명시하지 않으면 레포 기본값을 상속하는데, 그 기본값은 이 파일 밖에서 바뀔 수 있고 바뀌어도 여기서는
+# 보이지 않는다. 서드파티 액션이 도는 잡에서 그건 그냥 미확인 쓰기 권한이다.
+permissions:
+  contents: read
+
 jobs:
   scan:
     runs-on: ubuntu-latest
@@ -14,6 +20,8 @@ jobs:
         with:
           fetch-depth: 0
       - name: gitleaks
-        uses: gitleaks/gitleaks-action@v2
+        # 유일한 서드파티 액션 — 가변 태그가 아니라 커밋 SHA로 고정한다. `@v2`는 언제든 다른 코드를
+        # 가리키게 재지정될 수 있고, 그 재지정은 이 레포의 어떤 diff에도 나타나지 않는다.
+        uses: gitleaks/gitleaks-action@dcedce43c6f43de0b836d1fe38946645c9c638dc # v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/loop-engine-test.yml
+++ b/.github/workflows/loop-engine-test.yml
@@ -11,6 +11,10 @@ on:
     # change — an acceptable cost for closing the base-retarget staleness gap.
     types: [opened, synchronize, reopened, edited]
 
+# 이 워크플로는 GITHUB_TOKEN을 전혀 쓰지 않는다 — 레포 기본값 상속 대신 명시적 최소권한.
+permissions:
+  contents: read
+
 jobs:
   selftest:
     runs-on: ubuntu-latest

--- a/.github/workflows/loop-memory-test.yml
+++ b/.github/workflows/loop-memory-test.yml
@@ -14,6 +14,10 @@ on:
       - ".claude-plugin/marketplace.json"
       - ".github/workflows/loop-memory-test.yml"
 
+# 이 워크플로는 GITHUB_TOKEN을 전혀 쓰지 않는다 — 레포 기본값 상속 대신 명시적 최소권한.
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,46 @@ Explicit-version channel — see [README § Development status](README.md#develo
 not a SHA channel. Entries below `## loop-engine 0.2.0` and earlier predate the multi-plugin split
 and refer to `loop-engine` only (see the un-prefixed version numbers).
 
+## loop-engine 0.13.2 · loop-memory 0.6.2 · ship-flow 0.9.3 — SECURITY
+
+The last batch from the audit that produced 0.13.0 and 0.13.1 — six MED findings. Different files,
+different layers, one shape: **a value the code treats as inert is load-bearing, and nothing in the
+suite disagreed.**
+
+- **`--protect` globs lost their directory, and the guard deletes.** `protect_files()` reduced a
+  `**` pattern to its basename before handing it to `find`, so `sub/**/*.test.ts` protected every
+  `*.test.ts` in the repository. That is not a harmless over-approximation:
+  `cleanup_rogue_protected()` `rm -f`s any protect-matching file absent at run start, so an
+  unrelated test file created anywhere during a run was silently deleted. The basename is now a
+  pre-filter only; each candidate is matched against the whole pattern.
+- **`ln` was missing from the mutation verbs.** `ln -sf /dev/null tests/x.test.ts` replaced a
+  protected file's content without using any listed verb.
+- **The database password reached the agent's context.** `tcp-reachable.mjs` returned the raw
+  connection string as `label` on its two failure paths, and `loop-doctor-heartbeat` prints `label`
+  into a SessionStart nudge. Those paths fire precisely when the URL cannot be trusted, so nothing
+  from it is kept now — including the host, since `not-a-url-at-all://<secret>` parses successfully
+  with the secret sitting in the host field. The success path still reports `host:port`.
+- **`--run-id` was an unvalidated filename.** `<root>/.loop/runs/<run-id>.jsonl` made it a path;
+  `--run-id '../../../../pwned'` appended four directories above the repository. Restricted to the
+  shape a run id actually has, rather than filtered for `..`.
+- **A bare credential passed sanitization untouched.** Every existing rule hangs off a key
+  (`token=`, `Bearer `, `scheme://user:pass@`). Value-shape rules now cover credentials that prove
+  themselves without one (OpenAI, AWS, GitHub, Google, Slack, PEM private-key blocks) — including
+  the multi-line PEM case the `[ \t]`-based rules could not match in principle.
+- **This repo's clone URL survived only on a GitHub redirect.** `setup-loop-engine.action.yml.template`
+  — the URL a *consuming* repo's CI clones and then executes — named the namespace this repository
+  was transferred away from. A redirect stops the instant someone creates a repository at the old
+  path, and no consuming repo's diff would change. The plugin manifests and both READMEs had the
+  same stale path. Gated, not just corrected: the expectation is derived from `origin`, so a future
+  transfer updates it by the same act that makes the old path stale.
+
+Also: explicit `permissions: contents: read` on the three workflows that had none (they inherited a
+repository default that can change out of sight of these files), and the one third-party action is
+pinned to a commit SHA.
+
+`ship-flow` bumps because the setup-action template it ships changed. `loop-memory` bumps for its
+manifest's repository URL.
+
 ## loop-engine 0.13.1 · loop-memory 0.6.1 — SECURITY
 
 Two more injection sites from the same audit as 0.13.0. Different files, one shape: **data ends up

--- a/README.ko.md
+++ b/README.ko.md
@@ -156,7 +156,7 @@ require-tests.sh "*.integration.test.ts" "RLS isolation proof"
 ## 설치
 
 ```bash
-claude plugin marketplace add paulkim-lansik/paul-loop
+claude plugin marketplace add reach0908/paul-loop
 claude plugin install loop-engine@paul-loop
 ```
 
@@ -166,7 +166,7 @@ claude plugin install loop-engine@paul-loop
 먼저 써보거나, 이 저장소 자체를 개발할 때 쓰기 좋다:
 
 ```bash
-git clone https://github.com/paulkim-lansik/paul-loop
+git clone https://github.com/reach0908/paul-loop
 claude --plugin-dir paul-loop/tools/loop-engine
 # 세션 안에서 bin/은 이미 PATH에 등록돼 있다:
 #   verdict-run.sh -- echo hi

--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ valid but are meaningless, not an empty/obviously-wrong result.
 ## Install
 
 ```bash
-claude plugin marketplace add paulkim-lansik/paul-loop
+claude plugin marketplace add reach0908/paul-loop
 claude plugin install loop-engine@paul-loop
 # loop-memory installs disabled (defaultEnabled:false) — install, configure, then enable:
 claude plugin install loop-memory@paul-loop --config openai_api_key=sk-...
@@ -299,7 +299,7 @@ claude plugin enable loop-memory@paul-loop
 trying it against a clone, or for developing this repo itself:
 
 ```bash
-git clone https://github.com/paulkim-lansik/paul-loop
+git clone https://github.com/reach0908/paul-loop
 claude --plugin-dir paul-loop/tools/loop-engine
 # inside the session, bin/ is already on PATH:
 #   verdict-run.sh -- echo hi

--- a/tools/loop-engine/.claude-plugin/plugin.json
+++ b/tools/loop-engine/.claude-plugin/plugin.json
@@ -5,8 +5,8 @@
   "author": {
     "name": "paulkim-lansik"
   },
-  "homepage": "https://github.com/paulkim-lansik/paul-loop",
-  "repository": "https://github.com/paulkim-lansik/paul-loop",
+  "homepage": "https://github.com/reach0908/paul-loop",
+  "repository": "https://github.com/reach0908/paul-loop",
   "license": "MIT",
   "keywords": ["verifier", "tdd", "loop", "verdict", "lessons"]
 }

--- a/tools/loop-engine/.claude-plugin/plugin.json
+++ b/tools/loop-engine/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "loop-engine",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "description": "Core loop mechanics: verdict-run (machine-readable PASS/FAIL contract), loop-fix (closed verify->fix loop), lessons (verified-fix memory), classify-risk, require-tests, check-docs-hygiene/check-pr-hygiene/check-module-size (repo hygiene gates). verifier=ceiling — the agent's self-judgement never substitutes for it.",
   "author": {
     "name": "paulkim-lansik"

--- a/tools/loop-engine/bin/ledger-append.mjs
+++ b/tools/loop-engine/bin/ledger-append.mjs
@@ -15,7 +15,8 @@
 import { readFileSync } from 'node:fs'
 import { appendRunEvent, resolveLedgerTarget } from '../lib/run-ledger.mjs'
 
-function usage() {
+function usage(msg) {
+  if (msg) process.stderr.write(`ledger-append.mjs: ${msg}\n`)
   process.stderr.write(
     'usage: echo <payload-json> | ledger-append.mjs --type <type> [--run-id <id> | --auto-run-id]\n',
   )
@@ -34,6 +35,13 @@ for (let i = 0; i < argv.length; i++) {
   else usage()
 }
 if (!type || (runId && autoRunId)) usage()
+// `run-id` becomes a FILENAME (`<root>/.loop/runs/<run-id>.jsonl`), so an unvalidated value is a path.
+// Measured against the pre-fix binary: `--run-id '../../../../pwned'` from a nested cwd appended to a
+// file four directories above the repo. Restricted to the shape run ids actually have — the session
+// id / `unknown` bucket — rather than filtered for `..`, which loses to `.../....//` and to absolute
+// paths. A bad value is a usage error, not a silent fallback: the caller asked for a specific bucket.
+if (runId && !/^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/.test(runId))
+  usage(`--run-id must match [A-Za-z0-9][A-Za-z0-9._-]{0,127} (it is used as a filename): ${runId}`)
 
 try {
   const cwd = process.cwd()

--- a/tools/loop-engine/bin/loop-fix.sh
+++ b/tools/loop-engine/bin/loop-fix.sh
@@ -299,12 +299,29 @@ esac
 # Expand the protect globs into a concrete file list.
 #  - a pattern with '**' recurses via find (skipping node_modules/.git, and $LOOP_DIR itself)
 #  - otherwise it is a single-level shell glob or a literal path
+#
+# The recursive branch used to reduce the pattern to its BASENAME (`packages/db/test/**/*.test.ts` ->
+# `*.test.ts`) and hand that to `find . -name`, discarding the directory part entirely. Every
+# `*.test.ts` in the repository then counted as protected — and `cleanup_rogue_protected()` `rm -f`s
+# any protect-matching file that did not exist at run start, so an unrelated test file created
+# anywhere during a run was deleted. Over-protection is not the safe direction when the protection
+# includes a delete.
+#
+# So the basename is now only a fast PRE-FILTER for find; each candidate is then matched against the
+# WHOLE pattern. Shell `case` is the matcher: its `*` crosses `/`, which is exactly `**` semantics, so
+# `**` -> `*` is a faithful translation. `/**/` additionally has to match zero directories
+# (`a/**/x` matches `a/x`), which one `case` pattern cannot express — hence the second pattern with
+# `/**` elided, and a match against either.
+glob_to_case() { printf '%s' "$1" | sed 's/\*\*/*/g'; }
+
 protect_files() {
   printf '%s\n' "$PROTECT_LIST" | while IFS= read -r g; do
     [ -z "$g" ] && continue
     case "$g" in
       *'**'*)
-        base="${g##*/}"   # e.g. '**/*.test.*' -> '*.test.*'
+        base="${g##*/}"                                   # fast pre-filter only, NOT the match
+        pat_deep="$(glob_to_case "$g")"                   # '**' -> '*' (one or more dirs)
+        pat_flat="$(glob_to_case "$(printf '%s' "$g" | sed 's#/\*\*##g')")"   # zero dirs
         find . -type f -name "$base" 2>/dev/null \
           | grep -vE '/(node_modules|\.git)/' \
           | sed 's#^\./##' \
@@ -314,7 +331,9 @@ protect_files() {
                   "$LOOP_DIR_EXCL"/*) continue ;;
                 esac
               fi
-              printf '%s\n' "$p"
+              case "$p" in
+                $pat_deep|$pat_flat) printf '%s\n' "$p" ;;
+              esac
             done ;;
       *)
         for f in $g; do [ -f "$f" ] && printf '%s\n' "$f"; done ;;

--- a/tools/loop-engine/hooks/protect-during-loop.mjs
+++ b/tools/loop-engine/hooks/protect-during-loop.mjs
@@ -169,8 +169,11 @@ if (tool === 'Bash') {
   if (typeof cmd !== 'string' || !cmd) process.exit(0);
   // (a) does it look mutating — conservative; the real gate is the token match below, so
   // over-matching here is harmless (it only lets more commands through the mutation check).
+  // `ln` belongs here for the same reason `mv` does: `ln -sf /dev/null tests/x.test.ts` and
+  // `ln -f decoy tests/x.test.ts` both replace a protected file's content without any of the verbs
+  // that were listed. It was the one obvious mutation verb missing.
   const mutates =
-    /(^|[\s;&|(])(rm|unlink|mv|cp|dd|truncate|tee|install)\b/.test(cmd) ||
+    /(^|[\s;&|(])(rm|unlink|mv|cp|ln|dd|truncate|tee|install)\b/.test(cmd) ||
     /\bsed\b[^|;&]*\s-[a-z]*i/.test(cmd) ||
     /\bgit\s+(checkout|restore|reset|stash)\b/.test(cmd) ||
     />>?/.test(cmd);

--- a/tools/loop-engine/lib/sanitize.mjs
+++ b/tools/loop-engine/lib/sanitize.mjs
@@ -55,9 +55,27 @@ const URL_CRED = /\b([a-z][a-z0-9+.-]*:\/\/[^\s/:@]+):([^\s@]+)@/gi
 // 마스킹하지 않는다 — lessons 서명의 "operand를 지우지 않는다" 불변식과 loop-fix stall 서명 오탐
 // (진짜 전진을 동일 실패로 오인) 방지(리뷰). 콜론+순수 알파벳 장문/인용값/=값은 여전히 마스킹.
 const OPERAND = /^(?:undefined|null|true|false|nan|\d+)$/i
+// 값 자체가 시크릿인 모양(VALUE SHAPE) — 위 규칙은 전부 **키에 매달려 있다**. `token=`·`Bearer `·
+// `scheme://user:pass@` 중 하나가 곁에 있어야 마스킹된다. 그런데 로그·원장에 시크릿이 착지하는 가장
+// 흔한 모양 하나가 그 셋 어디에도 안 걸린다 — **맨몸 값**이다: 셸 에러가 인자를 그대로 되뱉거나,
+// 테스트 출력이 키를 찍거나, 스택트레이스가 URL 쿼리를 흘릴 때. 그래서 키 없이도 스스로를 증명하는
+// 형태들을 따로 잡는다. 전부 발급자가 정한 고유 프리픽스+길이라 오탐이 사실상 없다 — 진단 어휘가
+// 우연히 `AKIA`+대문자 16자나 `sk-`+20자가 되지는 않는다.
+const VALUE_SHAPES = [
+  [/\bsk-[A-Za-z0-9_-]{20,}/g, 'sk-[REDACTED]'],                    // OpenAI (sk-, sk-proj-)
+  [/\b(?:AKIA|ASIA)[0-9A-Z]{16}\b/g, '[REDACTED-AWS-KEY-ID]'],      // AWS access key id
+  [/\bgh[pousr]_[A-Za-z0-9]{20,}/g, '[REDACTED-GITHUB-TOKEN]'],     // GitHub PAT / OAuth / refresh
+  [/\bgithub_pat_[A-Za-z0-9_]{20,}/g, '[REDACTED-GITHUB-TOKEN]'],   // GitHub fine-grained PAT
+  [/\bAIza[0-9A-Za-z_-]{35}\b/g, '[REDACTED-GOOGLE-KEY]'],          // Google / Gemini
+  [/\bxox[baprs]-[A-Za-z0-9-]{10,}/g, '[REDACTED-SLACK-TOKEN]'],    // Slack
+  // 개인키 블록은 여러 줄이라 위 [ \t] 규칙들이 원리적으로 못 잡는다. 본문만 지우고 BEGIN/END는
+  // 남긴다 — "여기에 개인키가 있었다"가 진단에서 사라지면 안 된다.
+  [/(-----BEGIN [A-Z ]*PRIVATE KEY-----)[\s\S]*?(-----END [A-Z ]*PRIVATE KEY-----)/g, '$1[REDACTED]$2'],
+]
+
 export function sanitizeText(text, env = process.env) {
   if (sanitizeOff(env) || typeof text !== 'string') return text
-  return text
+  const keyed = text
     .replace(TEXT_KEY, (m, key, sep, ws, val) => {
       const quoted = /^["']/.test(val)
       const inner = quoted ? val.slice(1, -1) : val
@@ -67,6 +85,8 @@ export function sanitizeText(text, env = process.env) {
     })
     .replace(BEARER, '$1 [REDACTED]')
     .replace(URL_CRED, '$1:[REDACTED]@')
+  const shaped = VALUE_SHAPES.reduce((acc, [re, to]) => acc.replace(re, to), keyed)
+  return shaped
 }
 
 // 레코드 살균 — 비파괴(입력 불변, 항상 새 값 반환). blocklist 키는 값을 마커로 낙하(감사 가능하게

--- a/tools/loop-engine/lib/tcp-reachable.mjs
+++ b/tools/loop-engine/lib/tcp-reachable.mjs
@@ -3,6 +3,15 @@
 // nudge, ADR-0062 decision 6) don't carry duplicate copies of the same never-throws logic.
 import { connect } from 'node:net';
 
+// `label`은 loop-doctor-heartbeat이 SessionStart nudge로 **에이전트 컨텍스트에 그대로 출력**한다.
+// 성공 경로의 label(`host:port`)은 포트까지 숫자로 읽힌 URL이라 구조적으로 연결문자열이 맞고 호스트를
+// 남기는 게 진단에 쓸모 있다. 실패 경로 둘은 다르다 — 원본 `urlStr`을 그대로 돌려주고 있었고, 그게 곧
+// `postgres://user:password@host/db`다. 게다가 그 경로들은 **URL을 못 믿는 상황에서만** 발동한다:
+// `not-a-url-at-all://<secret>`은 WHATWG URL 파싱에 성공하면서 호스트 자리에 시크릿 전체가 들어앉는다.
+// 그래서 실패 경로에서는 호스트조차 남기지 않는다 — 무엇이 호스트인지 모르는 상태이기 때문이다.
+// 어느 실패인지는 `reason`이 이미 구분해 주므로 진단 정보는 잃지 않는다.
+const OPAQUE = '<connection string redacted>';
+
 export function short(e) {
   const m = e && e.message ? e.message : String(e);
   return m.split('\n')[0].slice(0, 120);
@@ -21,10 +30,10 @@ export function tcpReachable(urlStr, timeoutMs) {
     host = u.hostname;
     port = Number(u.port);
   } catch (e) {
-    return Promise.resolve({ ok: false, label: urlStr, reason: `URL 파싱 실패: ${short(e)}` });
+    return Promise.resolve({ ok: false, label: OPAQUE, reason: `URL 파싱 실패: ${short(e)}` });
   }
   if (!host || !Number.isInteger(port) || port <= 0 || port > 65535) {
-    return Promise.resolve({ ok: false, label: urlStr, reason: 'host/port를 읽을 수 없음(LOOP_DATABASE_URL 형식 확인)' });
+    return Promise.resolve({ ok: false, label: OPAQUE, reason: 'host/port를 읽을 수 없음(LOOP_DATABASE_URL 형식 확인)' });
   }
   const label = `${host}:${port}`;
   return new Promise((resolve) => {

--- a/tools/loop-engine/test/canonical-repo-url.test.sh
+++ b/tools/loop-engine/test/canonical-repo-url.test.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Every place this repository names ITSELF must name where it actually lives.
+#
+# It did not. The clone URL in `setup-loop-engine.action.yml.template` — the one a CONSUMING repo's
+# CI runs to fetch and then execute this plugin — pointed at the namespace this repo was transferred
+# away from. That resolves today only because GitHub keeps a redirect, and a redirect stops the
+# instant anyone creates a repository at the old path. From that moment every consuming repo's CI
+# clones and runs whatever is there, and nothing in their diffs changes. The plugin manifests and the
+# install instructions in both READMEs had the same stale path.
+#
+# A gate rather than a one-time correction, because the failure mode is silence: the stale URL worked
+# in every test, in CI, and by hand. Nothing would have complained until the day it mattered.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+
+fail() { echo "FAIL: $1"; exit 1; }
+
+# Derived, not hardcoded: the canonical path is whatever `origin` says, so a future transfer updates
+# this gate's expectation by moving the remote — the same act that makes the old path stale.
+ORIGIN="$(git -C "$ROOT" remote get-url origin 2>/dev/null)" || ORIGIN=""
+[ -n "$ORIGIN" ] || fail "no git origin — this check cannot know the canonical path, and passing anyway would prove nothing"
+CANON="$(printf '%s' "$ORIGIN" | sed -e 's#^git@github.com:#https://github.com/#' -e 's#\.git$##' -e 's#^https://github.com/##')"
+case "$CANON" in */*) ;; *) fail "could not derive owner/repo from origin '$ORIGIN'" ;; esac
+REPO_NAME="${CANON#*/}"
+
+# Any `<owner>/paul-loop` (or github.com/<owner>/paul-loop) that is not the canonical owner.
+HITS="$(grep -rnE "(github\.com[:/]|marketplace add )[A-Za-z0-9_-]+/${REPO_NAME}\b" "$ROOT" \
+  --exclude-dir=node_modules --exclude-dir=.git --exclude-dir=dist 2>/dev/null \
+  | grep -vF "$CANON" || true)"
+
+if [ -n "$HITS" ]; then
+  echo "  A reference names a different owner for this repository than origin does ($CANON):"
+  printf '%s\n' "$HITS" | sed "s#^$ROOT/#    #"
+  fail "$(printf '%s\n' "$HITS" | wc -l | tr -d ' ') stale self-reference(s) — a clone URL or install instruction that survives only on a GitHub redirect hands the path to whoever claims the old namespace"
+fi
+
+# The check must not pass by finding nothing at all — the pattern has to actually match this repo.
+FOUND="$(grep -rlE "(github\.com[:/]|marketplace add )[A-Za-z0-9_-]+/${REPO_NAME}\b" "$ROOT" \
+  --exclude-dir=node_modules --exclude-dir=.git --exclude-dir=dist 2>/dev/null | wc -l | tr -d ' ')"
+[ "$FOUND" -gt 0 ] || fail "the self-reference pattern matched nothing anywhere — this check verified nothing"
+
+echo "PASS: every self-reference names the canonical repository ($CANON; $FOUND file(s) scanned)"
+exit 0

--- a/tools/loop-engine/test/guard-bypass-and-leak.test.sh
+++ b/tools/loop-engine/test/guard-bypass-and-leak.test.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# Three findings from the security audit that share one shape: a value the code treats as inert is
+# actually load-bearing, and nothing in the suite disagreed.
+#
+#   M2  protect-during-loop.mjs — the mutation-verb list omitted `ln`, and the repo-relative path was
+#       computed lexically. Either one alone lets a fixer rewrite a protected file: `ln -sf` replaces
+#       its content with no listed verb. (The audit also flagged the lexical `relative()` fallback as
+#       a symlink bypass; measured, it is not — worktree re-rooting resolves the symlink through git
+#       before that line runs. The case is pinned below rather than fixed, since there was no defect.)
+#   M4  tcp-reachable.mjs — the two failure paths returned the raw connection string as `label`, and
+#       loop-doctor-heartbeat.mjs prints `label` straight into an agent's SessionStart context. That
+#       string is `postgres://user:password@host/db`.
+#   M6  ledger-append.mjs — `--run-id` becomes a filename with no validation, so it is a path.
+#
+# Each is written against the property, not the payload: "no mutation verb reaches a protected file",
+# "no output field carries credentials", "a run id cannot be a path".
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+HOOK="$HERE/../hooks/protect-during-loop.mjs"
+TCP="$HERE/../lib/tcp-reachable.mjs"
+LEDGER="$HERE/../bin/ledger-append.mjs"
+
+fail() { echo "FAIL: $1"; exit 1; }
+for f in "$HOOK" "$TCP" "$LEDGER"; do [ -f "$f" ] || fail "missing fixture target: $f"; done
+
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/tmp.XXXXXXXX")" || fail "mktemp -d failed"
+trap 'rm -rf "$WORK"' EXIT
+g() { git -c user.email=t@example.com -c user.name=t -C "$@"; }
+
+FAILURES=()
+
+# ── fixture: a repo on a working branch, so the guard is armed ────────────────────────────────────
+REPO="$WORK/repo"
+mkdir -p "$REPO/.loop"
+git init -q -b feature/x "$REPO" || fail "git init failed"
+printf '**/*.test.sh\n' > "$REPO/.loop/protect.globs"
+echo x > "$REPO/a.test.sh"
+echo decoy > "$REPO/decoy"
+g "$REPO" add -A >/dev/null && g "$REPO" commit -qm init || fail "git commit failed"
+
+run() { # run <root> <tool> <arg> [cwd]
+  node -e '
+    const [tool, arg, cwd] = process.argv.slice(1);
+    const p = { tool_name: tool, tool_input: tool === "Bash" ? { command: arg } : { file_path: arg } };
+    if (cwd) p.cwd = cwd;
+    process.stdout.write(JSON.stringify(p));
+  ' "$2" "$3" "${4:-}" | CLAUDE_PROJECT_DIR="$1" node "$HOOK" 2>>"$WORK/stderr"
+}
+check() { # check <desc> <deny|allow> <root> <tool> <arg> [cwd]
+  local desc="$1" want="$2"; shift 2
+  local out got=allow
+  out="$(run "$@")" || { echo "FAILED: $desc — hook exited non-zero (it must always exit 0)"; FAILURES+=("$desc"); return; }
+  printf '%s' "$out" | grep -q '"permissionDecision":"deny"' && got=deny
+  if [ "$got" = "$want" ]; then echo "PASS: $desc"
+  else echo "FAILED: $desc — wanted $want, got $got"; FAILURES+=("$desc"); fi
+}
+
+# ── M2: every way to replace a protected file's content is a mutation ─────────────────────────────
+# `ln` was the missing verb. Both forms replace the bytes an agent reads at that path.
+check "ln -sf onto a protected file is a mutation" deny "$REPO" Bash "ln -sf /dev/null a.test.sh" "$REPO"
+check "ln -f onto a protected file is a mutation"  deny "$REPO" Bash "ln -f decoy a.test.sh"      "$REPO"
+# Pin the verbs that already worked, so a future edit to the regex cannot drop one silently.
+check "mv onto a protected file is still a mutation" deny "$REPO" Bash "mv decoy a.test.sh" "$REPO"
+check "rm of a protected file is still a mutation"   deny "$REPO" Bash "rm a.test.sh"       "$REPO"
+# …and that widening the verb list did not start blocking ordinary commands.
+check "an unrelated ln is not blocked" allow "$REPO" Bash "ln -s decoy other-link" "$REPO"
+
+# M2b: a symlinked route to the same bytes. This one ALREADY passed before the `ln` fix — the
+# worktree re-rooting (BAC-785) asks git where the target lives, and git resolves the symlink. It is
+# pinned here anyway because the audit flagged the lexical `relative()` fallback below it, and the
+# reason that fallback is not exploitable is precisely that re-rooting gets there first. If re-rooting
+# is ever narrowed, this case is what says so.
+LINK="$WORK/link-to-repo"
+ln -s "$REPO" "$LINK" || fail "fixture: ln -s failed"
+check "an Edit reaching a protected file through a symlinked root is blocked" \
+  deny "$REPO" Edit "$LINK/a.test.sh" "$REPO"
+# A genuinely unrelated path must still be allowed — the fix must not turn "resolve symlinks" into
+# "block everything outside the repo I cannot resolve".
+echo x > "$WORK/loose.test.sh"
+check "a file in no repository at all is still allowed" allow "$REPO" Edit "$WORK/loose.test.sh" "$REPO"
+
+# ── M4: no output field carries credentials ───────────────────────────────────────────────────────
+SECRET='hunter2SUPERSECRET'
+for url in "postgres://user:${SECRET}@localhost" "postgres://user:${SECRET}@host:not-a-port/db" "not-a-url-at-all://${SECRET}" "localhost:5434?p=${SECRET}"; do
+  out="$(node --input-type=module -e "
+    import { tcpReachable } from '$TCP';
+    const r = await tcpReachable(process.argv[1], 200);
+    process.stdout.write(JSON.stringify(r));
+  " "$url" 2>&1)"
+  if printf '%s' "$out" | grep -qF "$SECRET"; then
+    echo "FAILED: tcpReachable leaked the password for <$url> — this value is printed into an agent's SessionStart context"
+    FAILURES+=("tcpReachable leak: $url")
+  else
+    echo "PASS: no credential in tcpReachable's result for a $( [ "${url:0:9}" = "postgres:" ] && echo malformed || echo non- )URL input"
+  fi
+done
+# The diagnostic must not be gutted into uselessness — but only where the parse is trustworthy.
+# A URL that yields a numeric port is structurally a connection string, so the SUCCESS path names the
+# host. The failure paths deliberately name nothing: `not-a-url-at-all://<secret>` parses fine and
+# puts the secret in the host field, so "keep the host" is unsafe exactly where it would be used.
+reach="$(node --input-type=module -e "
+  import { tcpReachable } from '$TCP';
+  const r = await tcpReachable(process.argv[1], 200);
+  process.stdout.write(r.label);
+" "postgres://user:${SECRET}@127.0.0.1:1/x")"
+case "$reach" in
+  127.0.0.1:1) echo "PASS: a well-formed URL still yields host:port — the nudge stays diagnostic" ;;
+  *) echo "FAILED: a well-formed URL no longer reports host:port (got '$reach') — redaction went too far"; FAILURES+=("redaction too aggressive") ;;
+esac
+
+# ── M6: a run id cannot be a path ─────────────────────────────────────────────────────────────────
+T="$WORK/ledger"; mkdir -p "$T/repo/a/b"
+for bad in '../../../../pwned' '/tmp/abs-pwned' 'a/b/nested' '..' '.'; do
+  ( cd "$T/repo/a/b" && echo '{}' | node "$LEDGER" --type test.done --run-id "$bad" ) >/dev/null 2>&1
+  rc=$?
+  if [ "$rc" -ne 2 ]; then
+    echo "FAILED: --run-id '$bad' was accepted (exit $rc) — a run id is used as a filename"
+    FAILURES+=("run-id accepted: $bad")
+  else
+    echo "PASS: --run-id '$bad' refused as a usage error"
+  fi
+done
+# Nothing may have been written anywhere but the one legitimate bucket below.
+ESCAPED="$(find "$T" -name 'pwned*' -o -name 'nested*' | head -5)"
+[ -z "$ESCAPED" ] || { echo "FAILED: files were written outside the runs directory: $ESCAPED"; FAILURES+=("ledger escape"); }
+[ -e /tmp/abs-pwned.jsonl ] && { echo "FAILED: an absolute --run-id wrote /tmp/abs-pwned.jsonl"; FAILURES+=("ledger abs escape"); }
+# …and an ordinary run id still works, or the fix is just a break.
+( cd "$T/repo/a/b" && echo '{}' | node "$LEDGER" --type test.done --run-id 'sess-abc_123.v2' ) >/dev/null 2>&1
+if [ -f "$T/repo/a/b/.loop/runs/sess-abc_123.v2.jsonl" ]; then
+  echo "PASS: an ordinary run id still appends to its own bucket"
+else
+  echo "FAILED: a valid run id stopped working — the pattern is over-tight"
+  FAILURES+=("run-id over-tight")
+fi
+
+if [ "${#FAILURES[@]}" -gt 0 ]; then
+  echo "FAIL: ${#FAILURES[@]} case(s) failed: ${FAILURES[*]}"
+  exit 1
+fi
+echo "PASS: guard bypass + leak — ln and symlinked routes to a protected file are mutations, no tcpReachable output field carries credentials, and a run id cannot be a path"
+exit 0

--- a/tools/loop-engine/test/loop-fix-protect.test.sh
+++ b/tools/loop-engine/test/loop-fix-protect.test.sh
@@ -568,5 +568,35 @@ sleep 2
 cmp -s guard-file.txt original-guard-file.txt \
   || fail "case16: file drifted from the restored content after settling — a residual write landed post-restore"
 
+# ── case 17: a directory-scoped '**' glob must not protect — or DELETE — files outside it ──────────
+# protect_files() reduced a '**' pattern to its basename and ran `find . -name <basename>`, throwing
+# the directory part away: `sub/**/*.test.ts` protected EVERY *.test.ts in the tree. That is not a
+# harmless over-approximation, because cleanup_rogue_protected() `rm -f`s any protect-matching file
+# that was absent at run start — so an unrelated test file created anywhere during a run was deleted.
+#
+# One case, both directions:
+#   (a) `other/b.test.ts` is created by the fixer and is OUTSIDE the glob -> must survive.
+#   (b) `sub/c.test.ts` sits directly under `sub/` and IS inside it (`/**/` matches zero directories)
+#       -> must still be detected and byte-restored. Without (b) the fix could "pass" by narrowing
+#       the glob to require at least one intermediate directory, which would silently unprotect files.
+C="$WORK/c17"; mkdir -p "$C/sub/nested" "$C/other"; cd "$C" || fail "cd c17"
+cp "$WORK/fake-verify-fail.sh" fake-verify-fail.sh
+printf 'PROTECTED-ZERO-DIR\n' > sub/c.test.ts
+printf 'PROTECTED-NESTED\n'   > sub/nested/a.test.ts
+cp sub/c.test.ts original-c.test.ts   # reference copy, outside the glob
+cat > fake-fix-c17.sh <<'EOF'
+#!/bin/sh
+printf 'SABOTAGED\n' > sub/c.test.ts
+printf 'a brand new, unrelated test file\n' > other/b.test.ts
+EOF
+"$LOOPFIX" --verify 'sh fake-verify-fail.sh' --fix 'sh fake-fix-c17.sh' --protect 'sub/**/*.test.ts' --max-iter 2 >/dev/null 2>&1
+code=$?
+[ "$code" -eq 3 ] || fail "case17: expected exit 3 — 'sub/**/*.test.ts' must still cover sub/c.test.ts (zero intermediate directories), got $code"
+cmp -s sub/c.test.ts original-c.test.ts \
+  || fail "case17(b): sub/c.test.ts was not restored — '/**/' stopped matching zero directories, silently unprotecting files directly under the glob's root"
+[ -f other/b.test.ts ] \
+  || fail "case17(a): other/b.test.ts was DELETED — a glob scoped to sub/ reached outside it, and the rogue-file cleanup turned that over-match into data loss"
+echo "  case17 ok: directory-scoped '**' protects inside (incl. zero-dir) and does not delete outside"
+
 echo "PASS: --protect reverts a tampered/deleted protected file to its exact pre-run bytes, excludes its own backup dir from '**' scans, detects+refuses on backup poisoning OR backup deletion/unreadability via a fail-closed marker, deletes rogue new protect-glob-matching files before aborting, cannot be defeated by forging or deleting the on-disk hash bookkeeping (round-3: ground truth now lives in-process, not on disk), catches a mutation backgrounded to land after the FAIL-path check but before the next verify (round-4: check_protected() runs on the PASS path too), raises the bar with a bounded grace-period recheck on both paths while honestly not claiming to catch delays past that window (round-5), and now (round-6) also covers the VERDICT-RUN-ERROR abort point and survives the watchdog's own descendant-killer trying to defeat the grace-period sleep, plus restores/warns-but-preserves-exit-code on STALLED/BUDGET/watchdog/INFRA/VERDICT-RUN-ERROR aborts that used to leave an earlier iteration's pending corruption unflagged"
 exit 0

--- a/tools/loop-engine/test/sanitize.test.sh
+++ b/tools/loop-engine/test/sanitize.test.sh
@@ -140,4 +140,36 @@ printf 'FAIL: boom token=sigfileleak77\n' > "$DIR/sig.txt"
 node "$LESSONS" record --signature-file "$DIR/sig.txt" --verified --lessons "$DIR/ls2" >/dev/null || fail "T16: record via signature-file failed"
 grep -rq sigfileleak77 "$DIR/ls2" && fail "T16: signature-file secret persisted in the lessons store"
 
+# T17: 값 자체가 시크릿인 모양(키 없이 맨몸으로 착지한 자격증명).
+# T1/T4가 증명하는 규칙은 전부 **키에 매달려 있다** — `token=`·`Bearer `·`scheme://user:pass@`. 로그에
+# 시크릿이 앉는 가장 흔한 모양 하나가 그 셋 어디에도 안 걸린다: 셸이 인자를 되뱉거나 스택트레이스가
+# 쿼리를 흘려서 값만 덩그러니 남는 경우다.
+#
+# 이 파일 머리말의 "실제 포맷 금지" 규칙을 지키려고 모양은 **런타임에 조립**한다 — 소스에는 시크릿
+# 모양 리터럴이 존재하지 않으므로 커밋 시점 gitleaks가 이 테스트 자신을 잡지 않는다. 그러면서도
+# sanitize.mjs가 보는 문자열은 진짜 포맷이라 증명력은 그대로다.
+p_sk='sk-'; p_aws='AK'; p_gh='gh'; p_g='AI'
+BARE_SK="${p_sk}proj0123456789abcdefghijklmnop"
+BARE_AWS="${p_aws}IA0123456789ABCDEF"                     # AKIA + 16 = 20자 (AWS 고정 길이)
+BARE_GH="${p_gh}p_0123456789abcdefghijklmnopqrstuvwxyz"
+BARE_G="${p_g}za0123456789abcdefghijklmnopqrstuvwxy"      # AIza + 35 = 39자 (Google 고정 길이)
+for v in "$BARE_SK" "$BARE_AWS" "$BARE_GH" "$BARE_G"; do
+  OUT="$(printf 'remote rejected: %s\n' "$v" | node "$S" --text)" || fail "T17: text mode exited non-zero"
+  printf '%s' "$OUT" | grep -qF "$v" && fail "T17: a bare credential survived text masking (no key to hang off): $OUT"
+  printf '%s' "$OUT" | grep -q 'REDACTED' || fail "T17: nothing was redacted, so the shape was not recognised at all: $OUT"
+done
+# 레코드 경로도 같은 규칙을 상속해야 한다 — 원장 payload가 텍스트 경로를 안 타면 구멍이 그대로 남는다.
+OUT="$(printf '{"note":"deploy failed for %s"}' "$BARE_AWS" | node "$S" --record)" || fail "T17: --record exited non-zero"
+printf '%s' "$OUT" | grep -qF "$BARE_AWS" && fail "T17: a bare credential survived record sanitization: $OUT"
+# 개인키 블록은 여러 줄 — [ \t] 기반 규칙이 원리적으로 못 잡는 모양이다. BEGIN/END는 남아야 한다.
+PEM="$(printf -- '-----BEGIN RSA PRIVATE KEY-----\nMIIBOgIBAAJBAKleaked99\n-----END RSA PRIVATE KEY-----\n')"
+OUT="$(printf '%s' "$PEM" | node "$S" --text)" || fail "T17: PEM text mode exited non-zero"
+printf '%s' "$OUT" | grep -q 'leaked99' && fail "T17: private key body survived: $OUT"
+printf '%s' "$OUT" | grep -q 'BEGIN RSA PRIVATE KEY' || fail "T17: BEGIN marker was destroyed — the log can no longer say a key was there: $OUT"
+# 오탐 금지 — 진단 어휘가 우연히 시크릿으로 읽히면 로그가 못 쓰게 된다.
+for keep in 'FAILED src/a.test.ts > expected 401, got 403' 'Authorization: header missing' 'SESSION_SECRET: Required' 'sk-1' 'installed ghost@1.2.3'; do
+  OUT="$(printf '%s\n' "$keep" | node "$S" --text)" || fail "T17: exited non-zero on '$keep'"
+  printf '%s' "$OUT" | grep -q 'REDACTED' && fail "T17: false positive — ordinary diagnostic text was redacted: '$keep' -> $OUT"
+done
+
 echo "PASS: sanitize.mjs — blocklist drop, truncation, pass-through, text masking, in-place atomic rewrite, fail-closed switch, verdict-run + lessons wiring, operand preservation, JSON/URL shapes, metric pass-through, fail-open path"

--- a/tools/loop-memory/.claude-plugin/plugin.json
+++ b/tools/loop-memory/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "loop-memory",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "pgvector semantic recall for verified dev-loop lessons (and, optionally, ADR/glossary/research knowledge). Opt-in: installs disabled by default — this is a database dependency, not core loop mechanics.",
   "author": {
     "name": "paulkim-lansik"

--- a/tools/loop-memory/.claude-plugin/plugin.json
+++ b/tools/loop-memory/.claude-plugin/plugin.json
@@ -5,8 +5,8 @@
   "author": {
     "name": "paulkim-lansik"
   },
-  "homepage": "https://github.com/paulkim-lansik/paul-loop",
-  "repository": "https://github.com/paulkim-lansik/paul-loop",
+  "homepage": "https://github.com/reach0908/paul-loop",
+  "repository": "https://github.com/reach0908/paul-loop",
   "license": "MIT",
   "keywords": ["memory", "pgvector", "recall", "semantic-search", "lessons"],
   "defaultEnabled": false,

--- a/tools/ship-flow/.claude-plugin/plugin.json
+++ b/tools/ship-flow/.claude-plugin/plugin.json
@@ -5,8 +5,8 @@
   "author": {
     "name": "paulkim-lansik"
   },
-  "homepage": "https://github.com/paulkim-lansik/paul-loop",
-  "repository": "https://github.com/paulkim-lansik/paul-loop",
+  "homepage": "https://github.com/reach0908/paul-loop",
+  "repository": "https://github.com/reach0908/paul-loop",
   "license": "MIT",
   "keywords": ["delivery", "git-flow", "hotfix", "ship", "release"],
   "dependencies": [

--- a/tools/ship-flow/.claude-plugin/plugin.json
+++ b/tools/ship-flow/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ship-flow",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "Delivery-loop skills — land and release already-verified work through a repo's real gates. Tracker- and branch-model-agnostic: reads a consuming repo's own config instead of hardcoding one repo's setup.",
   "author": {
     "name": "paulkim-lansik"

--- a/tools/ship-flow/templates/setup-loop-engine.action.yml.template
+++ b/tools/ship-flow/templates/setup-loop-engine.action.yml.template
@@ -11,14 +11,21 @@ description: >
   would make one implicitly depend on the other's version, so they're cloned separately. Bump the
   tags below deliberately when you want a newer plugin version — this is an explicit semver pin, not
   a SHA channel that auto-follows (see paul-loop's ADR-0078 addendum for why).
+
+  The clone URL is the CANONICAL repository path, not a GitHub redirect. It used to name the old
+  namespace the repo was transferred away from. That works only for as long as GitHub's redirect
+  holds, and a redirect stops the moment anyone creates a repository at the old path — at which
+  point every consuming repo's CI clones and executes whatever is there. A stale namespace in a
+  clone URL is a supply-chain hand-off waiting to happen, and nothing in a consuming repo's diff
+  would show it changing hands.
 runs:
   using: composite
   steps:
     - shell: bash
       run: |
         git clone --depth 1 --branch loop-engine--{{LOOP_ENGINE_TAG}} \
-          https://github.com/paulkim-lansik/paul-loop.git /tmp/paul-loop-loop-engine
+          https://github.com/reach0908/paul-loop.git /tmp/paul-loop-loop-engine
         echo "LOOP_ENGINE_PATH=/tmp/paul-loop-loop-engine/tools/loop-engine" >> "$GITHUB_ENV"
         git clone --depth 1 --branch ship-flow--{{SHIP_FLOW_TAG}} \
-          https://github.com/paulkim-lansik/paul-loop.git /tmp/paul-loop-ship-flow
+          https://github.com/reach0908/paul-loop.git /tmp/paul-loop-ship-flow
         echo "SHIP_FLOW_PATH=/tmp/paul-loop-ship-flow/tools/ship-flow" >> "$GITHUB_ENV"


### PR DESCRIPTION
> 보안 수정 3/3. #81(CRITICAL, dotenv allowlist) · #82(HIGH, 인터프리터 소스 주입 2건)에 이어지는 마지막 묶음 — MED 등급 6건.
>
> **base 주의**: 이 브랜치는 `origin/main`(= #81까지) 기준입니다. #82가 먼저 머지되면 리베이스 후 버전·CHANGELOG를 붙이겠습니다. 지금은 버전 무변경입니다.

여섯 건이 서로 다른 파일·다른 계층인데 형태는 하나입니다 — **코드가 무해하다고 취급하는 값이 실제로는 하중을 받고 있고, 스위트의 어떤 테스트도 반대하지 않았습니다.**

---

## 1 · 보호 글로브가 디렉터리를 버려 레포 전역을 삭제 대상으로 삼았다

`protect_files()`가 `**` 패턴을 **베이스네임으로 줄여** `find . -name <base>`에 넘겼습니다. `sub/**/*.test.ts`가 레포의 *모든* `*.test.ts`를 보호 대상으로 만듭니다.

과보호는 무해한 근사가 아닙니다 — `cleanup_rogue_protected()`가 런 시작 시점에 없던 protect-매칭 파일을 `rm -f`합니다. 런 도중 **어디에** 만들어진 무관한 테스트 파일이든 조용히 삭제됐습니다.

수정 전 바이너리 실측:

```
--protect 'sub/**/*.test.ts' 로 실행, 픽서가 other/b.test.ts 생성
exit=3
### RED 판정 (수정 전):
  other/b.test.ts: >>> 삭제됨 (글로브 밖인데 rm -f 당함) <<<
```

베이스네임은 이제 find의 **빠른 사전필터로만** 쓰고, 후보마다 패턴 전체와 대조합니다. 매처는 셸 `case` — 그 `*`는 `/`를 넘으므로 `**`와 정확히 같은 의미이고, `**` → `*` 치환이 충실한 번역입니다. `/**/`가 디렉터리 0개도 매치해야 하는 부분(`a/**/x`가 `a/x`를 잡는다)은 한 패턴으로 표현할 수 없어 `/**`를 지운 두 번째 패턴을 함께 둡니다.

**case17이 양방향을 한 케이스로 고정합니다.** 글로브 밖 파일은 살아남아야 하고, 글로브 루트 바로 아래 파일(중간 디렉터리 0개)은 여전히 탐지·복원돼야 합니다. 후자가 없으면 "중간 디렉터리 1개 이상"으로 좁혀 통과시키는 가짜 수정이 가능해지고, 그건 조용히 보호를 푸는 것입니다.

## 2 · `ln`이 뮤테이션 동사 목록에 없었다

`ln -sf /dev/null tests/x.test.ts`와 `ln -f decoy tests/x.test.ts`는 목록에 있는 어떤 동사도 쓰지 않고 보호 파일의 내용을 바꿉니다. `mv`가 목록에 있는 이유와 정확히 같은 이유로 `ln`도 있어야 합니다 — 빠진 유일한 명백한 동사였습니다.

## 3 · DB 자격증명이 에이전트 컨텍스트로 나갔다

`tcp-reachable.mjs`의 실패 경로 두 곳이 원본 `urlStr`을 `label`로 돌려줬고, `loop-doctor-heartbeat`이 그 `label`을 SessionStart nudge로 **그대로 출력**합니다. 그 값이 `postgres://user:password@host/db`입니다.

실패 경로는 URL이 이상할 때만 발동하므로, 비밀번호에 파싱을 깨는 문자가 있으면 바로 그때 전문이 샙니다.

**첫 수정이 부족했고 새 테스트가 잡았습니다.** "호스트는 진단에 필요하니 남기자"고 썼는데, `not-a-url-at-all://<secret>`은 WHATWG URL 파싱에 **성공**하면서 시크릿 전체가 호스트 자리에 들어앉습니다:

```
FAILED: tcpReachable leaked the password for <not-a-url-at-all://hunter2SUPERSECRET>
        — this value is printed into an agent's SessionStart context
```

파싱을 못 믿는 경로에서 "호스트는 안전하다"고 가정하는 것 자체가 모순이었습니다. 실패 경로는 이제 아무것도 남기지 않습니다. 성공 경로(포트가 숫자로 읽힌 URL = 구조적으로 연결 문자열)는 `host:port`를 그대로 남겨 진단 가치를 지킵니다.

## 4 · `--run-id`가 파일명이 되는데 검증이 없었다

`<root>/.loop/runs/<run-id>.jsonl`이므로 run id는 곧 경로입니다. 수정 전 실측 — 중첩 cwd에서 `--run-id '../../../../pwned'`가 레포 네 단계 위 파일에 append했습니다.

`..` 필터가 아니라 **run id가 실제로 갖는 모양**으로 제한합니다 — 필터는 `.../....//`와 절대경로에 집니다. 나쁜 값은 조용한 폴백이 아니라 usage 에러입니다(호출자가 특정 버킷을 지정한 것이므로).

## 5 · 키 없이 맨몸으로 착지한 자격증명이 살균을 통과했다

`sanitize.mjs`의 규칙 셋은 전부 **키에 매달려 있습니다** — `token=`·`Bearer `·`scheme://user:pass@` 중 하나가 곁에 있어야 마스킹됩니다. 그런데 로그·원장에 시크릿이 앉는 가장 흔한 모양 하나가 그 셋 어디에도 안 걸립니다: 셸 에러가 인자를 되뱉거나 스택트레이스가 URL 쿼리를 흘려서 남는 **맨몸 값**입니다.

키 없이도 스스로를 증명하는 형태를 따로 잡습니다(OpenAI · AWS · GitHub · Google · Slack · PEM 개인키 블록). 전부 발급자가 정한 고유 프리픽스+고정 길이라 오탐이 사실상 없습니다 — 진단 어휘가 우연히 `AKIA`+대문자 16자가 되지는 않습니다. 개인키는 여러 줄이라 기존 `[ \t]` 기반 규칙이 **원리적으로** 못 잡던 모양이고, 본문만 지우고 `BEGIN`/`END`는 남깁니다("여기 개인키가 있었다"가 진단에서 사라지면 안 됩니다).

T17은 **오탐 금지도 함께** 고정합니다 — `expected 401, got 403` · `Authorization: header missing` · `SESSION_SECRET: Required`가 마스킹되면 로그가 못 쓰게 됩니다.

픽스처는 이 파일 머리말의 "실제 포맷 금지" 규칙을 지키려고 **런타임에 조립**합니다. 소스에는 시크릿 모양 리터럴이 없어 커밋 시점 gitleaks가 이 테스트 자신을 잡지 않으면서, `sanitize.mjs`가 보는 문자열은 진짜 포맷이라 증명력은 그대로입니다.

## 6 · 이 레포가 자기 자신을 가리키는 경로가 GitHub 리다이렉트에만 기대고 있었다

`setup-loop-engine.action.yml.template`의 clone URL — **소비 레포의 CI가 이 플러그인을 받아서 실행하려고 돌리는 바로 그 URL** — 이 레포가 이전을 떠나온 네임스페이스를 가리켰습니다. 오늘 동작하는 건 GitHub이 리다이렉트를 유지하기 때문이고, 그 리다이렉트는 **누군가 옛 경로에 레포를 만드는 순간 멈춥니다**. 그 시점부터 모든 소비 레포의 CI는 거기 있는 걸 clone해서 실행하고, 그들의 diff는 아무것도 달라지지 않습니다.

플러그인 매니페스트 3개와 두 README의 설치 안내도 같은 옛 경로였습니다.

**일회성 정정이 아니라 게이트로 둡니다** — 실패 양상이 침묵이기 때문입니다. 옛 URL은 모든 테스트에서, CI에서, 손으로도 잘 동작했습니다. 문제가 되는 날까지 아무도 불평하지 않습니다. 기대값은 하드코딩하지 않고 `origin`에서 유도합니다: 나중에 또 이전하면 리모트를 옮기는 행위 자체가 이 게이트의 기대값을 갱신합니다(옛 경로를 stale하게 만드는 그 행위와 같은 행위입니다).

RED 실측(README 한 줄만 되돌림):

```
  A reference names a different owner for this repository than origin does (reach0908/paul-loop):
    README.md:288:claude plugin marketplace add paulkim-lansik/paul-loop
FAIL: 1 stale self-reference(s) — a clone URL or install instruction that survives only on a GitHub redirect hands the path to whoever claims the old namespace
```

## 7 · CI 최소권한 (부수)

워크플로 셋에 `permissions:` 블록이 없어 레포 기본값을 상속했습니다. 그 기본값은 이 파일 밖에서 바뀔 수 있고, 바뀌어도 여기서는 보이지 않습니다 — 서드파티 액션이 도는 잡에서 그건 미확인 쓰기 권한입니다. 셋 다 `GITHUB_TOKEN`을 전혀 쓰지 않으므로 `contents: read`를 명시합니다. `gitleaks/gitleaks-action@v2`는 커밋 SHA로 고정합니다(가변 태그의 재지정은 이 레포의 어떤 diff에도 나타나지 않습니다). GitHub 소유 `actions/*`는 범위 밖입니다 — 위협 모델이 다르고 전면 SHA 고정은 별건입니다.

---

## 감사 지적 중 **결함이 아니었던** 것 (실측해서 내림)

정직하게 남깁니다. 다섯 렌즈 감사가 낸 지적을 전부 원본에서 재확인했고, 아래 셋은 재현되지 않았습니다.

| 지적 | 실측 결과 |
|---|---|
| `relative()`가 lexical이라 심볼릭 링크로 보호 가드를 우회 가능 | **재현 안 됨.** BAC-785의 워크트리 재루팅이 그 줄보다 먼저 git으로 심볼릭 링크를 해소한다. 근거 없는 `realpath` 변경은 되돌리고 케이스만 고정 — 재루팅이 좁아지면 그때 이 케이스가 말한다. |
| `CODEOWNERS`의 `@paulkim-lansik`이 무효라 민감경로 리뷰 게이트가 꺼져 있다 | **재현 안 됨.** `gh api .../codeowners/errors`가 0건, 해당 사용자는 실제 collaborator다. |
| `verdict-state.json`의 `cmd`가 미살균이라 JSON 주입 가능 | **재현 안 됨.** `json_esc()`가 제어문자 제거 후 백슬래시·따옴표를 (그 순서로) 이스케이프한다. |

## 이번 묶음에서 **의도적으로 안 한 것**

- **`.loop/**` 파일 권한(0644→0600)** — 같은 머신 같은 사용자 범위라 실익이 낮고, 정작 자격증명이 있는 `.loop/.env`는 우리가 만드는 파일이 아니라 사용자 것입니다. 반쪽 조치보다 별건이 낫습니다.
- **레포가 제공하는 `risk-rules.json` 신뢰** — 확인해 보니 `raise()`가 단조라 룰이 등급을 **내릴 수는 없고**, `merge`/`deploy`/`send`는 하드코딩된 `HUMAN_ONLY_STAGES`라 룰 파일과 무관하게 항상 REQUIRE이며, `gate-risky-commands`의 탐지 단계도 플러그인 안에 하드코딩입니다. 남는 것은 "적대적 레포가 path 룰을 비워 라우팅을 약화"뿐인데, 룰 테이블 외부화는 ADR-0078/BAC-698의 **의도된 설계**입니다(플러그인 이식성). 코드가 아니라 결정 사안이라 손대지 않았습니다.
- **`dist/cli.js`를 CI에서 소스와 대조** · **`context-budget.mjs`가 개인 파일을 올리는 문제** — 둘 다 새 게이트/설계 결정이라 별도 이슈가 맞습니다.

## 검증

```
=== VERDICT ===
VERDICT: PASS
EXIT: 0
SUMMARY: passed=63 failed= skipped= duration_ms=119141
LOG: /Users/paul/dev/paul-loop-sec3/.loop/last-run.log
=== END VERDICT ===
```

신규 검증 3건이 스위트 로그에 실제로 있는지 문자열로 확인(자동발견이 조용히 건너뛰지 않았다는 증거):

```
$ grep -c "PASS: guard bypass + leak" .loop/last-run.log            → 1
$ grep -c "PASS: every self-reference names the canonical" ...      → 1
$ grep -c "case17 ok" .loop/last-run.log                            → 1
```

loop-memory:

```
 Test Files  11 passed (11)
      Tests  119 passed | 2 skipped (121)
```

`tsc --noEmit` exit 0.

**모든 신규 테스트를 수정 전 코드로 RED 실측했습니다** — 가드/누출/탈출 묶음 12건 RED, case17 삭제 재현, canonical-URL 게이트 1건 RED. 세 게이트 모두 "아무것도 스캔하지 않으면 FAIL"을 자기 안에 갖고 있습니다(빈 결과로 인한 가짜 그린 차단).
