### PR TITLE
fix(loop-engine): ac-verify.sh fake-greens a 0-executed verify: command

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "loop-engine",
       "source": "./tools/loop-engine",
       "description": "Core loop mechanics: verdict-run (machine-readable PASS/FAIL contract), loop-fix (closed verify->fix loop), lessons (verified-fix memory), classify-risk, require-tests, plugin-path (resolve sibling plugin install paths), check-docs-hygiene/check-pr-hygiene/check-module-size/check-skill-refs (repo hygiene gates). No framework opinions beyond \"the verifier is the ceiling, never the agent's self-report\".",
-      "version": "0.13.2",
+      "version": "0.13.3",
       "keywords": ["verifier", "tdd", "loop", "verdict", "lessons"]
     },
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ Explicit-version channel — see [README § Development status](README.md#develo
 not a SHA channel. Entries below `## loop-engine 0.2.0` and earlier predate the multi-plugin split
 and refer to `loop-engine` only (see the un-prefixed version numbers).
 
+## loop-engine 0.13.3
+
+`ac-verify.sh` (the AC-level success contract gate) gated an AC's `verify:` field purely on
+`verdict-run.sh`'s exit code. A `verify:` command like `vitest run -t "<pattern>"` whose `-t`
+filter matches zero test titles exits 0 by vitest's own default ("0 run" / all-skipped) — so a
+mistyped or drifted filter was silently certified PASS, having exercised nothing. This produced a
+real false-PASS incident in a consuming repo (glucofit-partners, BAC-837), reproduced live against
+this exact published version during a 2026-09-02 harness maturity audit (BAC-1010). Distinct from
+`require-tests.sh`'s existing zero-**matched-files** guard (a test glob matching no files) — this
+is zero-matched-**test-titles** inside a file that genuinely exists and runs, which that guard has
+no reach into.
+
+- **`ac-verify.sh`'s verify branch now also fails closed on a zero-executed verify: command.**
+  When `verdict-run.sh` exits 0, its own best-effort `passed=`/`failed=`/`skipped=` counts (already
+  extracted from the wrapped command's output, jest/vitest/node --test/pytest shapes) are checked:
+  skipped positive, passed and failed both absent-or-zero means nothing actually ran. That AC now
+  reports `FAIL` with an explicit `0 tests executed — verify command exited 0 but ran nothing ...`
+  reason, instead of `PASS`. An ordinary non-test-runner `verify:` command (`true`, a shell
+  one-liner) never matches any of `verdict-run.sh`'s count patterns, so this stays silent — no
+  false positive on the common case.
+- Regression coverage added to `tools/loop-engine/test/ac-verify.test.sh` (block `(u)`):
+  jest-style and vitest's actual colon-less zero-match summary shapes both FAIL, a real passing run
+  (skipped=0) and an ordinary non-test `verify:` command both still PASS.
+
 ## ship-flow 0.9.4
 
 `harness-audit` is a named workflow the `harness-maturity-audit` skill calls internally (kept

--- a/tools/loop-engine/.claude-plugin/plugin.json
+++ b/tools/loop-engine/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "loop-engine",
-  "version": "0.13.2",
+  "version": "0.13.3",
   "description": "Core loop mechanics: verdict-run (machine-readable PASS/FAIL contract), loop-fix (closed verify->fix loop), lessons (verified-fix memory), classify-risk, require-tests, check-docs-hygiene/check-pr-hygiene/check-module-size (repo hygiene gates). verifier=ceiling — the agent's self-judgement never substitutes for it.",
   "author": {
     "name": "paulkim-lansik"

--- a/tools/loop-engine/bin/ac-verify.sh
+++ b/tools/loop-engine/bin/ac-verify.sh
@@ -41,9 +41,13 @@
 # Per contracted AC:
 #   - verify:    run via `verdict-run.sh --log <per-AC log> -- sh -c "<command>"` (same
 #                `-- sh -c` invocation loop-fix.sh uses). verdict-run.sh's own exit code decides
-#                this check: 0 = pass, nonzero = fail. A verdict-run.sh exit of 2 (its own
-#                usage-error / fail-closed refusal) is NOT a normal AC failure — it aborts
-#                ac-verify.sh itself with exit 2, same as loop-fix.sh's handling of the same case.
+#                this check: 0 = pass, nonzero = fail — UNLESS verdict-run.sh's own best-effort
+#                passed=/failed=/skipped= counts show zero tests actually ran (e.g. a vitest `-t`
+#                filter matching zero test titles: exit 0, "0 run"/all-skipped) — that is fail-closed
+#                to FAIL too (BAC-837/BAC-1010: a mistyped/drifted filter must not silently PASS).
+#                A verdict-run.sh exit of 2 (its own usage-error / fail-closed refusal) is NOT a
+#                normal AC failure — it aborts ac-verify.sh itself with exit 2, same as loop-fix.sh's
+#                handling of the same case.
 #   - artifacts: each comma-separated path must exist (`-e`), resolved relative to the CWD
 #                ac-verify.sh itself runs from (NOT the plan file's directory — verify commands
 #                and artifacts are expected relative to the repo/worktree root, same as verify
@@ -381,6 +385,29 @@ while IFS= read -r line || [ -n "$line" ]; do
           reasons+=("verify exited $real_exit")
         else
           reasons+=("verify failed (verdict-run.sh exit $vcode)")
+        fi
+      else
+        # Fake-green hole (BAC-837/BAC-1010): a `verify:` command can exit 0 while having actually
+        # exercised NOTHING — e.g. `vitest run -t "<pattern>"` where the -t filter matches zero
+        # test titles. vitest's default behavior there is "0 run / N skipped" with exit 0. Gating
+        # PASS purely on vcode (as above) silently certifies a mistyped/drifted filter as passing.
+        #
+        # Reuse verdict-run.sh's own best-effort passed=/failed=/skipped= count extraction (its
+        # SUMMARY line) rather than re-parsing test-runner output ourselves — it already recognizes
+        # jest/vitest ("Tests: N failed, N passed, N skipped" and the colon-less "N skipped (N)"
+        # shape, via its pytest-style fallback), node --test, and pytest. Signal: skipped is a
+        # positive number while passed and failed are both absent-or-zero — nothing actually ran,
+        # everything was skipped. A command that isn't a test runner at all (`true`, `echo ...`)
+        # never matches any of verdict-run.sh's count patterns, so all three stay empty and this
+        # check stays silent — no false positive on ordinary non-test verify: commands.
+        vr_summary="$(printf '%s\n' "$vr_out" | grep -m1 '^SUMMARY: ')"
+        vr_skipped="$(printf '%s' "$vr_summary" | sed -n 's/.*skipped=\([0-9]*\).*/\1/p')"
+        vr_passed="$(printf '%s' "$vr_summary" | sed -n 's/.*passed=\([0-9]*\).*/\1/p')"
+        vr_failed="$(printf '%s' "$vr_summary" | sed -n 's/.*failed=\([0-9]*\).*/\1/p')"
+        if [ -n "$vr_skipped" ] && [ "$vr_skipped" -gt 0 ] \
+           && { [ -z "$vr_passed" ] || [ "$vr_passed" -eq 0 ]; } \
+           && { [ -z "$vr_failed" ] || [ "$vr_failed" -eq 0 ]; }; then
+          reasons+=("0 tests executed — verify command exited 0 but ran nothing (passed=${vr_passed:-0} failed=${vr_failed:-0} skipped=$vr_skipped) — likely a filter/pattern mismatch")
         fi
       fi
     else

--- a/tools/loop-engine/test/ac-verify.test.sh
+++ b/tools/loop-engine/test/ac-verify.test.sh
@@ -360,6 +360,43 @@ OUT_S2="$(env -u LOOP_DIR "$AC_VERIFY" plan.md --log-dir --weird 2>&1)"; CODE_S2
 [ "$CODE_S2" -eq 2 ] || fail "(s2): expected exit 2 (flag-shaped --log-dir value), got $CODE_S2: $OUT_S2"
 printf '%s' "$OUT_S2" | grep -qi 'requires a directory path' || fail "(s2): expected a clear error naming --log-dir's value as flag-shaped, got: $OUT_S2"
 
+# ==== (u) BAC-837/BAC-1010 regression: a `verify:` command that EXITS 0 but actually ran zero
+# tests (e.g. `vitest run -t "<pattern>"` whose -t filter matches zero test titles — vitest's
+# default is "0 run"/all-skipped, exit 0) must FAIL the AC, not silently PASS. verdict-run.sh's own
+# best-effort passed=/failed=/skipped= count extraction is reused as the signal — no re-parsing of
+# test-runner output inside ac-verify.sh itself. Fake test runners (`printf`) stand in for real
+# vitest/jest here so this stays fast and dependency-free, matching this suite's existing style. ====
+SUB="$DIR/u"; mkdir -p "$SUB"; cd "$SUB" || fail "cd u"
+
+# ---- (u1) jest/vitest colon-style zero-match line: "Tests: 0 failed, 0 passed, N skipped, N total" ----
+printf -- '- AC: t-filter zero match (jest-style) | verify: printf "Tests: 0 failed, 0 passed, 5 skipped, 5 total\\n"\n' > plan-u1.md
+OUT_U1="$(run_ac_verify plan-u1.md .loop-u1 2>&1)"; CODE_U1=$?
+[ "$CODE_U1" -eq 1 ] || fail "(u1): a verify: command that exits 0 but ran zero tests must FAIL the AC (not silently PASS), got $CODE_U1: $OUT_U1"
+printf '%s' "$OUT_U1" | grep -qE '^SUMMARY: passed=0 failed=1 skipped=0 ' || fail "(u1): expected failed=1 at the ac-verify.sh aggregate level: $OUT_U1"
+printf '%s' "$OUT_U1" | grep -q '^FAIL: AC "t-filter zero match (jest-style)":.*0 tests executed' || fail "(u1): expected a FAIL line naming '0 tests executed': $OUT_U1"
+
+# ---- (u2) vitest's actual colon-less summary shape: "Tests  5 skipped (5)" (no "passed"/"failed"
+# words at all — only verdict-run.sh's pytest-style fallback pattern can see this one) ----
+printf -- '- AC: t-filter zero match (vitest-style) | verify: printf "     Tests  5 skipped (5)\\n"\n' > plan-u2.md
+OUT_U2="$(run_ac_verify plan-u2.md .loop-u2 2>&1)"; CODE_U2=$?
+[ "$CODE_U2" -eq 1 ] || fail "(u2): vitest's colon-less all-skipped summary must also FAIL the AC, got $CODE_U2: $OUT_U2"
+printf '%s' "$OUT_U2" | grep -q '^FAIL: AC "t-filter zero match (vitest-style)":.*0 tests executed' || fail "(u2): expected a FAIL line naming '0 tests executed': $OUT_U2"
+
+# ---- (u3) control: a REAL passing run (skipped=0) must NOT be flagged — proves this is not a
+# blanket rejection of every test-runner-shaped SUMMARY line, only the all-skipped/zero-run one ----
+printf -- '- AC: real tests actually ran | verify: printf "Tests: 0 failed, 5 passed, 0 skipped, 5 total\\n"\n' > plan-u3.md
+OUT_U3="$(run_ac_verify plan-u3.md .loop-u3 2>&1)"; CODE_U3=$?
+[ "$CODE_U3" -eq 0 ] || fail "(u3): a verify: command reporting real passes (skipped=0) must still PASS, got $CODE_U3: $OUT_U3"
+printf '%s' "$OUT_U3" | grep -qE '^SUMMARY: passed=1 failed=0 skipped=0 ' || fail "(u3): expected passed=1 at the ac-verify.sh aggregate level: $OUT_U3"
+
+# ---- (u4) control: an ordinary non-test-runner verify: command (no passed=/failed=/skipped=
+# signal at all) must be completely unaffected by this check — proves no false positive on the
+# common case (verify: true / a shell one-liner) ----
+printf -- '- AC: ordinary non-test verify | verify: true\n' > plan-u4.md
+OUT_U4="$(run_ac_verify plan-u4.md .loop-u4 2>&1)"; CODE_U4=$?
+[ "$CODE_U4" -eq 0 ] || fail "(u4): an ordinary verify: command with no test-runner-shaped output must still PASS, got $CODE_U4: $OUT_U4"
+printf '%s' "$OUT_U4" | grep -qE '^SUMMARY: passed=1 failed=0 skipped=0 ' || fail "(u4): expected passed=1: $OUT_U4"
+
 cd "$ORIG_PWD" || true
-echo "PASS: ac-verify.sh (issue #23) — zero-AC/zero-contract fail-closed, independent verify:/artifacts:/expect: checks, mixed pass+fail and contracted+uncontracted aggregation, Verdict Contract block shape, verdict-state.json aggregate-sync via an EXIT trap covering early-exit paths too (not last-writer-wins, not just the normal-completion path, and now armed BEFORE argument parsing itself), --log-dir/LOOP_DIR coupling applied inline the instant --log-dir is parsed (isolated verdict-state.json per --log-dir, correct even when a later argument errors), flag-shaped --log-dir values rejected up front, case/markdown-emphasis-tolerant field parsing, unrecognized-field-like-segment warning (both colon-containing and colon-omitted typos)"
+echo "PASS: ac-verify.sh (issue #23) — zero-AC/zero-contract fail-closed, independent verify:/artifacts:/expect: checks, mixed pass+fail and contracted+uncontracted aggregation, Verdict Contract block shape, verdict-state.json aggregate-sync via an EXIT trap covering early-exit paths too (not last-writer-wins, not just the normal-completion path, and now armed BEFORE argument parsing itself), --log-dir/LOOP_DIR coupling applied inline the instant --log-dir is parsed (isolated verdict-state.json per --log-dir, correct even when a later argument errors), flag-shaped --log-dir values rejected up front, case/markdown-emphasis-tolerant field parsing, unrecognized-field-like-segment warning (both colon-containing and colon-omitted typos), zero-executed/all-skipped verify: commands FAIL instead of fake-greening (BAC-837/BAC-1010)"
 exit 0


### PR DESCRIPTION
## Summary

- `ac-verify.sh` (the AC-level success contract gate) gated an AC's `verify:` field purely on `verdict-run.sh`'s exit code. A command like `vitest run -t "<pattern>"` whose `-t` filter matches zero test titles exits **0** by vitest's own default ("0 run" / all-skipped) — so a mistyped or drifted filter was silently certified `PASS`, having exercised nothing.
- This is a real reported incident (BAC-837 in the consuming glucofit-partners repo) and was reproduced live against the currently-published plugin version (0.13.2) during a 2026-09-02 harness maturity audit.
- Distinct from `require-tests.sh`'s existing zero-**matched-files** guard (a test glob matching no files at all) — this bug is zero-matched-**test-titles** inside a file that genuinely exists and runs, which that guard has no reach into.

## Fix

When `verdict-run.sh` exits 0, `ac-verify.sh` now also checks `verdict-run.sh`'s own best-effort `passed=`/`failed=`/`skipped=` counts (already extracted from the wrapped command's output — jest/vitest colon-style, vitest's colon-less "N skipped (N)" shape via the existing pytest-style fallback pattern, node `--test`, and pytest). Signal: `skipped` positive, `passed` and `failed` both absent-or-zero — nothing actually ran. That AC now reports `FAIL` with an explicit `0 tests executed — verify command exited 0 but ran nothing ...` reason instead of `PASS`.

An ordinary non-test-runner `verify:` command (`true`, a shell one-liner) never matches any of `verdict-run.sh`'s count patterns, so all three counts stay empty and this check stays silent — no false positive on the common case.

No changes to `verdict-run.sh` itself — its count extraction is reused as-is, not re-invented.

## How I verified this actually closes the hole

1. Added regression block `(u)` to `tools/loop-engine/test/ac-verify.test.sh`:
   - `(u1)`: jest/vitest colon-style zero-match summary (`Tests: 0 failed, 0 passed, 5 skipped, 5 total`) → must FAIL
   - `(u2)`: vitest's *actual* colon-less summary shape (`     Tests  5 skipped (5)`, no "passed"/"failed" words at all) → must FAIL
   - `(u3)` control: a real passing run (`skipped=0`) → must still PASS (proves this isn't a blanket rejection of test-runner-shaped output)
   - `(u4)` control: an ordinary non-test `verify: true` → must still PASS (proves no false positive on the common case)
2. **Red/green proof**: stashed the fix (`git stash push -- tools/loop-engine/bin/ac-verify.sh`), reran the test file against the pre-fix binary — `(u1)` failed exactly as expected, with the script printing `VERDICT: PASS` / `EXIT: 0` for the synthetic zero-match AC (the fake-green reproduced verbatim). Restored the fix, reran — all pass.
3. Full self-test suite: `bash tools/loop-engine/test/run.sh` → **64/64 passed** (63 pre-existing + the new block, no regressions).
4. `claude plugin validate ./tools/loop-engine --strict` → passed, after the version bump.
5. `claude plugin validate --strict .` (root marketplace manifest) → passed.

## Version bump

`loop-engine` 0.13.2 → 0.13.3 (patch, bug fix) in both `tools/loop-engine/.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json`. `CHANGELOG.md` entry added at the top matching the repo's existing per-plugin section style.

## Reference

BAC-1010 (glucofit-partners Linear tracker) — filed as a cross-repo tracking issue for this exact fix. No cross-repo Linear link mechanism exists between these two repos, so this is a text reference only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UgzJ4a6wzYwi2eJnvWtbic