### PR TITLE
feat(loop-engine,ship-flow): recall 계측 축 + adversarial-review 팬아웃 상한

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,14 +12,14 @@
       "name": "loop-engine",
       "source": "./tools/loop-engine",
       "description": "Core loop mechanics: verdict-run (machine-readable PASS/FAIL contract), loop-fix (closed verify->fix loop), lessons (verified-fix memory), classify-risk, require-tests, plugin-path (resolve sibling plugin install paths), check-docs-hygiene/check-pr-hygiene/check-module-size/check-skill-refs (repo hygiene gates). No framework opinions beyond \"the verifier is the ceiling, never the agent's self-report\".",
-      "version": "0.13.3",
+      "version": "0.14.0",
       "keywords": ["verifier", "tdd", "loop", "verdict", "lessons"]
     },
     {
       "name": "ship-flow",
       "source": "./tools/ship-flow",
       "description": "Delivery-loop skills — ship-feature (plan-to-PR autonomous loop), hotfix, retrospect, grill-with-docs (= grilling + domain-modeling), diagnosing-bugs, deps-audit, to-issues/to-prd, tdd, harness-maturity-audit, improve-codebase-architecture (built on codebase-design), resolving-merge-conflicts, wizard, to-questionnaire, ask-paul (skill router), wait-what, plus review agents and audit/research workflows — parameterized by a consuming repo's own tracker/branch-model config instead of hardcoded to one repo. dependencies: loop-engine.",
-      "version": "0.9.4",
+      "version": "0.10.0",
       "keywords": ["delivery", "git-flow", "hotfix", "ship", "release"]
     },
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,59 @@ Explicit-version channel — see [README § Development status](README.md#develo
 not a SHA channel. Entries below `## loop-engine 0.2.0` and earlier predate the multi-plugin split
 and refer to `loop-engine` only (see the un-prefixed version numbers).
 
+## loop-engine 0.14.0 · ship-flow 0.10.0
+
+Two measurement gaps, found by pointing a token/cost research report at this repo and then checking
+every one of its claims against the actual code. Most of the report's recommendations did not
+survive that check — the harness invokes no LLM of its own (`--verify` is a shell exit code,
+`--fix` is a user-supplied command), so "route verify to a cheaper model" and "align the prompt
+cache prefix" had nothing to attach to, and the always-on context audit it asked for already exists
+as `bin/context-budget.mjs`. What did survive were two places where **this repo cannot see its own
+behaviour**.
+
+- **`run-metrics.mjs` now folds the `memory.recall` ledger.** loop-memory's recall hook is
+  fail-open by contract (a `UserPromptSubmit` hook exiting non-zero discards the user's prompt), so
+  "nothing to recall" and "broken" look identical from outside — the ledger is the only thing that
+  tells them apart, and no aggregator read it. Measured in a consuming repo (glucofit-partners,
+  958 firings): `cli_failed` ran at **89% of attempted for six days** (2026-08-27→09-01, 626
+  events) with zero user-visible symptom, and was fixed by an unrelated change without anyone being
+  able to confirm the recovery. Three axes are now reported, per-run and overall:
+  - *Failure rate over `attempted` (= fired − skipped), not over `fired`.* Self-gated firings (no
+    embedding key, prompt under 8 chars) are not failures; counting them in the denominator diluted
+    89% down to 65%.
+  - *Cutoff efficacy at the hit level* (`candidates` / `passed` / `dropped`), not via the
+    `above_cutoff` reason. That reason only fires when **every** candidate is dropped: it showed 1
+    event out of 958 while the hit-level count showed 55 dropped out of 456. Reported per corpus —
+    `lessons` dropped 4.4% where `knowledge` dropped 19.7%, a split a single merged number hides.
+  - *Observed nearest-distance distribution beside the observed cutoff.* The right cutoff is
+    embedder-dependent and the code default (0.65) is documented as a loose safety net; this is the
+    only way to tell whether the configured value is doing work. It reports and warns; it does not
+    retune anything, because a sample from one embedder is not grounds to move a default for
+    everyone.
+  Zero `memory.recall` events report `INSUFFICIENT_DATA` rather than a healthy-looking 0%, matching
+  the rest of the file. Coverage: `test/run-metrics-recall.test.sh`.
+- **`adversarial-review`'s verification fan-out is bounded.** Total agents were
+  `domains + 3 × findings + 1` with **no cap on `findings`** — one domain returning 20 findings
+  spawns 60 verifier agents on its own, and the workflow authoring reference this script is written
+  against both caps workflows far below that and requires (`no silent caps`) that any bounded
+  coverage be logged. The finder schema now requires a `severity`, findings are verified in
+  severity order, and each domain verifies at most `maxVerifiedPerDomain` (default 8, raise it via
+  args for a deliberately exhaustive run). Nothing is discarded: findings past the cap come back as
+  `unverifiedOverCap` — a separate field from `unverified` (which means verification ran but too
+  few votes returned) — and the drop is `log()`'d, so a truncated review cannot read as a complete
+  one. Coverage: `test/adversarial-review-fanout.test.sh`, which runs the real script under a stub
+  harness and counts agents (60 before, 24 after). The completeness critic is also told which
+  findings went unverified, so it cannot report full coverage over a capped run.
+  - **The refutation votes were deliberately left at full strength.** Routing them to a cheaper
+    model or lower effort was the obvious token saving and is the wrong trade for this plugin: the
+    votes *are* the verifier, and a cheaper skeptic is precisely how a plausible-but-wrong finding
+    survives. The test asserts they carry no `model` pin and no `low` effort, so that the next
+    cost-cutting pass cannot quietly erode `verifier = ceiling`. Bound the quantity of
+    verification, never its quality.
+- Dependent plugins' `loop-engine` ranges widened to `^0.14.0` (`plugin-dep-range.test.sh` — a
+  caret on a 0.x line excludes the next minor, and `claude plugin update` reports success while
+  keeping the old version).
+
 ## loop-engine 0.13.3
 
 `ac-verify.sh` (the AC-level success contract gate) gated an AC's `verify:` field purely on

--- a/tools/loop-engine/.claude-plugin/plugin.json
+++ b/tools/loop-engine/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "loop-engine",
-  "version": "0.13.3",
+  "version": "0.14.0",
   "description": "Core loop mechanics: verdict-run (machine-readable PASS/FAIL contract), loop-fix (closed verify->fix loop), lessons (verified-fix memory), classify-risk, require-tests, check-docs-hygiene/check-pr-hygiene/check-module-size (repo hygiene gates). verifier=ceiling — the agent's self-judgement never substitutes for it.",
   "author": {
     "name": "paulkim-lansik"

--- a/tools/loop-engine/bin/run-metrics.mjs
+++ b/tools/loop-engine/bin/run-metrics.mjs
@@ -16,6 +16,21 @@
 //        "post-compaction"으로 표시한다(압축이 여러 번 연달아 와도 "최근 압축됨" 불리언 상태로
 //        취급 — 압축마다 같은 다음 verdict를 중복 카운트하지 않는다). 이 표본들 중 verdict.failed
 //        비율이 post_compaction_red — 체크포인트(별도 조건부 이슈) 착수 여부의 실측 근거.
+//   recall 건전성 = loop-memory의 memory.recall 원장(hooks/recall-lessons.mjs가 UserPromptSubmit
+//        마다 1줄 남긴다) fold. 이 훅은 **fail-open 계약**(항상 exit 0)이라 "안 붙었다"와 "고장났다"가
+//        겉으로 같다 — 원장만이 둘을 가른다. 그런데 이 축을 아무도 fold하지 않아, 소비 레포에서
+//        cli_failed가 6일간 attempted의 89%였는데 무증상으로 지나갔다(2026-08-27~09-01 실측 626건).
+//        그래서 여기서 세 가지를 따로 보고한다:
+//        · 실패율 = error / attempted. **분모는 fired가 아니라 attempted**(= fired − skipped) —
+//          키 부재·짧은 프롬프트 같은 self-gate는 고장이 아니므로 실패율을 희석하면 안 된다.
+//        · 컷오프 실효성 = hit 단위 dropped/candidates. `above_cutoff` 사유(=후보 전부 탈락)만 세면
+//          과소보고된다: 실측에서 above_cutoff는 958건 중 1건이었지만 hit 단위로는 456개 중 55개
+//          (12%)가 탈락했다. 코퍼스별로 갈라 보고한다 — lessons와 knowledge는 임베딩 분포가 달라
+//          한 숫자로 합치면 둘 다 못 읽는다(실측: lessons 4.4% vs knowledge 19.7%).
+//        · nearest distance 분포(min/median/max)와 관측된 컷오프값. 컷오프는 임베더 의존이라
+//          코드 기본값 0.65가 맞는지 알려면 **관측 분포와 나란히 놓는 것 말고 방법이 없다**.
+//          여기서 교정값을 자동으로 정하지는 않는다(표본이 임베더 1종에 묶여 있다) — 사람이 읽고
+//          userConfig로 정한다.
 //   서브에이전트(BAC-778) = started / stopped_paired / stopped_unattributed 3분할. 플랫폼이
 //        SubagentStart가 안 뜨는 종류에도 SubagentStop을 쏘고 그 이벤트엔 agent_type이 없다(실측) —
 //        stopped 총계는 "서브에이전트 수"를 뒷받침하지 못하므로 짝이 맞은 것만 따로 센다.
@@ -66,6 +81,62 @@ for (const r of H1_EXCLUDED_SURFACES) {
 const excludedTotal = {}
 for (const s of knownSurfaces) excludedTotal[s] = 0
 
+// recall 원장이 쓰는 두 코퍼스. 하나로 합치지 않는 이유는 헤더 참조(임베딩 분포가 다르다).
+const RECALL_CORPORA = ['lessons', 'knowledge']
+
+// memory.recall 이벤트 배열 1런분 fold. hooks/recall-lessons.mjs가 쓰는 payload 스키마를 그대로
+// 읽는다: outcome(injected|no_match|skipped|error) · reason(고정 슬러그) · <corpus>{candidates,near,
+// nearest} · cutoffs{<corpus>} · injected_chars. 필드 부재는 0/미집계로 흘리고 절대 날조하지 않는다
+// (훅이 페이로드를 비관적으로 시드하므로 예기치 못한 종료 경로도 reason 슬러그는 남긴다).
+function foldRecall(events) {
+  const byReason = {}
+  const corpus = {}
+  const cutoffs = {}
+  for (const c of RECALL_CORPORA) {
+    corpus[c] = { candidates: 0, passed: 0, nearest: [] }
+    cutoffs[c] = []
+  }
+  let injected = 0
+  let skipped = 0
+  let failed = 0
+  let injectedChars = 0
+  for (const e of events) {
+    const p = e.payload ?? {}
+    // reason이 없는 줄도 'unknown'으로 세어 표에 남긴다 — 침묵 탈락 금지(파일 관례).
+    const reason = typeof p.reason === 'string' && p.reason ? p.reason : 'unknown'
+    byReason[reason] = (byReason[reason] ?? 0) + 1
+    if (p.outcome === 'skipped') skipped++
+    else if (p.outcome === 'error') failed++
+    else if (p.outcome === 'injected') {
+      injected++
+      if (Number.isFinite(p.injected_chars)) injectedChars += p.injected_chars
+    }
+    for (const c of RECALL_CORPORA) {
+      const b = p[c]
+      if (b && typeof b === 'object') {
+        if (Number.isFinite(b.candidates)) corpus[c].candidates += b.candidates
+        if (Number.isFinite(b.near)) corpus[c].passed += b.near
+        if (Number.isFinite(b.nearest)) corpus[c].nearest.push(b.nearest)
+      }
+      const cut = p.cutoffs?.[c]
+      // 관측된 컷오프값은 전부 모은다 — 런 도중 userConfig가 바뀌면 여러 값이 보여야 한다.
+      if (Number.isFinite(cut) && !cutoffs[c].includes(cut)) cutoffs[c].push(cut)
+    }
+  }
+  return {
+    fired: events.length,
+    // 분모는 attempted — self-gate(키 부재·짧은 프롬프트)는 고장이 아니다(헤더 참조).
+    attempted: events.length - skipped,
+    injected,
+    failed,
+    skipped,
+    by_reason: byReason,
+    injected_chars: injectedChars,
+    corpus,
+    cutoffs,
+  }
+}
+
 let skippedLines = 0
 let skippedFiles = 0
 const runs = []
@@ -99,6 +170,7 @@ for (const f of files) {
   const compactions = []
   const startedAgentIds = new Set()
   const stoppedAgentIds = []
+  const recallEvents = []
   for (const e of events) {
     if (e.type === 'subagent.started') {
       if (e.payload?.agent_id) startedAgentIds.add(e.payload.agent_id)
@@ -117,6 +189,8 @@ for (const f of files) {
       verdicts.push(e)
     } else if (e.type === 'compaction') {
       compactions.push(e)
+    } else if (e.type === 'memory.recall') {
+      recallEvents.push(e)
     }
   }
   verdicts.sort((x, y) => String(x.ts).localeCompare(String(y.ts))) // ts 순 안정 정렬(파일 순 보조)
@@ -144,6 +218,7 @@ for (const f of files) {
   // "stopped 수 = 서브에이전트 수"는 뒷받침되지 않는 숫자다 — 짝이 맞은 것과 귀속 불가를 분리해
   // 보고하고, 지속시간/성공률 같은 파생은 짝 맞은 모집단에서만 도출하게 한다.
   const stoppedPaired = stoppedAgentIds.filter((id) => id && startedAgentIds.has(id)).length
+  const recall = foldRecall(recallEvents)
   runs.push({
     run_id: runId,
     instrumented,
@@ -158,6 +233,7 @@ for (const f of files) {
       stopped_paired: stoppedPaired,
       stopped_unattributed: stoppedAgentIds.length - stoppedPaired,
     },
+    recall,
   })
 }
 
@@ -179,6 +255,87 @@ const h1Values = instrumentedRuns.map((r) => r.h1)
 const compactionsTotal = attributed.reduce((sum, r) => sum + r.compactions, 0)
 const postCompactionSamples = attributed.flatMap((r) => r.post_compaction_red)
 const postCompactionRedCount = postCompactionSamples.filter(Boolean).length
+
+// recall은 **runs 전체**를 접는다 — Q1/Q2/H1과 달리 'unknown' 버킷을 빼지 않는다. 그 제외 근거는
+// "append-only 의사-런이 *런 단위* 분모를 희석한다"인데, recall 지표는 런이 아니라 **이벤트 단위**
+// 비율(failed/attempted, dropped/candidates)이라 그 논거가 적용되지 않는다. 오히려 self-gate 발화는
+// 세션 귀속이 안 돼 unknown으로 떨어지는 경우가 있어(liveness.mjs 폴백), 빼면 attempted 분모가
+// 왜곡된다. regression-signals.mjs가 같은 이유로 같은 분기를 한 선례가 있다.
+const recallFolds = runs.map((r) => r.recall)
+const recallTotal = {
+  fired: 0,
+  attempted: 0,
+  injected: 0,
+  failed: 0,
+  skipped: 0,
+  injected_chars: 0,
+  by_reason: {},
+  corpus: {},
+  cutoffs: {},
+}
+for (const c of RECALL_CORPORA) {
+  recallTotal.corpus[c] = { candidates: 0, passed: 0, nearest: [] }
+  recallTotal.cutoffs[c] = []
+}
+for (const f of recallFolds) {
+  for (const k of ['fired', 'attempted', 'injected', 'failed', 'skipped', 'injected_chars']) {
+    recallTotal[k] += f[k]
+  }
+  for (const [k, v] of Object.entries(f.by_reason)) {
+    recallTotal.by_reason[k] = (recallTotal.by_reason[k] ?? 0) + v
+  }
+  for (const c of RECALL_CORPORA) {
+    recallTotal.corpus[c].candidates += f.corpus[c].candidates
+    recallTotal.corpus[c].passed += f.corpus[c].passed
+    recallTotal.corpus[c].nearest.push(...f.corpus[c].nearest)
+    for (const cut of f.cutoffs[c]) {
+      if (!recallTotal.cutoffs[c].includes(cut)) recallTotal.cutoffs[c].push(cut)
+    }
+  }
+}
+
+// 결손 축은 INSUFFICIENT_DATA를 1급으로 — 훅 미설치/미발화를 0%처럼 보이게 하지 않는다.
+const recallOverall =
+  recallTotal.fired === 0
+    ? INSUFFICIENT
+    : {
+        fired: recallTotal.fired,
+        attempted: recallTotal.attempted,
+        injected: recallTotal.injected,
+        failed: recallTotal.failed,
+        skipped: recallTotal.skipped,
+        // attempted=0(전부 self-gate)이면 비율은 정의되지 않는다 — 0으로 뭉개지 않는다.
+        failure_ratio: recallTotal.attempted > 0 ? recallTotal.failed / recallTotal.attempted : INSUFFICIENT,
+        injected_chars_total: recallTotal.injected_chars,
+        injected_chars_mean:
+          recallTotal.injected > 0 ? recallTotal.injected_chars / recallTotal.injected : INSUFFICIENT,
+        by_reason: recallTotal.by_reason,
+        corpus: Object.fromEntries(
+          RECALL_CORPORA.map((c) => {
+            const b = recallTotal.corpus[c]
+            const dropped = b.candidates - b.passed
+            return [
+              c,
+              {
+                candidates: b.candidates,
+                passed_cutoff: b.passed,
+                dropped_by_cutoff: dropped,
+                // 컷오프 실효성. candidates=0이면 비율이 없다(임베더 미가동/코퍼스 공백).
+                dropped_ratio: b.candidates > 0 ? dropped / b.candidates : INSUFFICIENT,
+                nearest: b.nearest.length
+                  ? {
+                      n: b.nearest.length,
+                      min: Math.min(...b.nearest),
+                      median: median(b.nearest),
+                      max: Math.max(...b.nearest),
+                    }
+                  : INSUFFICIENT,
+                cutoffs_observed: recallTotal.cutoffs[c],
+              },
+            ]
+          }),
+        ),
+      }
 
 const overall = {
   runs: runs.length,
@@ -211,6 +368,7 @@ const overall = {
         total: postCompactionSamples.length,
       }
     : INSUFFICIENT,
+  recall: recallOverall,
 }
 
 if (asJson) {
@@ -251,6 +409,46 @@ if (asJson) {
       ? `post_compaction_red (압축 직후 첫 verdict가 RED인 비율): ${fmt(overall.post_compaction_red.ratio)} (${overall.post_compaction_red.red}/${overall.post_compaction_red.total})`
       : `post_compaction_red (압축 직후 첫 verdict가 RED인 비율): ${overall.post_compaction_red}`,
   )
+  if (overall.recall === INSUFFICIENT) {
+    lines.push(`recall (loop-memory 시맨틱 회수): ${INSUFFICIENT} (memory.recall 이벤트 0 — 훅 미설치이거나 한 번도 발화하지 않았다)`)
+  } else {
+    const rc = overall.recall
+    lines.push(
+      'recall (loop-memory 시맨틱 회수 — 훅이 fail-open이라 원장만이 "안 붙음"과 "고장"을 가른다):',
+    )
+    lines.push(
+      `  fired=${rc.fired} attempted=${rc.attempted} (=fired−skipped) injected=${rc.injected} failed=${rc.failed} ` +
+        `failure_ratio=${fmt(rc.failure_ratio)} (attempted 기준 — self-gate는 고장이 아니라 분모에서 뺀다)`,
+    )
+    lines.push(
+      `  by_reason: ${Object.entries(rc.by_reason).sort((a, b) => b[1] - a[1]).map(([k, v]) => `${k}=${v}`).join(' ')}`,
+    )
+    lines.push(
+      `  injected_chars: total=${rc.injected_chars_total} mean=${fmt(rc.injected_chars_mean)} (주입 1회당 문자수 — 컨텍스트 세금)`,
+    )
+    for (const c of RECALL_CORPORA) {
+      const b = rc.corpus[c]
+      // 거리는 3자리로 — 실측 대역이 0.08~0.27로 좁아 fmt()의 2자리로는 컷오프와의 간격이 뭉갠다.
+      const d = (v) => (typeof v === 'number' ? v.toFixed(3) : String(v))
+      const near =
+        b.nearest === INSUFFICIENT
+          ? INSUFFICIENT
+          : `min=${d(b.nearest.min)} median=${d(b.nearest.median)} max=${d(b.nearest.max)} (n=${b.nearest.n})`
+      lines.push(
+        `  ${c.padEnd(9)}: candidates=${b.candidates} passed=${b.passed_cutoff} dropped=${b.dropped_by_cutoff} ` +
+          `(${fmt(b.dropped_ratio)}) nearest ${near} cutoff=${b.cutoffs_observed.length ? b.cutoffs_observed.join(',') : 'n/a'}`,
+      )
+      // 컷오프 교정 nudge. 여기서 값을 자동으로 고치지 않는다 — 표본이 임베더 1종에 묶여 있고,
+      // 어떤 컷오프가 옳은지는 임베더/코퍼스마다 다르다(userConfig loop_recall_max_distance).
+      // 사실만 부상시키고 판단은 사람에게 남긴다. "게이트가 한 번도 일하지 않았다"는 임계값 판정이
+      // 아니라 관측 사실이므로 이 조건만 경고한다.
+      if (b.candidates > 0 && b.dropped_by_cutoff === 0) {
+        lines.push(
+          `    WARN: ${c} 컷오프가 후보 ${b.candidates}개 중 하나도 막지 않았다 — 이 임베더에 대해 느슨할 수 있다(교정: loop_recall_max_distance).`,
+        )
+      }
+    }
+  }
   for (const r of runs) {
     const tag = r.run_id === 'unknown' ? ' (귀속 불가 verdict — current 포인터 부재분)' : ''
     lines.push(

--- a/tools/loop-engine/test/adversarial-review-fanout.test.sh
+++ b/tools/loop-engine/test/adversarial-review-fanout.test.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# Regression test for ship-flow/workflows/adversarial-review.js의 검증 팬아웃 상한.
+#
+# 왜: 총 에이전트 = domains + VOTES_PER_FINDING × findings + 1 인데 finder의 findings 배열에
+# 상한이 없었다. 한 도메인이 20건을 내면 그 도메인만으로 60개의 검증 에이전트가 뜬다 — 워크플로
+# 저작 레퍼런스가 스스로 고지하는 규모를 한참 넘고, 같은 레퍼런스의 "no silent caps"(커버리지를
+# 자르면 log로 무엇이 빠졌는지 밝힐 것) 규약도 어긴다.
+#
+# 잠그는 계약:
+#   ① 도메인당 검증 팬아웃이 상한을 넘지 않는다(에이전트 수를 실제로 세서 확인 — 상수 존재 여부가
+#      아니라 행위를 잰다).
+#   ② 잘린 findings는 버려지지 않고 unverifiedOverCap으로 반환된다(침묵 절단 금지).
+#   ③ 잘렸다는 사실이 log()로 드러난다.
+#   ④ 잘리는 순서는 severity — blocker가 minor 때문에 검증에서 밀려나지 않는다.
+#   ⑤ 반박 투표는 저가 모델/저 effort로 라우팅되지 않는다(verifier=ceiling — 검증의 *양*은 묶되
+#      *질*은 절대 깎지 않는다. 비용 절감이 이 원칙을 침식하는 걸 게이트로 막는다).
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$HERE/../../.."
+WF="$ROOT/tools/ship-flow/workflows/adversarial-review.js"
+
+fail() { echo "FAIL: $1"; exit 1; }
+[ -f "$WF" ] || fail "adversarial-review.js not found at $WF"
+
+# 실제 파일을 스텁 하네스로 실행한다 — 로직을 복사하면 복사본만 통과하는 가짜 green이 된다.
+node -e '
+const fs = require("node:fs");
+const src = fs.readFileSync(process.argv[1], "utf8").replace(/^export const meta/m, "const meta");
+
+const FINDINGS_PER_DOMAIN = 20;
+const CAP = 8;               // adversarial-review.js의 DEFAULT_MAX_VERIFIED_PER_DOMAIN
+const VOTES = 3;             // VOTES_PER_FINDING
+
+const calls = { find: 0, verify: 0, other: 0 };
+const logs = [];
+const verifyOpts = [];
+
+async function agent(prompt, opts = {}) {
+  const phase = opts.phase || "";
+  if (phase === "Find") {
+    calls.find++;
+    // severity를 섞어서 준다 — minor가 앞줄에 오도록 배치해 정렬이 실제로 일어나는지 본다.
+    const findings = Array.from({ length: FINDINGS_PER_DOMAIN }, (_, i) => ({
+      title: `f${i}`,
+      detail: "d",
+      file: "x.ts",
+      severity: i < 15 ? "minor" : "blocker",
+    }));
+    return { findings };
+  }
+  if (phase === "Verify") {
+    calls.verify++;
+    verifyOpts.push(opts);
+    return { refuted: false, reason: "r" };
+  }
+  calls.other++;
+  return "text";
+}
+const parallel = (thunks) => Promise.all(thunks.map((t) => t()));
+async function pipeline(items, ...stages) {
+  return Promise.all(items.map(async (item, i) => {
+    let acc = item;
+    for (const s of stages) acc = await s(acc, item, i);
+    return acc;
+  }));
+}
+const phase = () => {};
+const log = (m) => logs.push(String(m));
+
+const AsyncFn = Object.getPrototypeOf(async function () {}).constructor;
+const fn = new AsyncFn("args", "agent", "parallel", "pipeline", "phase", "log", src);
+const args = { target: "t", domains: [{ key: "alpha", prompt: "p" }] };
+
+fn(args, agent, parallel, pipeline, phase, log).then((res) => {
+  // ① 팬아웃 상한이 실제로 작동한다
+  const expected = CAP * VOTES;
+  const uncapped = FINDINGS_PER_DOMAIN * VOTES;
+  if (calls.verify !== expected) {
+    throw new Error(`verify fan-out must be capped at ${expected} (cap ${CAP} x ${VOTES} votes), got ${calls.verify} (uncapped would be ${uncapped})`);
+  }
+  // ② 잘린 것은 버려지지 않는다
+  const over = res.unverifiedOverCap || [];
+  if (over.length !== FINDINGS_PER_DOMAIN - CAP) {
+    throw new Error(`unverifiedOverCap must carry the ${FINDINGS_PER_DOMAIN - CAP} dropped findings, got ${over.length}`);
+  }
+  if (over.some((f) => f.severity === "blocker")) {
+    throw new Error("a blocker must never be the thing dropped while minors get verified");
+  }
+  // ③ 침묵 절단 금지
+  if (!logs.some((l) => l.includes("cap") || l.includes("unverified"))) {
+    throw new Error("a truncated run must log() what it dropped, got logs: " + JSON.stringify(logs));
+  }
+  // ④ severity 우선순위 — blocker 5건이 전부 검증 대상에 들어가야 한다
+  const confirmedTitles = new Set((res.confirmed || []).map((f) => f.title));
+  const blockers = Array.from({ length: 5 }, (_, i) => `f${15 + i}`);
+  for (const b of blockers) {
+    if (!confirmedTitles.has(b)) throw new Error(`blocker ${b} must be verified ahead of minors`);
+  }
+  // ⑤ verifier=ceiling — 반박 투표를 싸게 만들지 않는다
+  for (const o of verifyOpts) {
+    if (o.model) throw new Error("refutation votes must not pin a model — the verifier is the ceiling, never the place to save tokens");
+    if (o.effort && o.effort === "low") throw new Error("refutation votes must not drop to low effort");
+  }
+  console.log("ok");
+}).catch((e) => { console.error(e.message); process.exit(1); });
+' "$WF" || fail "adversarial-review fan-out contract broken"
+echo "PASS: verification fan-out is capped per domain, drops are severity-ordered, carried, and logged; votes stay full-strength"
+
+# 상한 상향 경로가 살아 있는지 — 의도적 전수 실행을 막아서는 안 된다
+node -e '
+const fs = require("node:fs");
+const src = fs.readFileSync(process.argv[1], "utf8").replace(/^export const meta/m, "const meta");
+let verify = 0;
+async function agent(prompt, opts = {}) {
+  if (opts.phase === "Find") return { findings: Array.from({ length: 12 }, (_, i) => ({ title: `f${i}`, detail: "d", severity: "major" })) };
+  if (opts.phase === "Verify") { verify++; return { refuted: false, reason: "r" }; }
+  return "text";
+}
+const parallel = (t) => Promise.all(t.map((x) => x()));
+async function pipeline(items, ...stages) {
+  return Promise.all(items.map(async (item, i) => { let a = item; for (const s of stages) a = await s(a, item, i); return a; }));
+}
+const AsyncFn = Object.getPrototypeOf(async function () {}).constructor;
+const fn = new AsyncFn("args", "agent", "parallel", "pipeline", "phase", "log", src);
+fn({ target: "t", domains: [{ key: "a", prompt: "p" }], maxVerifiedPerDomain: 12 }, agent, parallel, pipeline, () => {}, () => {}).then((res) => {
+  if (verify !== 36) throw new Error("args.maxVerifiedPerDomain=12 must verify all 12 findings (36 votes), got " + verify);
+  if ((res.unverifiedOverCap || []).length !== 0) throw new Error("nothing should be over the cap when it is raised to fit");
+  console.log("ok");
+}).catch((e) => { console.error(e.message); process.exit(1); });
+' "$WF" || fail "args.maxVerifiedPerDomain override must allow an exhaustive run"
+echo "PASS: args.maxVerifiedPerDomain raises the cap for a deliberately exhaustive run"
+
+exit 0

--- a/tools/loop-engine/test/run-metrics-recall.test.sh
+++ b/tools/loop-engine/test/run-metrics-recall.test.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# Regression test for run-metrics.mjs의 recall 건전성 축 (memory.recall fold).
+#
+# 왜 이 축이 필요한가: hooks/recall-lessons.mjs는 fail-open 계약(항상 exit 0)이라 "회수할 게
+# 없었다"와 "고장났다"가 겉으로 똑같다. 원장(memory.recall)만이 둘을 가르는데 그걸 아무도
+# fold하지 않아, 소비 레포에서 cli_failed가 attempted의 89%인 상태로 6일간(2026-08-27~09-01,
+# 실측 626건) 무증상으로 지나갔다. 이 테스트가 잠그는 계약 4가지:
+#   ① 실패율 분모는 attempted(=fired−skipped) — self-gate(키 부재·짧은 프롬프트)는 고장이 아니다.
+#   ② 컷오프 실효성은 hit 단위(candidates/passed)로 잰다 — `above_cutoff` 사유(후보 전부 탈락)만
+#      세면 과소보고된다(실측: above_cutoff 1건 vs hit 단위 탈락 55건).
+#   ③ 코퍼스(lessons/knowledge)를 합치지 않는다 — 임베딩 분포가 달라 한 숫자로는 둘 다 못 읽는다.
+#   ④ 결손은 INSUFFICIENT_DATA 1급 — 훅 미발화를 0%처럼 보이게 하지 않는다.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$HERE/../../.."
+METRICS="$ROOT/tools/loop-engine/bin/run-metrics.mjs"
+
+fail() { echo "FAIL: $1"; exit 1; }
+[ -f "$METRICS" ] || fail "run-metrics.mjs not found at $METRICS"
+
+DIR="$(mktemp -d "${TMPDIR:-/tmp}/tmp.XXXXXXXX")" || fail "mktemp -d failed"
+trap 'rm -rf "$DIR"' EXIT
+
+# ── T1) 혼합 원장: self-gate 2 + 고장 2 + 주입 2 ──────────────────────────────────────────
+A="$DIR/a"; mkdir -p "$A"
+cat > "$A/runA.jsonl" <<'EOF'
+{"id":"r1","type":"run.started","ts":"2026-09-01T00:00:00.000Z","aggregate_id":"runA","payload":{},"version":1}
+{"id":"r2","type":"memory.recall","ts":"2026-09-01T00:01:00.000Z","aggregate_id":"runA","payload":{"outcome":"skipped","reason":"prompt_too_short","lessons":{"candidates":0,"near":0,"nearest":null},"knowledge":{"candidates":0,"near":0,"nearest":null},"injected_chars":0},"version":1}
+{"id":"r3","type":"memory.recall","ts":"2026-09-01T00:02:00.000Z","aggregate_id":"runA","payload":{"outcome":"skipped","reason":"no_embedding_key","lessons":{"candidates":0,"near":0,"nearest":null},"knowledge":{"candidates":0,"near":0,"nearest":null},"injected_chars":0},"version":1}
+{"id":"r4","type":"memory.recall","ts":"2026-09-01T00:03:00.000Z","aggregate_id":"runA","payload":{"outcome":"error","reason":"cli_failed","cli_status":1,"lessons":{"candidates":0,"near":0,"nearest":null},"knowledge":{"candidates":0,"near":0,"nearest":null},"injected_chars":0},"version":1}
+{"id":"r5","type":"memory.recall","ts":"2026-09-01T00:04:00.000Z","aggregate_id":"runA","payload":{"outcome":"error","reason":"cli_failed","cli_status":1,"lessons":{"candidates":0,"near":0,"nearest":null},"knowledge":{"candidates":0,"near":0,"nearest":null},"injected_chars":0},"version":1}
+{"id":"r6","type":"memory.recall","ts":"2026-09-01T00:05:00.000Z","aggregate_id":"runA","payload":{"outcome":"injected","reason":"injected","lessons":{"candidates":3,"near":2,"nearest":0.15},"knowledge":{"candidates":3,"near":1,"nearest":0.1},"cutoffs":{"lessons":0.25,"knowledge":0.2},"injected_chars":1000},"version":1}
+{"id":"r7","type":"memory.recall","ts":"2026-09-01T00:06:00.000Z","aggregate_id":"runA","payload":{"outcome":"injected","reason":"injected","lessons":{"candidates":3,"near":3,"nearest":0.25},"knowledge":{"candidates":3,"near":3,"nearest":0.2},"cutoffs":{"lessons":0.25,"knowledge":0.2},"injected_chars":2000},"version":1}
+EOF
+JSON="$(node "$METRICS" --runs-dir "$A" --json)" || fail "T1 --json must exit 0"
+node -e '
+  const m = JSON.parse(process.argv[1]).overall.recall;
+  if (m === "INSUFFICIENT_DATA") throw new Error("T1 recall axis must be present");
+  if (m.fired !== 6) throw new Error("T1 fired must be 6, got " + m.fired);
+  if (m.skipped !== 2) throw new Error("T1 skipped must be 2, got " + m.skipped);
+  // ① 분모는 attempted=4, 실패 2 -> 0.5. fired(6) 기준이면 0.33으로 희석된다.
+  if (m.attempted !== 4) throw new Error("T1 attempted must be fired-skipped=4, got " + m.attempted);
+  if (m.failed !== 2) throw new Error("T1 failed must be 2, got " + m.failed);
+  if (m.failure_ratio !== 0.5) throw new Error("T1 failure_ratio must be failed/attempted=0.5, got " + m.failure_ratio);
+  if (m.injected !== 2) throw new Error("T1 injected must be 2, got " + m.injected);
+  if (m.injected_chars_total !== 3000) throw new Error("T1 injected_chars_total must be 3000, got " + m.injected_chars_total);
+  if (m.injected_chars_mean !== 1500) throw new Error("T1 injected_chars_mean must be 1500, got " + m.injected_chars_mean);
+  if (m.by_reason.cli_failed !== 2) throw new Error("T1 by_reason.cli_failed must be 2");
+  if (m.by_reason.no_embedding_key !== 1) throw new Error("T1 by_reason must keep distinct skip slugs");
+  // ② hit 단위 컷오프 실효성. above_cutoff 사유는 0건인데 실제로는 hit이 탈락했다.
+  if (m.by_reason.above_cutoff) throw new Error("T1 fixture has no above_cutoff reason — the hit-level count must not depend on it");
+  const L = m.corpus.lessons, K = m.corpus.knowledge;
+  if (L.candidates !== 6 || L.passed_cutoff !== 5 || L.dropped_by_cutoff !== 1)
+    throw new Error("T1 lessons hit-level wrong: " + JSON.stringify(L));
+  // ③ 코퍼스 분리 — knowledge는 lessons와 다른 수치여야 한다(합치면 3/12로 뭉갠다).
+  if (K.candidates !== 6 || K.passed_cutoff !== 4 || K.dropped_by_cutoff !== 2)
+    throw new Error("T1 knowledge hit-level wrong: " + JSON.stringify(K));
+  if (L.dropped_ratio === K.dropped_ratio) throw new Error("T1 corpora must stay separate, not merged");
+  if (L.nearest.n !== 2 || L.nearest.min !== 0.15 || L.nearest.max !== 0.25)
+    throw new Error("T1 lessons nearest distribution wrong: " + JSON.stringify(L.nearest));
+  if (JSON.stringify(L.cutoffs_observed) !== JSON.stringify([0.25]))
+    throw new Error("T1 observed cutoff must come from the ledger, got " + JSON.stringify(L.cutoffs_observed));
+' "$JSON" || fail "T1 recall fold contract broken"
+echo "PASS: T1 failure_ratio uses attempted (not fired), hit-level cutoff efficacy, corpora kept separate"
+
+# ── T2) memory.recall 0건 -> INSUFFICIENT_DATA (0%로 날조 금지) ────────────────────────────
+B="$DIR/b"; mkdir -p "$B"
+cat > "$B/runB.jsonl" <<'EOF'
+{"id":"b1","type":"run.started","ts":"2026-09-01T00:00:00.000Z","aggregate_id":"runB","payload":{},"version":1}
+{"id":"b2","type":"verdict.passed","ts":"2026-09-01T00:01:00.000Z","aggregate_id":"runB","payload":{"verdict":"PASS","exit":0},"version":1}
+EOF
+JSON="$(node "$METRICS" --runs-dir "$B" --json)" || fail "T2 --json must exit 0"
+node -e '
+  const m = JSON.parse(process.argv[1]).overall.recall;
+  if (m !== "INSUFFICIENT_DATA") throw new Error("T2 no memory.recall events must be INSUFFICIENT_DATA, got " + JSON.stringify(m));
+' "$JSON" || fail "T2 must not fabricate a recall ratio from zero events"
+OUT="$(node "$METRICS" --runs-dir "$B")" || fail "T2 text mode must exit 0"
+printf '%s' "$OUT" | grep -q "recall (loop-memory 시맨틱 회수): INSUFFICIENT_DATA" \
+  || fail "T2 text mode must say INSUFFICIENT_DATA, got: $OUT"
+echo "PASS: T2 zero memory.recall events report INSUFFICIENT_DATA in both json and text"
+
+# ── T3) attempted=0(전부 self-gate) -> failure_ratio는 0이 아니라 INSUFFICIENT ────────────
+C="$DIR/c"; mkdir -p "$C"
+cat > "$C/runC.jsonl" <<'EOF'
+{"id":"c1","type":"run.started","ts":"2026-09-01T00:00:00.000Z","aggregate_id":"runC","payload":{},"version":1}
+{"id":"c2","type":"memory.recall","ts":"2026-09-01T00:01:00.000Z","aggregate_id":"runC","payload":{"outcome":"skipped","reason":"no_embedding_key","injected_chars":0},"version":1}
+EOF
+JSON="$(node "$METRICS" --runs-dir "$C" --json)" || fail "T3 --json must exit 0"
+node -e '
+  const m = JSON.parse(process.argv[1]).overall.recall;
+  if (m.attempted !== 0) throw new Error("T3 attempted must be 0, got " + m.attempted);
+  if (m.failure_ratio !== "INSUFFICIENT_DATA")
+    throw new Error("T3 attempted=0 must give INSUFFICIENT_DATA, not a 0 that reads as healthy, got " + m.failure_ratio);
+  if (m.corpus.lessons.nearest !== "INSUFFICIENT_DATA")
+    throw new Error("T3 no distances -> nearest must be INSUFFICIENT_DATA, got " + JSON.stringify(m.corpus.lessons.nearest));
+' "$JSON" || fail "T3 an all-self-gated ledger must not read as 0% failure"
+echo "PASS: T3 attempted=0 yields INSUFFICIENT_DATA, not a healthy-looking 0"
+
+# ── T4) 컷오프가 후보를 하나도 안 막으면 WARN — 교정 nudge(자동 변경은 안 한다) ──────────
+D="$DIR/d"; mkdir -p "$D"
+cat > "$D/runD.jsonl" <<'EOF'
+{"id":"d1","type":"run.started","ts":"2026-09-01T00:00:00.000Z","aggregate_id":"runD","payload":{},"version":1}
+{"id":"d2","type":"memory.recall","ts":"2026-09-01T00:01:00.000Z","aggregate_id":"runD","payload":{"outcome":"injected","reason":"injected","lessons":{"candidates":3,"near":3,"nearest":0.11},"knowledge":{"candidates":3,"near":1,"nearest":0.1},"cutoffs":{"lessons":0.65,"knowledge":0.2},"injected_chars":900},"version":1}
+EOF
+OUT="$(node "$METRICS" --runs-dir "$D")" || fail "T4 text mode must exit 0"
+printf '%s' "$OUT" | grep -q "WARN: lessons 컷오프가 후보 3개 중 하나도 막지 않았다" \
+  || fail "T4 a cutoff that never bound must WARN, got: $OUT"
+printf '%s' "$OUT" | grep -q "WARN: knowledge" \
+  && fail "T4 a cutoff that DID bind must not WARN"
+echo "PASS: T4 a never-binding cutoff warns; a binding one stays quiet"
+
+exit 0

--- a/tools/loop-memory/.claude-plugin/plugin.json
+++ b/tools/loop-memory/.claude-plugin/plugin.json
@@ -10,7 +10,7 @@
   "license": "MIT",
   "keywords": ["memory", "pgvector", "recall", "semantic-search", "lessons"],
   "defaultEnabled": false,
-  "dependencies": [{ "name": "loop-engine", "version": "^0.13.0" }],
+  "dependencies": [{ "name": "loop-engine", "version": "^0.14.0" }],
   "userConfig": {
     "openai_api_key": {
       "type": "string",

--- a/tools/ship-flow/.claude-plugin/plugin.json
+++ b/tools/ship-flow/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ship-flow",
-  "version": "0.9.4",
+  "version": "0.10.0",
   "description": "Delivery-loop skills — land and release already-verified work through a repo's real gates. Tracker- and branch-model-agnostic: reads a consuming repo's own config instead of hardcoding one repo's setup.",
   "author": {
     "name": "paulkim-lansik"
@@ -10,6 +10,6 @@
   "license": "MIT",
   "keywords": ["delivery", "git-flow", "hotfix", "ship", "release"],
   "dependencies": [
-    { "name": "loop-engine", "version": "^0.13.0" }
+    { "name": "loop-engine", "version": "^0.14.0" }
   ]
 }

--- a/tools/ship-flow/workflows/adversarial-review.js
+++ b/tools/ship-flow/workflows/adversarial-review.js
@@ -12,6 +12,19 @@
 // one that's genuinely refuted by valid votes, and one that's merely unverified because too few
 // votes came back cleanly (an infrastructure failure isn't read as a refutation).
 //
+// Verification fan-out is BOUNDED. Total agents = domains + VOTES_PER_FINDING x verified-findings + 1,
+// and the finder's `findings` array had no cap — a finder that returns 20 findings across 6 domains
+// spawns 360 verifier agents from a script whose own authoring guidance caps workflows far below
+// that. The bound here is per-domain and severity-ordered (blocker first), so what gets verified is
+// the part most worth spending votes on. Nothing is DISCARDED: findings past the cap are returned as
+// `unverifiedOverCap` and the drop is log()'d — the authoring reference's "no silent caps" rule,
+// because a truncated review that looks complete is worse than one that says what it skipped.
+//
+// Note on what is deliberately NOT done here: the refutation votes are not routed to a cheaper model
+// or a lower effort tier. They are the verifier, and this plugin's whole premise is that the verifier
+// is the ceiling — a cheaper skeptic is exactly how a plausible-but-wrong finding survives. Bound the
+// QUANTITY of verification, never its quality.
+//
 // args (all required — domains are task-specific, this workflow does not guess a default set):
 //   { target: '<what is being reviewed — one sentence>',
 //     domains: [{ key: '<slug>', prompt: '<what to look for in this domain>' }, ...] }
@@ -45,8 +58,12 @@ const FINDER_SCHEMA = {
           title: { type: 'string' },
           detail: { type: 'string' },
           file: { type: 'string' },
+          // severity drives WHICH findings get the verification budget when a domain overflows the
+          // cap. Required so the ordering is the finder's judgement rather than array order, which
+          // carries no meaning. An unrecognised/missing value sorts last (see SEVERITY_RANK).
+          severity: { type: 'string', enum: ['blocker', 'major', 'minor'] },
         },
-        required: ['title', 'detail'],
+        required: ['title', 'detail', 'severity'],
       },
     },
   },
@@ -64,6 +81,41 @@ const VERDICT_SCHEMA = {
 
 const VOTES_PER_FINDING = 3
 const REFUTATIONS_REQUIRED = 2
+// Per-domain cap on how many findings get the (VOTES_PER_FINDING-agent) verification treatment.
+// Per-domain rather than global so one noisy domain cannot starve every other domain's findings.
+// Overridable via args.maxVerifiedPerDomain for a deliberately exhaustive run.
+const DEFAULT_MAX_VERIFIED_PER_DOMAIN = 8
+const maxVerifiedPerDomain = Number.isInteger(parsedArgs.maxVerifiedPerDomain)
+  && parsedArgs.maxVerifiedPerDomain > 0
+  ? parsedArgs.maxVerifiedPerDomain
+  : DEFAULT_MAX_VERIFIED_PER_DOMAIN
+// Unknown/missing severity sorts last — a finder that ignores the enum loses priority, it does not
+// silently jump the queue ahead of a declared blocker.
+const SEVERITY_RANK = { blocker: 0, major: 1, minor: 2 }
+const severityRank = (f) => SEVERITY_RANK[f?.severity] ?? 3
+
+// Everything a domain found that the cap kept out of verification. Returned to the caller so a
+// truncated review can never read as an exhaustive one.
+const unverifiedOverCap = []
+
+// Stable severity ordering + hard slice. The schema's enum is a REQUEST to the model; this slice is
+// the enforcement — the same generator-vs-verifier split the rest of this plugin runs on.
+function capForVerification(findings, domainKey) {
+  const ordered = findings
+    .map((f, i) => ({ f, i }))
+    .sort((a, b) => severityRank(a.f) - severityRank(b.f) || a.i - b.i)
+    .map((x) => x.f)
+  if (ordered.length <= maxVerifiedPerDomain) return ordered
+  const kept = ordered.slice(0, maxVerifiedPerDomain)
+  const dropped = ordered.slice(maxVerifiedPerDomain)
+  unverifiedOverCap.push(...dropped)
+  log(
+    `${domainKey}: ${ordered.length} findings exceed the per-domain verification cap ` +
+      `(${maxVerifiedPerDomain}) — verifying the ${kept.length} most severe, carrying ` +
+      `${dropped.length} through as unverified (raise args.maxVerifiedPerDomain to verify all).`,
+  )
+  return kept
+}
 
 phase('Find')
 const perDomain = await pipeline(
@@ -73,9 +125,9 @@ const perDomain = await pipeline(
       `Target: ${parsedArgs.target}\n\nDomain: ${d.key}\n${d.prompt}\n\nOnly record something as a finding if you actually observed it by reading a file or running a command — don't assert from inference. This investigation is read-only.`,
       { label: `find:${d.key}`, phase: 'Find', schema: FINDER_SCHEMA }
     ).then((r) => (r?.findings ?? []).map((f) => ({ ...f, domain: d.key }))),
-  (domainFindings) =>
+  (domainFindings, d) =>
     parallel(
-      domainFindings.map((f) => () =>
+      capForVerification(domainFindings, d.key).map((f) => () =>
         parallel(
           Array.from({ length: VOTES_PER_FINDING }, () => () =>
             agent(
@@ -115,10 +167,21 @@ const completeness = await agent(
 ${JSON.stringify(confirmed.map(({ title, detail, file, domain }) => ({ title, detail, file, domain })))}
 
 Domains covered: ${parsedArgs.domains.map((d) => d.key).join(', ')}
+${unverifiedOverCap.length ? `\nNOT verified — ${unverifiedOverCap.length} finding(s) exceeded the per-domain verification cap (${maxVerifiedPerDomain}) and never got a verifier. Treat these as open, not as cleared:\n${JSON.stringify(unverifiedOverCap.map(({ title, file, domain, severity }) => ({ title, file, domain, severity })))}` : ''}
 
 Critique what's missing — domains/angles not covered, claims that went unverified, sources not read.
 Propose concretely what the next round should look at — no generic advice, be specific to this target.`,
   { phase: 'Completeness', label: 'completeness-critic' }
 )
 
-return { target: parsedArgs.target, confirmed, refuted, unverified, completeness }
+return {
+  target: parsedArgs.target,
+  confirmed,
+  refuted,
+  unverified,
+  // Distinct from `unverified` (verification RAN but too few votes came back): these never got a
+  // verifier at all because the per-domain cap stopped at them. Different fact, different field.
+  unverifiedOverCap,
+  maxVerifiedPerDomain,
+  completeness,
+}


### PR DESCRIPTION
토큰/비용 딥리서치 리포트를 이 레포 코드에 **대조**한 결과다. 리포트를 그대로 구현하지 않았다 — 최우선 권고 대부분이 코드 확인에서 반증됐고, 남은 두 지점만 구현했다.

## 기각한 권고 (코드로 반증)

| 리포트 권고 | 우선순위 | 반증 |
|---|---|---|
| 프롬프트 캐시 접두사 정렬 | 최우선 | `loop-fix.sh`는 API 요청을 조립하지 않는다. `.loop/fix-prompt.txt`(user message)만 쓰고 캐시 접두사(시스템 프롬프트+툴 정의)는 Claude Code 소유 — user message는 브레이크포인트 뒤라 가변값이 캐시를 깨지 않는다 |
| 모델 라우팅 (verify 저가 / fix 고가) | 높음 | 하네스에 LLM이 없다. `bin/`·`hooks/`·`lib/` 전체 grep 0건. verify는 쉘 exit code, `--fix`는 사용자 제공 명령 |
| CLAUDE.md·스킬 크기 감사 | Quick win | 이미 `bin/context-budget.mjs`로 존재(O1a/O1b/O1c 3층, Anthropic count_tokens 실측) |
| stall 시그니처에 "수정 파일" 추가 | Quick win | 논리 역전 — 필드를 더하면 지문이 유니크해져 stall 탐지가 *줄어든다* |
| 회수 lesson 프롬프트 끝 배치 | 높음 | lost-in-the-middle은 장문 현상. fix-prompt는 수백 토큰 |

## 채택 1 — `run-metrics.mjs`가 `memory.recall` 원장을 fold (loop-engine 0.14.0)

recall 훅은 fail-open 계약(`UserPromptSubmit`이 non-zero면 사용자 프롬프트가 폐기된다)이라 "회수할 게 없었다"와 "고장났다"가 겉으로 같다. 원장만이 둘을 가르는데 어떤 집계기도 읽지 않았다.

소비 레포(glucofit-partners) 실측 958건:

```
2026-08-27  n=212  cli_failed=188   2026-08-31  n=167  cli_failed=155
2026-08-28  n= 76  cli_failed=71    2026-09-01  n=136  cli_failed=124
2026-08-30  n= 69  cli_failed=63    2026-09-02  n=104  injected=75  cli_failed=12
```

`cli_failed`가 attempted의 **89%로 6일간** 무증상. 무관한 변경으로 고쳐졌는데 그 회복을 확인할 수단도 없었다.

세 축을 보고한다:
- **실패율 분모는 `attempted`(= fired − skipped)** — self-gate(키 부재·8자 미만 프롬프트)는 고장이 아니다. `fired` 기준이면 89%가 65%로 희석된다.
- **컷오프 실효성은 hit 단위**(`candidates`/`passed`/`dropped`). `above_cutoff` 사유는 *후보 전부* 탈락 시에만 뜬다 — 958건 중 1건을 보여줬지만 hit 단위로는 456개 중 55개가 탈락했다. 코퍼스 분리 필수(lessons 4.4% vs knowledge 19.7%).
- **관측 nearest distance 분포를 관측 컷오프와 나란히.** 보고·경고만 하고 재조정은 하지 않는다 — 임베더 1종 표본으로 모두의 기본값을 옮길 근거가 없다.

이벤트 0건은 `INSUFFICIENT_DATA`(0%처럼 보이게 하지 않는다).

## 채택 2 — `adversarial-review` 검증 팬아웃 상한 (ship-flow 0.10.0)

총 에이전트 = `domains + 3 × findings + 1`인데 **`findings`에 상한이 없었다**. 한 도메인 20건 → 검증 에이전트 60개. 워크플로 저작 레퍼런스가 고지하는 규모를 넘고, 같은 레퍼런스의 **"no silent caps"** 규약도 어긴다.

- finder 스키마가 `severity` 요구 → 심각도 순 검증
- 도메인당 `maxVerifiedPerDomain`(기본 8, args로 상향 가능)
- **버리지 않는다**: 초과분은 `unverifiedOverCap`으로 반환(`unverified`와 별개 필드 — 후자는 검증이 *돌았지만* 표가 부족한 경우) + `log()` + completeness critic에게 전달

### 반박 투표는 의도적으로 full strength

저가 모델/저 effort 라우팅이 명백한 절감이지만 이 플러그인엔 잘못된 거래다 — **투표가 곧 verifier**이고, 싼 회의론자는 그럴듯하지만 틀린 발견이 살아남는 바로 그 경로다. 저작 레퍼런스도 verify/judge는 *상향* 대상으로 지목한다. 테스트가 `model` 핀 부재와 `low` effort 부재를 잠가, 다음 비용절감 회차가 `verifier = ceiling`을 조용히 침식하지 못하게 한다. **검증의 양은 묶되 질은 깎지 않는다.**

## 검증

- `loop-engine selftest 66/66` (신규 2건 포함), exit 0
- 신규 테스트는 **수정 전 코드에 대해 RED 확인** — 팬아웃 60 → 24
- `adversarial-review-fanout.test.sh`는 로직 복사 없이 **실제 스크립트를 스텁 하네스로 실행해 에이전트 수를 센다**
- `claude plugin validate --strict` — 마켓플레이스 + 플러그인 3종 통과
- 의존 범위 `^0.14.0`으로 확대(`plugin-dep-range.test.sh` — 0.x 캐럿은 다음 마이너를 배제하고 `claude plugin update`는 성공을 보고하며 구버전을 유지)

## 리뷰 시 봐주면 좋을 곳

- `run-metrics.mjs`의 recall fold가 `runs` 전체(unknown 버킷 포함)를 접는다 — Q1/Q2/H1의 제외 근거(런 단위 분모 희석)가 이벤트 단위 비율엔 적용되지 않기 때문. 헤더에 근거를 적었다
- 기본 상한 8이 적절한지 (args로 상향 가능하지만 기본값은 판단이 필요)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018U6tAd67w9hcFtaZWzMNxp