### PR TITLE
fix(ship-flow): warn against direct harness-audit workflow invocation

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -19,7 +19,7 @@
       "name": "ship-flow",
       "source": "./tools/ship-flow",
       "description": "Delivery-loop skills — ship-feature (plan-to-PR autonomous loop), hotfix, retrospect, grill-with-docs (= grilling + domain-modeling), diagnosing-bugs, deps-audit, to-issues/to-prd, tdd, harness-maturity-audit, improve-codebase-architecture (built on codebase-design), resolving-merge-conflicts, wizard, to-questionnaire, ask-paul (skill router), wait-what, plus review agents and audit/research workflows — parameterized by a consuming repo's own tracker/branch-model config instead of hardcoded to one repo. dependencies: loop-engine.",
-      "version": "0.9.3",
+      "version": "0.9.4",
       "keywords": ["delivery", "git-flow", "hotfix", "ship", "release"]
     },
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ Explicit-version channel — see [README § Development status](README.md#develo
 not a SHA channel. Entries below `## loop-engine 0.2.0` and earlier predate the multi-plugin split
 and refer to `loop-engine` only (see the un-prefixed version numbers).
 
+## ship-flow 0.9.4
+
+`harness-audit` is a named workflow the `harness-maturity-audit` skill calls internally (kept
+named, not inlined, so an interrupted run can resume via `resumeFromRunId` — see the file's own
+header comment). Claude Code surfaces every named workflow in its "available skills" listing and
+allows it to be invoked directly via `Workflow({ name: ... })`, bypassing the wrapping skill —
+including the skill's report-saving/same-day-dedup logic. This produced a real duplicate-report
+incident in a consuming repo (glucofit-partners, 2026-09-02): two sessions ran a harness maturity
+audit around the same time, one through the skill and one by invoking the workflow directly, and
+only the skill-mediated run checked for an existing same-day report before writing.
+
+- **`harness-audit`'s `meta.description` now opens with an explicit do-not-invoke-directly
+  warning**, pointing at the `harness-maturity-audit` skill instead — the description is the only
+  text a workflow listing shows, so it's the one place this warning can actually reach an agent
+  deciding how to invoke it. No behavior change to the workflow itself.
+
 ## loop-engine 0.13.2 · loop-memory 0.6.2 · ship-flow 0.9.3 — SECURITY
 
 The last batch from the audit that produced 0.13.0 and 0.13.1 — six MED findings. Different files,

--- a/tools/ship-flow/.claude-plugin/plugin.json
+++ b/tools/ship-flow/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ship-flow",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "Delivery-loop skills — land and release already-verified work through a repo's real gates. Tracker- and branch-model-agnostic: reads a consuming repo's own config instead of hardcoding one repo's setup.",
   "author": {
     "name": "paulkim-lansik"

--- a/tools/ship-flow/workflows/harness-audit.js
+++ b/tools/ship-flow/workflows/harness-audit.js
@@ -14,11 +14,19 @@
 // prefixing `meta.name`. (An alternative invocation form exists, `Workflow({ scriptPath:
 // "${CLAUDE_PLUGIN_ROOT}/workflows/<file>.js" })`, used by the official code-modernization
 // plugin; it bypasses name resolution entirely and is not what this plugin uses.)
+//
+// Named workflows are surfaced in the harness's own "available skills" listing and are directly
+// callable via `Workflow({ name: ... })`, bypassing the wrapping skill entirely — including its
+// report-saving/dedup logic. This produced a real duplicate-report incident in a consuming repo
+// (glucofit-partners, 2026-09-02: two independent sessions each invoked this workflow around the
+// same time, one via the skill and one directly, and only the skill-mediated run checked for a
+// same-day report and asked before writing). `meta.description` below carries an explicit
+// do-not-invoke-directly warning as a result — it's the only text a listing shows.
 
 export const meta = {
   name: 'harness-audit',
   description:
-    "Six-lane parallel forensic audit of this repo's self-improvement loop harness — evidence-only, produces an L0-L5 scorecard",
+    "[Internal — do not invoke directly; use the harness-maturity-audit skill instead, which owns report saving/dedup] Six-lane parallel forensic audit of this repo's self-improvement loop harness — evidence-only, produces an L0-L5 scorecard",
   phases: [
     { title: 'Investigate', detail: 'Six dimensions, each measured by a parallel agent' },
     { title: 'Synthesize', detail: 'Scorecard + priority improvement list + delta vs. the prior report' },


### PR DESCRIPTION
## Summary
- `harness-audit` is a named workflow the `harness-maturity-audit` skill calls internally; Claude Code also lists it directly in the "available skills" catalog and allows `Workflow({ name: ... })` to invoke it directly, bypassing the wrapping skill's report-saving/same-day-dedup logic.
- Real incident: glucofit-partners, 2026-09-02 — two sessions ran a harness maturity audit around the same time, one through the skill, one by invoking the workflow directly; only the skill-mediated run checked for an existing same-day report before writing, producing a duplicate `docs/research/2026-09-02-*.md` report.
- Fix: `meta.description` now opens with an explicit "do not invoke directly — use the harness-maturity-audit skill" warning, since the description is the only text a workflow listing shows. No behavior change to the workflow itself. Bumped `ship-flow` 0.9.3 → 0.9.4 in both `plugin.json` and `marketplace.json`, plus a CHANGELOG entry.

## Test plan
- [x] `claude plugin validate ./tools/ship-flow --strict` passes
- [x] Diff scoped to exactly the 4 intended files (marketplace.json, plugin.json, CHANGELOG.md, harness-audit.js)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UgzJ4a6wzYwi2eJnvWtbic