### PR TITLE
fix(loop-memory): ^0.14.0 범위를 실제로 배포 — 버전 미상승으로 매니페스트가 갇혀 있었다

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -26,7 +26,7 @@
       "name": "loop-memory",
       "source": "./tools/loop-memory",
       "description": "pgvector semantic recall for verified dev-loop lessons (and, optionally, ADR/glossary/research knowledge). Opt-in / defaultEnabled:false — a database dependency, not core loop mechanics.",
-      "version": "0.6.2",
+      "version": "0.6.3",
       "defaultEnabled": false,
       "keywords": ["memory", "pgvector", "recall", "semantic-search", "lessons"]
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ Explicit-version channel — see [README § Development status](README.md#develo
 not a SHA channel. Entries below `## loop-engine 0.2.0` and earlier predate the multi-plugin split
 and refer to `loop-engine` only (see the un-prefixed version numbers).
 
+## loop-memory 0.6.3
+
+`loop-engine 0.14.0 / ship-flow 0.10.0` widened every dependent's `loop-engine` range to `^0.14.0`,
+loop-memory's manifest included — but loop-memory's own version was left at 0.6.2. A manifest only
+reaches consumers through a **new version**: the marketplace kept serving 0.6.2, which still
+declared `^0.13.0`, so the widening never shipped and loop-engine became unresolvable —
+`claude plugin update loop-engine@paul-loop` reported `✔ Skipped — conflicting version requirements
+(no version satisfies all of: ^0.13.0, ^0.14.0)`. Note the checkmark on a no-op: this is the same
+shape as the update-reports-success-without-moving failure the repo already had a verified lesson
+for.
+
+`plugin-dep-range.test.sh` passed throughout, correctly — it checks that the ranges in *this repo's
+tree* admit the loop-engine version *this repo ships*, and after the edit they did. It has no reach
+into "a manifest edit that never ships because its version didn't move". Every previous loop-engine
+minor bump carried a matching loop-memory bump (0.4.1→0.4.2 for `^0.11.0`, 0.4.2→0.4.3 for
+`^0.12.0`, …); this one didn't, and nothing said so.
+
+- **loop-memory 0.6.2 → 0.6.3**, publishing the `^0.14.0` range it already declared in-tree. No code
+  change.
+
 ## loop-engine 0.14.0 · ship-flow 0.10.0
 
 Two measurement gaps, found by pointing a token/cost research report at this repo and then checking

--- a/tools/loop-memory/.claude-plugin/plugin.json
+++ b/tools/loop-memory/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "loop-memory",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "pgvector semantic recall for verified dev-loop lessons (and, optionally, ADR/glossary/research knowledge). Opt-in: installs disabled by default — this is a database dependency, not core loop mechanics.",
   "author": {
     "name": "paulkim-lansik"


### PR DESCRIPTION
PR #90의 후속 결함 수정. **loop-engine 0.14.0이 현재 어떤 소비자에게도 도달하지 못한다.**

## 무슨 일이

#90이 모든 의존 플러그인의 `loop-engine` 범위를 `^0.14.0`으로 넓혔는데, loop-memory는 **매니페스트만 고치고 버전을 0.6.2에 두었다.** 매니페스트는 새 버전을 통해서만 소비자에게 도달한다 — 마켓플레이스는 계속 0.6.2를 서빙하고, 그 0.6.2는 여전히 `^0.13.0`을 선언한다.

실측:

```
$ claude plugin update loop-engine@paul-loop
✔ Skipped — Plugin "loop-engine@paul-loop" has conflicting version requirements
  (no version satisfies all of: ^0.13.0, ^0.14.0)
```

무동작에 `✔`가 붙는다 — "update가 성공을 보고하면서 버전을 안 움직인다"는 이 레포의 기존 검증된 교훈과 정확히 같은 형태다.

## 게이트는 왜 못 잡았나

`plugin-dep-range.test.sh`는 내내 통과했고 **그게 맞다.** 이 게이트가 검사하는 건 "*이 레포 트리의* 범위가 *이 레포가 배포하는* loop-engine 버전을 받아들이는가"이고, 편집 후 실제로 그랬다. **"버전이 안 움직여서 배포되지 않는 매니페스트 편집"** 에는 구조적으로 닿지 못한다.

레포 히스토리상 과거 loop-engine 마이너 상승은 전부 loop-memory 동반 상승을 가졌다:

| loop-memory | 선언 범위 |
|---|---|
| 0.4.1 | `^0.10.0` |
| 0.4.2 | `^0.11.0` |
| 0.4.3 | `^0.12.0` |
| 0.6.2 | `^0.13.0` |
| **0.6.3** | **`^0.14.0`** ← 이번에 빠졌던 것 |

## 이 PR

- **loop-memory 0.6.2 → 0.6.3.** 코드 변경 0 — 이미 트리에 있던 범위를 배포하기 위한 버전 상승뿐.

## 후속 제안 (이 PR 범위 밖)

`tag-on-publish.yml`의 존재 이유("수동 단계는 조용히 안 하게 된다")와 같은 논리로, **"플러그인 트리가 마지막 발행 태그와 다른데 버전이 그대로면 RED"** 게이트를 검토할 만하다. 그 게이트가 있었다면 이 결함이 #90에서 잡혔다. CI에 태그 fetch 배선이 필요해 별도 PR로 분리한다.

## 검증

- `plugin-dep-range.test.sh` 통과 (2 dependents 모두 `^0.14.0` → 0.14.0 admits)
- `claude plugin validate --strict .` 통과
- 머지 후 소비 레포에서 `plugin update` → `plugin-path.mjs resolve` 종료코드로 실제 버전 이동 확인 예정 (성공 메시지는 증거로 쓰지 않는다)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018U6tAd67w9hcFtaZWzMNxp