### PR TITLE
feat(loop-engine): 버전 미상승 편집을 막는 publish-freshness 게이트 (0.14.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "loop-engine",
       "source": "./tools/loop-engine",
       "description": "Core loop mechanics: verdict-run (machine-readable PASS/FAIL contract), loop-fix (closed verify->fix loop), lessons (verified-fix memory), classify-risk, require-tests, plugin-path (resolve sibling plugin install paths), check-docs-hygiene/check-pr-hygiene/check-module-size/check-skill-refs (repo hygiene gates). No framework opinions beyond \"the verifier is the ceiling, never the agent's self-report\".",
-      "version": "0.14.0",
+      "version": "0.14.1",
       "keywords": ["verifier", "tdd", "loop", "verdict", "lessons"]
     },
     {

--- a/.github/workflows/loop-engine-test.yml
+++ b/.github/workflows/loop-engine-test.yml
@@ -20,6 +20,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Tags are a test input, not decoration: publish-freshness.test.sh compares each plugin's
+          # subtree against its own `<plugin>--v<version>` tag. Without them it fails closed (by
+          # design — silently passing is the failure it exists to end), so the default tagless
+          # checkout would turn that gate red on every run.
+          fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
           node-version: 22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ Explicit-version channel — see [README § Development status](README.md#develo
 not a SHA channel. Entries below `## loop-engine 0.2.0` and earlier predate the multi-plugin split
 and refer to `loop-engine` only (see the un-prefixed version numbers).
 
+## loop-engine 0.14.1
+
+A gate for the failure that produced 0.6.3 one commit earlier: **a plugin file edited without that
+plugin's version moving.** `tag-on-publish.yml` closed "a released version has no tag"; this closes
+the level below it. The edit merges, CI is green, the marketplace serves the same version number as
+before, and the change reaches nobody — a manifest only travels on a new version.
+
+- **`test/publish-freshness.test.sh`.** For every plugin the marketplace lists (derived, never
+  hardcoded — a hardcoded list is the same failure one level down), if tag `<name>--v<version>`
+  already exists then that version is published, so the plugin's subtree must still match that tag.
+  Any difference means the tree is shipping under a number that already means something else.
+  Verified against the actual incident: run at `9211ab9` (the PR #90 merge) it names loop-memory and
+  the one line that changed; on a clean tree it is quiet.
+- **Two probes, not one.** `git diff <tag> -- <dir>` only considers *tracked* paths, so a new,
+  not-yet-added file reads as no difference — measured: the check passed on the very commit adding
+  its own test file. A plugin gaining a skill/hook/bin/test must ship, and must bump, exactly like
+  one whose file changed; `git ls-files --others` covers that half.
+- **Fail-closed with no tags visible.** A shallow or tagless checkout would let it pass on
+  everything while checking nothing — the exact silence it exists to end. It errors and says how to
+  fix it, and `loop-engine-test.yml`'s selftest job now checks out with `fetch-depth: 0` so CI has
+  the tags this reads.
+
+Scope note: deliberately a repo gate (a `test/`), not a shipped `bin/` tool. It guards this
+marketplace's own release discipline; making it a public tool would add a config surface (tag
+format, manifest path) for a need no consumer has stated.
+
 ## loop-memory 0.6.3
 
 `loop-engine 0.14.0 / ship-flow 0.10.0` widened every dependent's `loop-engine` range to `^0.14.0`,

--- a/tools/loop-engine/.claude-plugin/plugin.json
+++ b/tools/loop-engine/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "loop-engine",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Core loop mechanics: verdict-run (machine-readable PASS/FAIL contract), loop-fix (closed verify->fix loop), lessons (verified-fix memory), classify-risk, require-tests, check-docs-hygiene/check-pr-hygiene/check-module-size (repo hygiene gates). verifier=ceiling — the agent's self-judgement never substitutes for it.",
   "author": {
     "name": "paulkim-lansik"

--- a/tools/loop-engine/test/publish-freshness.test.sh
+++ b/tools/loop-engine/test/publish-freshness.test.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# Gate: a plugin's tree must not differ from its own last-published tag while its version stays put.
+#
+# `tag-on-publish.yml` closed "a released version has no tag". This closes the level below it: a
+# plugin file EDITED without bumping that plugin's version. The edit merges, CI is green, the
+# marketplace serves the same version number as before — and the change never reaches a single
+# consumer, because a manifest only travels on a NEW version.
+#
+# Measured 2026-09-02 (PR #90 → #91): loop-engine went to 0.14.0 and every dependent's range was
+# widened to `^0.14.0`, loop-memory's manifest included — but loop-memory stayed at 0.6.2. The
+# marketplace kept serving 0.6.2, which still declared `^0.13.0`, so loop-engine 0.14.0 became
+# unresolvable for everyone:
+#   claude plugin update loop-engine@paul-loop
+#   ✔ Skipped — conflicting version requirements (no version satisfies all of: ^0.13.0, ^0.14.0)
+# A checkmark on a no-op. `plugin-dep-range.test.sh` passed throughout and was right to: it checks
+# that the ranges in THIS TREE admit the loop-engine THIS TREE ships, and after the edit they did.
+# It has no reach into "an edit that never ships". Nothing else looked either.
+#
+# The check: for each plugin the marketplace lists, if tag `<name>--v<version>` already exists then
+# that exact version is already published — so the plugin's subtree must be byte-identical to what
+# that tag holds. Any difference means the working tree is shipping under a version number that
+# already means something else. Bump the version (which has no tag yet, so this check goes quiet
+# until it is published).
+#
+# Fail-closed on a missing tag universe: with no `*--v*` tags visible at all (shallow clone, tags
+# not fetched) this gate would pass on everything while checking nothing — the exact silence it
+# exists to end. It errors instead and says how to fix it.
+set -uo pipefail
+# `$0`, not `$BASH_SOURCE`: run.sh executes each test as `bash -c "$content" "$t"`.
+ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+
+fail() { echo "FAIL: $1"; exit 1; }
+
+command -v git >/dev/null 2>&1 || fail "git not available — this gate cannot run"
+git -C "$ROOT" rev-parse --git-dir >/dev/null 2>&1 || fail "$ROOT is not a git repo — this gate cannot run"
+
+MARKET="$ROOT/.claude-plugin/marketplace.json"
+[ -f "$MARKET" ] || fail "marketplace.json missing at $MARKET"
+
+# The plugin list is DERIVED, never hardcoded — same reasoning as tag-on-publish.yml's own comment:
+# a hardcoded list reintroduces the identical failure one level down (add a fourth plugin, forget
+# this file, and its unbumped edits go unnoticed just as silently).
+sources="$(python3 -c '
+import json, sys
+for p in json.load(open(sys.argv[1]))["plugins"]:
+    print(p["source"])
+' "$MARKET")" || fail "could not read plugins[].source from marketplace.json"
+[ -n "$sources" ] || fail "no plugins found in marketplace.json"
+
+# Fail-closed: no version tags visible at all means this gate is decorative.
+if [ -z "$(git -C "$ROOT" tag --list '*--v*' | head -n1)" ]; then
+  fail "no '<plugin>--v<semver>' tags are visible — this gate would pass without checking anything. Run 'git fetch origin --tags' (CI: checkout with fetch-depth: 0 or fetch-tags: true)."
+fi
+
+stale=0
+checked=0
+unpublished=0
+while IFS= read -r src; do
+  [ -n "$src" ] || continue
+  dir="${src#./}"
+  manifest="$ROOT/$dir/.claude-plugin/plugin.json"
+  [ -f "$manifest" ] || fail "marketplace.json lists $src but $manifest does not exist"
+  # Path as ARGV, never interpolated into the Python source — `plugins[].source` is a data field any
+  # PR can edit (same hardening tag-on-publish.yml carries, and for the same reason).
+  read_field() { python3 -c 'import json,sys;print(json.load(open(sys.argv[1]))[sys.argv[2]])' "$1" "$2"; }
+  name="$(read_field "$manifest" name)" || fail "could not read name from $manifest"
+  version="$(read_field "$manifest" version)" || fail "could not read version from $manifest"
+  tag="${name}--v${version}"
+
+  if ! git -C "$ROOT" rev-parse -q --verify "refs/tags/${tag}" >/dev/null; then
+    # This version has never been published — nothing to be stale against. tag-on-publish.yml will
+    # create the tag on merge, and from then on this check has a baseline for it.
+    echo "  · ${name} ${version}: not yet published (no ${tag}) — nothing to compare"
+    unpublished=$((unpublished + 1))
+    continue
+  fi
+
+  checked=$((checked + 1))
+  # Tag vs WORKING TREE (not HEAD): an uncommitted edit needs the bump just as much as a committed
+  # one, and saying so before the commit is the whole point of a local gate.
+  #
+  # TWO probes, because `git diff` alone silently misses the most common plugin change there is.
+  # `git diff <tag> -- <dir>` only ever considers TRACKED paths, so a brand-new, not-yet-added file
+  # (a new skill, hook, bin tool, or test) reads as "no difference" — measured while building this
+  # gate: it passed on the very commit that adds this file. A plugin gaining a file must ship, and
+  # therefore must bump, exactly like a plugin whose file changed.
+  untracked="$(git -C "$ROOT" ls-files --others --exclude-standard -- "$dir")"
+  if ! git -C "$ROOT" diff --quiet "$tag" -- "$dir" || [ -n "$untracked" ]; then
+    echo "  ✗ ${name}: tree differs from its own published tag ${tag}, but the version is still ${version}"
+    git -C "$ROOT" diff --stat "$tag" -- "$dir" | sed 's/^/      /'
+    [ -n "$untracked" ] && printf '%s\n' "$untracked" | sed 's/^/      (new, untracked) /'
+    stale=$((stale + 1))
+  else
+    echo "  · ${name} ${version}: matches ${tag}"
+  fi
+done <<< "$sources"
+
+if [ "$stale" -gt 0 ]; then
+  fail "${stale} plugin(s) edited without a version bump — the marketplace would keep serving the old version and these changes would reach nobody. Bump each plugin.json version (and its marketplace.json entry), and add a CHANGELOG entry."
+fi
+
+[ "$((checked + unpublished))" -gt 0 ] || fail "no plugins were examined — the derive step produced nothing"
+echo "PASS: every published plugin version still matches its tag (${checked} checked, ${unpublished} awaiting first publish)"
+exit 0


### PR DESCRIPTION
PR #91을 낳은 결함을 사람 기억이 아니라 기계가 잡게 한다.

## 막으려는 실패

**플러그인 파일을 고치면서 그 플러그인의 버전을 안 올리는 것.** `tag-on-publish.yml`이 "배포된 버전에 태그가 없다"를 막았고, 이건 그 **한 층 아래**를 막는다.

편집은 머지되고, CI는 그린이고, 마켓플레이스는 이전과 같은 버전 번호를 서빙한다 — 그리고 변경은 아무에게도 도달하지 않는다. 매니페스트는 새 버전을 타고만 움직이기 때문이다.

실측(#90 → #91): loop-engine이 0.14.0으로 가면서 모든 의존 플러그인 범위를 `^0.14.0`으로 넓혔는데 loop-memory가 0.6.2에 머물렀다. 결과:

```
claude plugin update loop-engine@paul-loop
✔ Skipped — conflicting version requirements (no version satisfies all of: ^0.13.0, ^0.14.0)
```

`plugin-dep-range.test.sh`는 내내 통과했고 그게 맞다 — "이 트리의 범위가 이 트리가 배포하는 loop-engine을 받아들이는가"를 보며, 편집 후 실제로 그랬다. **"배포되지 않는 편집"** 에는 사거리가 없다. 다른 무엇도 보지 않았다.

## 검사

마켓플레이스가 나열하는 각 플러그인에 대해(목록은 **파생** — 하드코딩하면 같은 실패가 한 층 아래에서 재현된다, `tag-on-publish.yml`이 자기 주석에 적어둔 논리 그대로), 태그 `<name>--v<version>`이 이미 있으면 그 버전은 배포된 것이므로 서브트리가 그 태그와 여전히 일치해야 한다.

**실제 사고 커밋으로 검증했다.** `9211ab9`(PR #90 머지 커밋)에서:

```
  · loop-engine 0.14.0: matches loop-engine--v0.14.0
  · ship-flow 0.10.0: matches ship-flow--v0.10.0
  ✗ loop-memory: tree differs from its own published tag loop-memory--v0.6.2, but the version is still 0.6.2
       tools/loop-memory/.claude-plugin/plugin.json | 2 +-
FAIL: 1 plugin(s) edited without a version bump — ...
```

바뀐 그 한 줄까지 정확히 짚는다. 깨끗한 트리에선 조용하다.

## 프로브가 둘인 이유 (게이트 자신에게서 찾은 버그)

`git diff <tag> -- <dir>`는 **추적되는** 경로만 본다. 아직 `add`하지 않은 새 파일은 "차이 없음"으로 읽힌다 — **실측: 자기 테스트 파일을 추가하는 바로 그 커밋에서 통과했다.** 플러그인이 스킬·훅·bin·테스트를 *얻는* 것도 배포돼야 하고 따라서 상승해야 한다. `git ls-files --others`가 나머지 절반을 덮는다.

수정 후엔 자기 PR을 먼저 잡았고, 그래서 이 PR이 loop-engine을 0.14.1로 올린다. 게이트가 스스로를 증명한 셈이다.

## 태그가 없으면 fail-closed

shallow/tagless 체크아웃에서는 아무것도 검사하지 않으면서 전부 통과시킬 텐데, **그 침묵이 바로 이 게이트가 끝내려는 것**이다. 에러를 내고 고치는 법을 말한다. `loop-engine-test.yml`의 selftest 잡을 `fetch-depth: 0`으로 배선해 CI가 이 게이트가 읽는 태그를 갖게 했다 — 안 하면 CI에서 항상 RED다.

## 스코프 판단

의도적으로 **레포 게이트(`test/`)이지 배포되는 `bin/` 도구가 아니다.** 이 마켓플레이스 자신의 릴리즈 규율을 지키는 것이고, 공개 도구로 만들면 아무 소비자도 요구하지 않은 설정 표면(태그 포맷·매니페스트 경로)을 늘린다. 나중에 필요해지면 그때 승격한다.

## 검증

- `loop-engine selftest 67/67`, EXIT 0
- 게이트: 사고 커밋에서 **RED**, 깨끗한 트리에서 **GREEN**, 태그 부재 시 **fail-closed** 모두 실측
- `plugin-dep-range.test.sh` 통과 — `^0.14.0`이 0.14.1을 받아들이므로 의존 플러그인 상승 불필요
- `claude plugin validate --strict .` 통과

## 알려진 한계

**정정**: 초안에 "상승을 잊은 그 PR 자체는 CI에서 못 잡는다"고 썼는데 틀렸다. 상승을 잊으면 버전이 *이미 발행된 값*에 머무르므로 태그가 존재하고, 따라서 그 PR의 CI에서 바로 RED가 된다 — `9211ab9`에서 실제로 그렇게 잡혔다. 목표 실패에 대한 사거리 공백은 없다.

실제 한계 둘:
- 버전은 올렸는데 `tag-on-publish`가 그 태그를 못 만든 경우, 그 버전에 대해 게이트가 조용해진다(비교 기준선이 없으므로). 그 층은 `tag-on-publish-derives-plugins.test.sh`의 몫이다.
- "했어야 하는데 안 한 변경"은 못 잡는다 — 예컨대 loop-engine을 올리면서 의존 범위 확대를 아예 잊었다면 이 게이트엔 안 걸린다. 그건 `plugin-dep-range.test.sh`가 본다. 두 게이트는 상보적이다: 하나는 "선언이 맞나", 다른 하나는 "선언이 배포되나".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018U6tAd67w9hcFtaZWzMNxp
